### PR TITLE
Update the FreeBSD versions referenced in the Poudriere Testing section.

### DIFF
--- a/en_US.ISO8859-1/books/porters-handbook/testing/chapter.xml
+++ b/en_US.ISO8859-1/books/porters-handbook/testing/chapter.xml
@@ -417,44 +417,51 @@ SVN_HOST=svn.FreeBSD.org</programlisting>
 	<application>Poudriere</application> will use for
 	building:</para>
 
-      <screen>&prompt.root; <userinput>poudriere jail -c -j 93Ramd64 -v 9.3-RELEASE -a amd64</userinput></screen>
+      <screen>&prompt.root; <userinput>poudriere jail -c -j 111Ramd64 -v 11.1-RELEASE -a amd64</userinput></screen>
 
-      <para>Fetch a <literal>9.3-RELEASE</literal> for
+      <para>Fetch a <literal>11.1-RELEASE</literal> for
 	<literal>amd64</literal> from the <acronym>FTP</acronym>
 	server given by <varname>FREEBSD_HOST</varname> in
 	<filename>poudriere.conf</filename>, create the zfs file
-	system <literal>tank/poudriere/jails/93Ramd64</literal>, mount
-	it on <filename>/poudriere/jails/93Ramd64</filename> and
-	extract the <literal>9.3-RELEASE</literal> tarballs into this
+	system <literal>tank/poudriere/jails/111Ramd64</literal>, mount
+	it on <filename>/poudriere/jails/111Ramd64</filename> and
+	extract the <literal>11.1-RELEASE</literal> tarballs into this
 	file system.</para>
 
-      <screen>&prompt.root; <userinput>poudriere jail -c -j 10i386 -v stable/10 -a i386 -m svn+https</userinput></screen>
+      <screen>&prompt.root; <userinput>poudriere jail -c -j 11i386 -v stable/11 -a i386 -m svn+https</userinput></screen>
 
-      <para>Create <literal>tank/poudriere/jails/10i386</literal>,
-	mount it on <filename>/poudriere/jails/10i386</filename>, then
+      <para>Create <literal>tank/poudriere/jails/11i386</literal>,
+	mount it on <filename>/poudriere/jails/11i386</filename>, then
 	check out the tip of the <application>Subversion</application>
-	branch of <literal>&os;-10-STABLE</literal> from
+	branch of <literal>&os;-11-STABLE</literal> from
 	<literal>SVN_HOST</literal> in
 	<filename>poudriere.conf</filename> into
-	<filename>/poudriere/jails/10i386/usr/src</filename>, then
+	<filename>/poudriere/jails/11i386/usr/src</filename>, then
 	complete a <buildtarget>buildworld</buildtarget> and install
-	it into <filename>/poudriere/jails/10i386</filename>.</para>
+	it into <filename>/poudriere/jails/11i386</filename>.</para>
 
       <tip>
 	<para>If a specific <application>Subversion</application>
 	  revision is needed, append it to the version string.  For
 	  example:</para>
 
-	<screen>&prompt.root; <userinput>poudriere jail -c -j 10i386 -v stable/10@123456 -a i386 -m svn+https</userinput></screen>
+	<screen>&prompt.root; <userinput>poudriere jail -c -j 11i386 -v stable/11@123456 -a i386 -m svn+https</userinput></screen>
       </tip>
 
       <note>
 	<para>While it is possible to build a newer version of &os; on
 	  an older version, most of the time it will not run.  For
-	  example, if a <literal>stable/10</literal> jail is needed,
-	  the host will have to run <literal>stable/10</literal> too.
-	  Running <literal>10.0-RELEASE</literal> is not
+	  example, if a <literal>stable/11</literal> jail is needed,
+	  the host will have to run <literal>stable/11</literal> too.
+	  Running <literal>11.1-RELEASE</literal> is not
 	  enough.</para>
+      </note>
+
+      <note>
+	<para>To create a <application>Poudriere</application> jail for
+	<literal>12.0-CURRENT</literal>:</para>
+
+        <screen>&prompt.root; <userinput>poudriere jail -c -j 12amd64 -v current/12 -a amd64 -m svn+https</userinput></screen>
       </note>
 
       <caution>
@@ -470,9 +477,11 @@ SVN_HOST=svn.FreeBSD.org</programlisting>
 	<command>poudriere jail -l</command>:</para>
 
       <screen>&prompt.root; <userinput>poudriere jail -l</userinput>
-JAILNAME             VERSION              ARCH    METHOD
-93Ramd64             9.3-RELEASE          amd64   ftp
-10i386               10.0-STABLE          i386    svn+https</screen>
+JAILNAME  VERSION                      ARCH  METHOD    TIMESTAMP           PATH
+111Ramd64 11.1-RELEASE                 amd64 ftp       2018-01-27 18:02:46 /usr/local/poudriere/jails/111Ramd64
+11i386    11.1-STABLE                  i386  svn+https 2018-01-27 18:41:11 /usr/local/poudriere/jails/11i386
+12amd64   12.0-CURRENT 1200056 r328445 amd64 svn+https 2018-01-26 19:15:34 /usr/local/poudriere/jails/12amd64
+</screen>
     </sect2>
 
 
@@ -635,9 +644,9 @@ development  -        /work/ports</screen>
       <para>For example, local modifications to the <package
 	  role="port">www/firefox</package> port located in
 	<filename>/work/ports/www/firefox</filename> can be tested in
-	the previously created 9.3-RELEASE jail:</para>
+	the previously created 11.1-RELEASE jail:</para>
 
-      <screen>&prompt.root; <userinput>poudriere testport -j 93Ramd64 -p development -o www/firefox</userinput></screen>
+      <screen>&prompt.root; <userinput>poudriere testport -j 111Ramd64 -p development -o www/firefox</userinput></screen>
 
       <para>This will build all dependencies of
 	<application>Firefox</application>.  If a dependency has been
@@ -648,13 +657,13 @@ development  -        /work/ports</screen>
 	built.</para>
 
       <para>The complete build of every port is logged to
-	<filename>/poudriere/data/logs/bulk/93Ri386-development/<replaceable>build-time</replaceable>/logs</filename>.</para>
+	<filename>/poudriere/data/logs/bulk/111Ramd64-development/<replaceable>build-time</replaceable>/logs</filename>.</para>
 
-      <para>The directory name <literal>93Ri386-development</literal>
+      <para>The directory name <literal>111Ramd64-development</literal>
 	is derived from the arguments to <literal>-j</literal> and
 	<literal>-p</literal>, respectively.  For convenience, a
 	symbolic link
-	<filename>/poudriere/data/logs/bulk/93Ri386-development/latest</filename>
+	<filename>/poudriere/data/logs/bulk/111Ramd64-development/latest</filename>
 	is also maintained.  The link points to the latest
 	<replaceable>build-time</replaceable> directory.  Also in this
 	directory is an <filename>index.html</filename> for observing
@@ -666,7 +675,7 @@ development  -        /work/ports</screen>
 	the build by adding <option>-i</option> to
 	<command>testport</command>:</para>
 
-      <screen>&prompt.root; <userinput>poudriere testport -j 93Ramd64 -p development -i -o www/firefox</userinput></screen>
+      <screen>&prompt.root; <userinput>poudriere testport -j 111Ramd64 -p development -i -o www/firefox</userinput></screen>
 
       <para>After the build completes, and regardless of whether it
 	was successful, a shell is provided within the jail.  The
@@ -677,16 +686,16 @@ development  -        /work/ports</screen>
 	will show the command to run when the jail is no longer
 	needed.  It is then possible to &man.jexec.8; into it:</para>
 
-      <screen>&prompt.root; <userinput>poudriere testport -j 93Ramd64 -p development -I -o www/firefox</userinput>
+      <screen>&prompt.root; <userinput>poudriere testport -j 111Ramd64 -p development -I -o www/firefox</userinput>
 [...]
 ====>> Installing local Pkg repository to /usr/local/etc/pkg/repos
-====>> Leaving jail 93Ramd64-development-n running, mounted at /poudriere/data/.m/93Ramd64-development/ref for interactive run testing
-====>> To enter jail: jexec 93Ramd64-development-n env -i TERM=$TERM /usr/bin/login -fp root
-====>> To stop jail: poudriere jail -k -j 93Ramd64 -p development
-&prompt.root; <userinput>jexec 93Ramd64-development-n env -i TERM=$TERM /usr/bin/login -fp root</userinput>
+====>> Leaving jail 111Ramd64-development-n running, mounted at /poudriere/data/.m/111Ramd64-development/ref for interactive run testing
+====>> To enter jail: jexec 111Ramd64-development-n env -i TERM=$TERM /usr/bin/login -fp root
+====>> To stop jail: poudriere jail -k -j 111Ramd64 -p development
+&prompt.root; <userinput>jexec 111Ramd64-development-n env -i TERM=$TERM /usr/bin/login -fp root</userinput>
 &prompt.root; <userinput><replaceable>[do some stuff in the jail]</replaceable></userinput>
 &prompt.root; <userinput>exit</userinput>
-&prompt.root; <userinput>poudriere jail -k -j 93Ramd64 -p development</userinput>
+&prompt.root; <userinput>poudriere jail -k -j 111Ramd64 -p development</userinput>
 ====>> Umounting file systems</screen>
 
       <para>An integral part of the &os; ports build infrastructure is
@@ -741,22 +750,22 @@ development  -        /work/ports</screen>
 	<literal>-z devset</literal> parameter to the testport
 	command:</para>
 
-      <screen>&prompt.root; <userinput>poudriere testport -j 93Ramd64 -p development -z devset -o www/firefox</userinput></screen>
+      <screen>&prompt.root; <userinput>poudriere testport -j 111Ramd64 -p development -z devset -o www/firefox</userinput></screen>
 
       <para>This will look for the existence of these directories in
 	this order:</para>
 
       <itemizedlist>
 	<listitem>
-	  <para><filename>/usr/local/etc/poudriere.d/93Ramd64-development-devset-options</filename></para>
+	  <para><filename>/usr/local/etc/poudriere.d/111Ramd64-development-devset-options</filename></para>
 	</listitem>
 
 	<listitem>
-	  <para><filename>/usr/local/etc/poudriere.d/93Ramd64-devset-options</filename></para>
+	  <para><filename>/usr/local/etc/poudriere.d/111Ramd64-devset-options</filename></para>
 	</listitem>
 
 	<listitem>
-	  <para><filename>/usr/local/etc/poudriere.d/93Ramd64-development-options</filename></para>
+	  <para><filename>/usr/local/etc/poudriere.d/111Ramd64-development-options</filename></para>
 	</listitem>
 
 	<listitem>
@@ -768,7 +777,7 @@ development  -        /work/ports</screen>
 	</listitem>
 
 	<listitem>
-	  <para><filename>/usr/local/etc/poudriere.d/93Ramd64-options</filename></para>
+	  <para><filename>/usr/local/etc/poudriere.d/111Ramd64-options</filename></para>
 	</listitem>
 
 	<listitem>
@@ -815,7 +824,7 @@ development  -        /work/ports</screen>
 	matching a name scheme derived from the command line.  For
 	instance:</para>
 
-      <screen>&prompt.root; <userinput>poudriere testport -j 93Ramd64 -p development -z devset -o www/firefox</userinput></screen>
+      <screen>&prompt.root; <userinput>poudriere testport -j 111Ramd64 -p development -z devset -o www/firefox</userinput></screen>
 
       <para>causes <application>Poudriere</application> to check for
 	the existence of these files in this order:</para>
@@ -834,19 +843,19 @@ development  -        /work/ports</screen>
 	</listitem>
 
 	<listitem>
-	  <para><filename>/usr/local/etc/poudriere.d/93Ramd64-make.conf</filename></para>
+	  <para><filename>/usr/local/etc/poudriere.d/111Ramd64-make.conf</filename></para>
 	</listitem>
 
 	<listitem>
-	  <para><filename>/usr/local/etc/poudriere.d/93Ramd64-development-make.conf</filename></para>
+	  <para><filename>/usr/local/etc/poudriere.d/111Ramd64-development-make.conf</filename></para>
 	</listitem>
 
 	<listitem>
-	  <para><filename>/usr/local/etc/poudriere.d/93Ramd64-devset-make.conf</filename></para>
+	  <para><filename>/usr/local/etc/poudriere.d/111Ramd64-devset-make.conf</filename></para>
 	</listitem>
 
 	<listitem>
-	  <para><filename>/usr/local/etc/poudriere.d/93Ramd64-development-devset-make.conf</filename></para>
+	  <para><filename>/usr/local/etc/poudriere.d/111Ramd64-development-devset-make.conf</filename></para>
 	</listitem>
       </itemizedlist>
 
@@ -859,7 +868,7 @@ development  -        /work/ports</screen>
 	Special variables, intended to affect only certain jails or
 	sets can be set in specialised <filename>make.conf</filename>
 	files, such as
-	<filename>/usr/local/etc/poudriere.d/93Ramd64-development-devset-make.conf</filename>.</para>
+	<filename>/usr/local/etc/poudriere.d/111Ramd64-development-devset-make.conf</filename>.</para>
 
       <example xml:id="testing-poudriere-sets-perl">
 	<title>Using <filename>make.conf</filename> to Change Default


### PR DESCRIPTION
9.3 is rather dated at this point.  Include a reference to 12.0-CURRENT.

https://reviews.freebsd.org/D14067