### PR TITLE
EleCtrônico -> Eletrônico

### DIFF
--- a/pt_BR.ISO8859-1/books/handbook/mail/chapter.xml
+++ b/pt_BR.ISO8859-1/books/handbook/mail/chapter.xml
@@ -6,7 +6,7 @@
      $FreeBSD$
 -->
 <chapter xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" version="5.0" xml:id="mail">
-  <title>Correio Electrônico</title>
+  <title>Correio EletrÃ´nico</title>
 
   <para>&nbsp;</para>
 </chapter>


### PR DESCRIPTION
EN: This translation had the letter C inside the Word "electrônico", this is true for Portuguese from Portugal, but not for Brazilian Portuguese.

Pt_BR: Essa tradução havia mantido o C na palavra eletrônico, conforme a grafia de português de Portugal e não corresponde ao padrão adotado em todo o documento "pt_BR.po", onde se encontra a tradução de Electronic Mail para Correio Eletrônico.