### PR TITLE
Update chapter.xml

### DIFF
--- a/pt_BR.ISO8859-1/books/handbook/boot/chapter.xml
+++ b/pt_BR.ISO8859-1/books/handbook/boot/chapter.xml
@@ -6,7 +6,7 @@
      $FreeBSD$
 -->
 <chapter xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" version="5.0" xml:id="boot">
-  <title>O Processo de Inicialização FreeBSD</title>
+  <title>O Processo de InicializaÃ§Ã£o do FreeBSD</title>
 
   <para>&nbsp;</para>
 </chapter>


### PR DESCRIPTION
EN: Included word 'do' in phrase "O Processo de Inicialização do FreeBSD" in order to respect translation pattern used inside pt_BR.po. Without this FreeBSD seems to be the name of an init process.