### PR TITLE
contribuintes -> contribuidores

### DIFF
--- a/pt_BR.ISO8859-1/books/handbook/colophon.xml
+++ b/pt_BR.ISO8859-1/books/handbook/colophon.xml
@@ -8,16 +8,16 @@
 -->
 <colophon xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" version="5.0">
   <para>Este livro representa o trabalho combinado de centenas de
-    contribuintes do <quote>Projeto de DocumentaÁ„o
-    do FreeBSD</quote>.  O texto est· escrito em SGML de
+    contribuidores do <quote>Projeto de Documenta√ß√£o
+    do FreeBSD</quote>.  O texto est√° escrito em SGML de
     acordo com o DocBook DTD e formatado a partir de SGML para
     muitos outros formatos utilizando <application>Jade</application>,
-    uma ferramenta DSSSL de cÛdigo aberto.  Os stylesheets
+    uma ferramenta DSSSL de c√≥digo aberto.  Os stylesheets
     DSSSL de Norm Walsh foram utilizados com uma camada adicional
-    de personalizaÁ„o para fornecer as
-    instruÁıes de apresentaÁ„o para o
-    Jade.  A vers„o impressa deste documento n„o seria
-    possÌvel sem a linguagem de tipografia
+    de personaliza√ß√£o para fornecer as
+    instru√ß√µes de apresenta√ß√£o para o
+    Jade.  A vers√£o impressa deste documento n√£o seria
+    poss√≠vel sem a linguagem de tipografia
     <application>TeX</application> de Donald Knuth,
     <application>LaTeX</application> de Leslie Lamport ou o pacote
     de macros <application>JadeTeX</application> de Sebastian


### PR DESCRIPTION
EN: In Brazilian Portuguese, both contribuintes and contribuidores are synonyms, but the first is widely used in juridic vocabulary as a person paying taxes to someone. This might be a little bit confusing as who is paying who to do this job. The word "contribuidores" does not have this implicit connotation, therefore makes the reading a lot easier on the eyes.