### PR TITLE
books/porters-handbook/: More reliable rebase

### DIFF
--- a/documentation/content/en/books/porters-handbook/upgrading/_index.adoc
+++ b/documentation/content/en/books/porters-handbook/upgrading/_index.adoc
@@ -111,7 +111,7 @@ Make sure to check the port using the checklist in crossref:quick-porting[portin
 [source,shell]
 ....
 % git status --short
-% git pull --rebase <.>
+% git pull --rebase --autosquash <.>
 ....
 
 <.> This will attempt to merge the differences between the patch and current repository version. Watch the output carefully. The letter in front of each file name indicates what was done with it.


### PR DESCRIPTION
When the reader follows the git instructions, the call to git pull
--rebase will just fail with the following message most of the time:

$ git pull --rebase
error: cannot pull with rebase: You have unstaged changes.
error: additionally, your index contains uncommitted changes.
error: please commit or stash them.

In order to fix the situation in most cases, using --autosquash seems
more reliable thing to do.