### PR TITLE
handbook/preface/: text corrections, updated urls

### DIFF
--- a/documentation/content/en/books/handbook/preface/_index.adoc
+++ b/documentation/content/en/books/handbook/preface/_index.adoc
@@ -37,7 +37,7 @@ For a list of additional sources of information, please see crossref:bibliograph
 The current online version of the Handbook represents the cumulative effort of many hundreds of contributors over the past 10 years.
 The following are some of the significant changes since the two volume third edition was published in 2004:
 
-* crossref:wine[wine,WINE] has been added with information about how to run Windows(R) applications on FreeBSD.</para>
+* crossref:wine[wine,WINE] has been added with information about how to run Windows(R) applications on FreeBSD.
 * crossref:dtrace[dtrace,DTrace] has been added with information about the powerful DTrace performance analysis tool.
 * crossref:filesystems[filesystems,Other File Systems] has been added with information about non-native file systems in FreeBSD, such as ZFS from Sun(TM).
 * crossref:audit[audit,Security Event Auditing] has been added to cover the new auditing capabilities in FreeBSD and explain its use.
@@ -129,7 +129,7 @@ _crossref:printing[printing,Printing]_::
 Describes managing printers on FreeBSD, including information about banner pages, printer accounting, and initial setup.
 
 _crossref:linuxemu[linuxemu,Linux® Binary Compatibility]_::
-Describes the Linux(R) compatibility features of FreeBSD. Also provides detailed installation instructions for many popular Linux(R) applications such as Oracle(R) and Mathematica(R).
+Describes the Linux(R) compatibility features of FreeBSD. Also provides detailed installation instructions for Linux(R) applications.
 
 _crossref:config[config-tuning,Configuration and Tuning]_::
 Describes the parameters available for system administrators to tune a FreeBSD system for optimum performance. Also describes the various configuration files used in FreeBSD and where to find them.
@@ -263,11 +263,11 @@ Unless otherwise noted, C-shell syntax is used for setting environment variables
 [[preface-acknowledgements]]
 == Acknowledgments
 
-The book you are holding represents the efforts of many hundreds of people around the world.
+The book you are reading represents the efforts of many hundreds of people around the world.
 Whether they sent in fixes for typos, or submitted complete chapters, all the contributions have been useful.
 
 Several companies have supported the development of this document by paying authors to work on it full-time, paying for publication, etc.
-In particular, BSDi (subsequently acquired by http://www.windriver.com[Wind River Systems]) paid members of the FreeBSD Documentation Project to work on improving this book full time leading up to the publication of the first printed edition in March 2000 (ISBN 1-57176-241-8).
+In particular, BSDi (subsequently acquired by https://www.windriver.com/[Wind River Systems]) paid members of the FreeBSD Documentation Project to work on improving this book full time leading up to the publication of the first printed edition in March 2000 (ISBN 1-57176-241-8).
 Wind River Systems then paid several additional authors to make a number of improvements to the print-output infrastructure and to add additional chapters to the text.
 This work culminated in the publication of the second printed edition in November 2001 (ISBN 1-57176-303-1).
-In 2003-2004, http://www.freebsdmall.com[FreeBSD Mall, Inc], paid several contributors to improve the Handbook in preparation for the third printed edition.
+In 2003-2004, https://www.freebsdmall.com/[FreeBSD Mall, Inc], paid several contributors to improve the Handbook in preparation for the third printed edition.


### PR DESCRIPTION
* some text corrections
* removed statement about installation of Mathematica and Oracle because they are not included in handbook/linuxemu/
* updated links of external websites