### PR TITLE
Advocacy: update and simplify the page

### DIFF
--- a/website/content/en/advocacy/_index.adoc
+++ b/website/content/en/advocacy/_index.adoc
@@ -7,36 +7,30 @@ include::shared/en/urls.adoc[]
 
 = FreeBSD Advocacy Project
 
-Much of FreeBSD's success comes from users advocating to their friends, colleagues, and employers.
-
-== Mailing lists
-
-* https://lists.freebsd.org/subscription/freebsd-advocacy[FreeBSD advocacy mailing list]
+Much of our success comes from users advocating to their friends, colleagues, and employers.
 
 == Web resources
 
-* link:../status[FreeBSD quarterly status reports]
-+
-Details of activities within and surrounding FreeBSD.
+link:../press[FreeBSD in the press]
 
-* link:whyusefreebsd[Why use FreeBSD?]
-+
-Users explain why FreeBSD should be used.
+link:../status[FreeBSD quarterly status reports]
 
-* link:myths[*BSD myths]
-+
-Describes and debunks some of the mythology.
+link:myths[Myths] – some of the misunderstandings about FreeBSD and other BSD projects.
 
-* link:../press[FreeBSD in the press]
-+
-Links to articles.
+link:whyusefreebsd[Why] – some of the reasons that people give for choosing FreeBSD.
 
-== Sites using FreeBSD
+== [#sites_using_freebsd]*Who uses it?*
 
 Organisations, products and services that make use of FreeBSD are https://freebsdfoundation.org/freebsd-project/what-is-freebsd/[shortlisted by the FreeBSD Foundation]. 
 
-== FreeBSD conferences
+== [#freebsd_conferences]*Conferences*
 
-* https://www.bsdcan.org/[BSDCan], the annual BSD Conference held in Ottawa, Canada.
-* https://www.eurobsdcon.org/[EuroBSDCon], the annual BSD Conference in Europe.
-* https://asiabsdcon.org/[AsiaBSDCon], the annual BSD Conference held in Asia.
+https://asiabsdcon.org/[AsiaBSDCon] – the annual BSD conference held in Asia.
+
+https://www.bsdcan.org/[BSDCan] – the annual BSD conference held in Ottawa, Canada.
+
+https://www.eurobsdcon.org/[EuroBSDCon] – the annual BSD conference in Europe.
+
+== [#mailing_lists]*Mailing lists*
+
+https://lists.freebsd.org/subscription/freebsd-advocacy[freebsd-advocacy]

--- a/website/content/en/advocacy/_index.adoc
+++ b/website/content/en/advocacy/_index.adoc
@@ -7,9 +7,7 @@ include::shared/en/urls.adoc[]
 
 = FreeBSD Advocacy Project
 
-Much of the success which surrounds FreeBSD is due to people advocating its use to their friends, colleagues, and employers.
-
-This page provides links to more information to help you do this.
+Much of FreeBSD's success comes from users advocating to their friends, colleagues, and employers.
 
 == Mailing lists
 
@@ -19,25 +17,23 @@ This page provides links to more information to help you do this.
 
 * link:../status[FreeBSD quarterly status reports]
 +
-Quarterly status reports detailing activity within and surrounding FreeBSD.
+Details of activities within and surrounding FreeBSD.
 
-* link:whyusefreebsd[Why Use FreeBSD?]
+* link:whyusefreebsd[Why use FreeBSD?]
 +
-Explanations given by existing users as to why FreeBSD should be used.
+Users explain why FreeBSD should be used.
 
-* link:myths[*BSD Myths]
+* link:myths[*BSD myths]
 +
-Describes and debunks some of the myths that surround the *BSD projects.
+Describes and debunks some of the mythology.
 
-* link:../press[FreeBSD in the Press]
+* link:../press[FreeBSD in the press]
 +
-Contains many links to articles that have appeared which mention FreeBSD.
+Links to articles.
 
 == Sites using FreeBSD
 
-* http://uptime.netcraft.com/perf/reports/Hosters[Hosting Providers Performance] by Netcraft is tracking the reliability of major webhosting services, many of them are using FreeBSD.
-
-* A brief list of sites using FreeBSD is maintained link:{handbook}#introduction-nutshell-users[in the Handbook].
+Organisations, products and services that make use of FreeBSD are https://freebsdfoundation.org/freebsd-project/what-is-freebsd/[shortlisted by the FreeBSD Foundation]. 
 
 == FreeBSD conferences
 


### PR DESCRIPTION
2011: <https://bugs.freebsd.org/bugzilla/show_bug.cgi?id=159664>

2012: <https://cgit.freebsd.org/doc/commit/?id=ef63f45e382f4fb457f5d3d48301c820ff774213> | <https://github.com/freebsd/freebsd-doc/commit/ef63f45e382f4fb457f5d3d48301c820ff774213>

> Add an entry referencing Netcraft's June 2011 report on reliable hosting providers.

2021: <https://uptime.netcraft.com/perf/reports/Hosters> most often draws attention to Linux, sometimes never shows FreeBSD; this is simply not good advocacy of FreeBSD. 

<https://bugs.freebsd.org/bugzilla/show_bug.cgi?id=260763> aims to update and simplify the Advocacy page.