### PR TITLE
xdm(1) moved to xdm(8) in 12.1-RELEASE.

### DIFF
--- a/documentation/content/en/books/handbook/x11/_index.adoc
+++ b/documentation/content/en/books/handbook/x11/_index.adoc
@@ -954,7 +954,7 @@ XDM will run on the ninth virtual terminal by default.
 The XDM configuration directory is located in [.filename]#/usr/local/etc/X11/xdm#.
 This directory contains several files used to change the behavior and appearance of XDM, as well as a few scripts and programs used to set up the desktop when XDM is running.
 <<xdm-config-files>> summarizes the function of each of these files.
-The exact syntax and usage of these files is described in man:xdm[1].
+The exact syntax and usage of these files is described in man:xdm[8].
 
 [[xdm-config-files]]
 .XDM Configuration Files
@@ -1003,7 +1003,7 @@ DisplayManager.requestPort:     0
 ....
 
 Save the edits and restart XDM.
-To restrict remote access, look at the example entries in [.filename]#/usr/local/etc/X11/xdm/Xaccess# and refer to man:xdm[1] for further information.
+To restrict remote access, look at the example entries in [.filename]#/usr/local/etc/X11/xdm/Xaccess# and refer to man:xdm[8] for further information.
 
 [[x11-wm]]
 == Desktop Environments


### PR DESCRIPTION
Please check that the HTML renders before merging change - it did not work on the preview function when I just changed "man:xdm[1]" to "man:xdm[8]", so I don't know how to verify this change is applied correctly.

line 957 and 1006. minor link update - It looks like man page for xdm(1) moved to xdm(8) between 12.0-RELEASE and 12.1-RELEASE per
https://bugs.freebsd.org/bugzilla/show_bug.cgi?id=239963
Since the change is prior to the oldest supported release (12.2 as of this update), there is no need to include xdm(1) in addition to xdm(8), and the xdm(1) link