### PR TITLE
Correction in _index.adoc ("testuser" => "tuser")

### DIFF
--- a/documentation/content/en/articles/ldap-auth/_index.adoc
+++ b/documentation/content/en/articles/ldap-auth/_index.adoc
@@ -272,7 +272,7 @@ In either case, the relevant schemas need to be loaded in [.filename]#slapd.conf
 For this example we will use the `person` object class.
 If you are using `inetOrgPerson`, the steps are basically identical, except that the `sn` attribute is required.
 
-To add a user `testuser`, the ldif would be:
+To add a test-user named `tuser`, the ldif would be:
 
 [.programlisting]
 ....


### PR DESCRIPTION
Line 275 said "To add a user `testuser`, the ldif would be" ...
... but the rest of the document used tuser, and occurence of "testuser" was never seen.
I changed line 275 to now read "To add a test-user named `tuser`, the ldif would be:"