### PR TITLE
Reduce confusion in IPSec setup

### DIFF
--- a/documentation/content/en/books/handbook/security/_index.adoc
+++ b/documentation/content/en/books/handbook/security/_index.adoc
@@ -1300,7 +1300,13 @@ In the example scenario:
 
 * Both sites are connected to the Internet through a gateway that is running FreeBSD.
 * The gateway on each network has at least one external IP address. In this example, the corporate LAN's external IP address is `172.16.5.4` and the home LAN's external IP address is `192.168.1.12`.
-* The internal addresses of the two networks can be either public or private IP addresses. However, the address space must not collide. For example, both networks cannot use `192.168.1.x`. In this example, the corporate LAN's internal IP address is `10.246.38.1` and the home LAN's internal IP address is `10.0.0.5`.
+* The internal addresses of the two networks can be either public or private IP addresses. However, the address space must not overlap. In this example, the corporate LAN's internal IP address is `10.246.38.1` and the home LAN's internal IP address is `10.0.0.5`.
+
+[.programlisting]
+....
+           corporate                          home
+10.246.38.1/24 -- 172.16.5.4 <--> 192.168.1.12 -- 10.0.0.5/24
+....
 
 === Configuring a VPN on FreeBSD
 
@@ -1308,17 +1314,24 @@ To begin, package:security/ipsec-tools[] must be installed from the Ports Collec
 This software provides a number of applications which support the configuration.
 
 The next requirement is to create two man:gif[4] pseudo-devices which will be used to tunnel packets and allow both networks to communicate properly.
-As `root`, run the following commands, replacing _internal_ and _external_ with the real IP addresses of the internal and external interfaces of the two gateways:
+As `root`, run the following command on each gateway:
 
 [source,shell]
 ....
-# ifconfig gif0 create
-# ifconfig gif0 internal1 internal2
-# ifconfig gif0 tunnel external1 external2
+corp-gw# ifconfig gif0 create
+corp-gw# ifconfig gif0 10.246.38.1 10.0.0.5
+corp-gw# ifconfig gif0 tunnel 172.16.5.4 192.168.1.12
 ....
 
-Verify the setup on each gateway, using `ifconfig`.
-Here is the output from Gateway 1:
+[source,shell]
+....
+home-gw# ifconfig gif0 create
+home-gw# ifconfig gif0 10.0.0.5 10.246.38.1
+home-gw# ifconfig gif0 tunnel 192.168.1.12 172.16.5.4
+....
+
+Verify the setup on each gateway, using `ifconfig gif0`.
+Here is the output from the home gateway:
 
 [.programlisting]
 ....
@@ -1328,7 +1341,7 @@ inet6 fe80::2e0:81ff:fe02:5881%gif0 prefixlen 64 scopeid 0x6
 inet 10.246.38.1 --> 10.0.0.5 netmask 0xffffff00
 ....
 
-Here is the output from Gateway 2:
+Here is the output from the corporate gateway:
 
 [.programlisting]
 ....
@@ -1342,7 +1355,7 @@ Once complete, both internal IP addresses should be reachable using man:ping[8]:
 
 [source,shell]
 ....
-priv-net# ping 10.0.0.5
+home-gw# ping 10.0.0.5
 PING 10.0.0.5 (10.0.0.5): 56 data bytes
 64 bytes from 10.0.0.5: icmp_seq=0 ttl=64 time=42.786 ms
 64 bytes from 10.0.0.5: icmp_seq=1 ttl=64 time=19.255 ms
@@ -1352,7 +1365,7 @@ PING 10.0.0.5 (10.0.0.5): 56 data bytes
 4 packets transmitted, 4 packets received, 0% packet loss
 round-trip min/avg/max/stddev = 19.255/25.879/42.786/9.782 ms
 
-corp-net# ping 10.246.38.1
+corp-gw# ping 10.246.38.1
 PING 10.246.38.1 (10.246.38.1): 56 data bytes
 64 bytes from 10.246.38.1: icmp_seq=0 ttl=64 time=28.106 ms
 64 bytes from 10.246.38.1: icmp_seq=1 ttl=64 time=42.917 ms
@@ -1365,15 +1378,15 @@ round-trip min/avg/max/stddev = 28.106/94.594/154.524/49.814 ms
 ....
 
 As expected, both sides have the ability to send and receive ICMP packets from the privately configured addresses.
-Next, both gateways must be told how to route packets in order to correctly send traffic from either network.
+Next, both gateways must be told how to route packets in order to correctly send traffic from the networks behind each gateway.
 The following commands will achieve this goal:
 
 [source,shell]
 ....
-corp-net# route add 10.0.0.0 10.0.0.5 255.255.255.0
-corp-net# route add net 10.0.0.0: gateway 10.0.0.5
-priv-net# route add 10.246.38.0 10.246.38.1 255.255.255.0
-priv-net# route add host 10.246.38.0: gateway 10.246.38.1
+corp-gw# route add 10.0.0.0 10.0.0.5 255.255.255.0
+corp-gw# route add net 10.0.0.0: gateway 10.0.0.5
+home-gw# route add 10.246.38.0 10.246.38.1 255.255.255.0
+home-gw# route add host 10.246.38.0: gateway 10.246.38.1
 ....
 
 At this point, internal machines should be reachable from each gateway as well as from machines behind the gateways.
@@ -1381,7 +1394,7 @@ Again, use man:ping[8] to confirm:
 
 [source,shell]
 ....
-corp-net# ping 10.0.0.8
+corp-gw# ping 10.0.0.8
 PING 10.0.0.8 (10.0.0.8): 56 data bytes
 64 bytes from 10.0.0.8: icmp_seq=0 ttl=63 time=92.391 ms
 64 bytes from 10.0.0.8: icmp_seq=1 ttl=63 time=21.870 ms
@@ -1392,7 +1405,7 @@ PING 10.0.0.8 (10.0.0.8): 56 data bytes
 5 packets transmitted, 5 packets received, 0% packet loss
 round-trip min/avg/max/stddev = 21.870/101.846/198.022/74.001 ms
 
-priv-net# ping 10.246.38.107
+home-gw# ping 10.246.38.107
 PING 10.246.38.1 (10.246.38.107): 56 data bytes
 64 bytes from 10.246.38.107: icmp_seq=0 ttl=64 time=53.491 ms
 64 bytes from 10.246.38.107: icmp_seq=1 ttl=64 time=23.395 ms
@@ -1404,8 +1417,7 @@ PING 10.246.38.1 (10.246.38.107): 56 data bytes
 round-trip min/avg/max/stddev = 21.145/31.721/53.491/12.179 ms
 ....
 
-Setting up the tunnels is the easy part. Configuring a secure link is a more in depth process.
-The following configuration uses pre-shared (PSK) RSA keys.
+At this point, traffic is flowing between the networks encapsulated in a gif tunnel but without any encryption. Next, we'll use IPSec to encrypt traffic using pre-shared (PSK) RSA keys.
 Other than the IP addresses, the [.filename]#/usr/local/etc/racoon/racoon.conf# on both gateways will be identical and look similar to:
 
 [.programlisting]
@@ -1496,7 +1508,7 @@ The output should be similar to the following:
 
 [source,shell]
 ....
-corp-net# /usr/local/sbin/racoon -F -f /usr/local/etc/racoon/racoon.conf
+corp-gw# /usr/local/sbin/racoon -F -f /usr/local/etc/racoon/racoon.conf
 Foreground mode.
 2006-01-30 01:35:47: INFO: begin Identity Protection mode.
 2006-01-30 01:35:48: INFO: received Vendor ID: KAME/racoon
@@ -1515,7 +1527,7 @@ Replace `em0` with the network interface card as required:
 
 [source,shell]
 ....
-# tcpdump -i em0 host 172.16.5.4 and dst 192.168.1.12
+corp-gw# tcpdump -i em0 host 172.16.5.4 and dst 192.168.1.12
 ....
 
 Data similar to the following should appear on the console.

--- a/documentation/content/en/books/handbook/security/_index.adoc
+++ b/documentation/content/en/books/handbook/security/_index.adoc
@@ -1389,36 +1389,33 @@ home-gw# route add 10.246.38.0 10.246.38.1 255.255.255.0
 home-gw# route add host 10.246.38.0: gateway 10.246.38.1
 ....
 
-At this point, internal machines should be reachable from each gateway as well as from machines behind the gateways.
+Internal machines should be reachable from each gateway as well as from machines behind the gateways.
 Again, use man:ping[8] to confirm:
 
 [source,shell]
 ....
-corp-gw# ping 10.0.0.8
+corp-gw# ping -c 3 10.0.0.8
 PING 10.0.0.8 (10.0.0.8): 56 data bytes
 64 bytes from 10.0.0.8: icmp_seq=0 ttl=63 time=92.391 ms
 64 bytes from 10.0.0.8: icmp_seq=1 ttl=63 time=21.870 ms
 64 bytes from 10.0.0.8: icmp_seq=2 ttl=63 time=198.022 ms
-64 bytes from 10.0.0.8: icmp_seq=3 ttl=63 time=22.241 ms
-64 bytes from 10.0.0.8: icmp_seq=4 ttl=63 time=174.705 ms
 --- 10.0.0.8 ping statistics ---
-5 packets transmitted, 5 packets received, 0% packet loss
+3 packets transmitted, 3 packets received, 0% packet loss
 round-trip min/avg/max/stddev = 21.870/101.846/198.022/74.001 ms
 
-home-gw# ping 10.246.38.107
+home-gw# ping -c 3 10.246.38.107
 PING 10.246.38.1 (10.246.38.107): 56 data bytes
 64 bytes from 10.246.38.107: icmp_seq=0 ttl=64 time=53.491 ms
 64 bytes from 10.246.38.107: icmp_seq=1 ttl=64 time=23.395 ms
 64 bytes from 10.246.38.107: icmp_seq=2 ttl=64 time=23.865 ms
-64 bytes from 10.246.38.107: icmp_seq=3 ttl=64 time=21.145 ms
-64 bytes from 10.246.38.107: icmp_seq=4 ttl=64 time=36.708 ms
 --- 10.246.38.107 ping statistics ---
-5 packets transmitted, 5 packets received, 0% packet loss
+3 packets transmitted, 3 packets received, 0% packet loss
 round-trip min/avg/max/stddev = 21.145/31.721/53.491/12.179 ms
 ....
 
-At this point, traffic is flowing between the networks encapsulated in a gif tunnel but without any encryption. Next, we'll use IPSec to encrypt traffic using pre-shared (PSK) RSA keys.
-Other than the IP addresses, the [.filename]#/usr/local/etc/racoon/racoon.conf# on both gateways will be identical and look similar to:
+At this point traffic is flowing between the networks encapsulated in a gif tunnel but without any encryption.
+Next, use IPSec to encrypt traffic using pre-shared keys (PSK).
+Other than the IP addresses, [.filename]#/usr/local/etc/racoon/racoon.conf# on both gateways will be identical and look similar to:
 
 [.programlisting]
 ....


### PR DESCRIPTION
* remove reference to 192.168.1.x colliding internal network which is the same as the example 192.168.1.12 public IP
* better clarity about what networks are in the example
* instead of a mixture of gateway1, priv-net and home network, use one set of terminology consistently

Not changed is using private IP addresses as the example public IPs. That's just confusing, but I've left it for now.