### PR TITLE
FreeBSD Handbook: Abstract: remove FreeBSD Mall

### DIFF
--- a/documentation/content/en/books/handbook/_index.adoc
+++ b/documentation/content/en/books/handbook/_index.adoc
@@ -56,7 +56,6 @@ Those interested in helping to update and expand this document should send email
 The latest version of this book is available from the https://www.FreeBSD.org/[FreeBSD web site].
 Previous versions can be obtained from https://docs.FreeBSD.org/doc/[https://docs.FreeBSD.org/doc/].
 The book can be downloaded in a variety of formats and compression options from the https://download.freebsd.org/doc/[FreeBSD download server] or one of the numerous link:./mirrors#mirrors[mirror sites].
-Printed copies can be purchased at the https://www.freebsdmall.com/[FreeBSD Mall].
 Searches can be performed on the handbook and other documents on the link:https://www.FreeBSD.org/search/[search page].
 
 '''


### PR DESCRIPTION
The available FreeBSD Handbook, 3rd Ed, Admin Guide (Vol 2) (ISBN 1-57176-328-7) was "completely up to date for the latest FreeBSD 4.x and 5.x versions.", versions that reached end of life years ago.

<https://www.freebsdmall.com/cgi-bin/fm/bsdhandbk3.2?id=EBKoCfMX&mv_pc=51>