### PR TITLE
Update "30.6.2. Installing and Configuring a DHCP Server"

### DIFF
--- a/documentation/content/en/books/handbook/network-servers/_index.adoc
+++ b/documentation/content/en/books/handbook/network-servers/_index.adoc
@@ -1793,9 +1793,9 @@ The DHCP client keeps a database of valid leases in this file, which is written 
 === Installing and Configuring a DHCP Server
 
 This section demonstrates how to configure a FreeBSD system to act as a DHCP server using the Internet Systems Consortium (ISC) implementation of the DHCP server.
-This implementation and its documentation can be installed using the package:net/isc-dhcp43-server[] package or port.
+This implementation and its documentation can be installed using the package:net/isc-dhcp44-server[] package or port.
 
-The installation of package:net/isc-dhcp43-server[] installs a sample configuration file.
+The installation of package:net/isc-dhcp44-server[] installs a sample configuration file.
 Copy [.filename]#/usr/local/etc/dhcpd.conf.example# to [.filename]#/usr/local/etc/dhcpd.conf# and make any edits to this new file.
 
 The configuration file is comprised of declarations for subnets and hosts which define the information that is provided to DHCP clients.


### PR DESCRIPTION
The latest version of the ics-dhcp-server port is "isc-dhcp44-server", the web page of the "isc-dhcp43-server" port only displays "Path not found".