### PR TITLE
Update #2 "30.6.2. Installing and Configuring a DHCP Server" 

### DIFF
--- a/documentation/content/en/books/handbook/network-servers/_index.adoc
+++ b/documentation/content/en/books/handbook/network-servers/_index.adoc
@@ -1872,7 +1872,7 @@ Refer to dhcpd.leases(5), which gives a slightly longer description.
 * [.filename]#/usr/local/sbin/dhcrelay#
 +
 This daemon is used in advanced environments where one DHCP server forwards a request from a client to another DHCP server on a separate network.
-If this functionality is required, install the package:net/isc-dhcp43-relay[] package or port.
+If this functionality is required, install the package:net/isc-dhcp44-relay[] package or port.
 The installation includes dhcrelay(8) which provides more detail.
 
 


### PR DESCRIPTION
Update the isc-dhcp-relay package in section "30.6.2. Installing and Configuring a DHCP Server" from version 43 to version 44:

"package:net/isc-dhcp43-relay" --> "package:net/isc-dhcp44-relay"

This way, the link to the ports tree website will display the correct page instead of "Path not found".