### PR TITLE
Info for serving poudriere packages privately

### DIFF
--- a/documentation/content/en/books/handbook/ports/_index.adoc
+++ b/documentation/content/en/books/handbook/ports/_index.adoc
@@ -1301,6 +1301,16 @@ custom: {
 }
 ....
 
+However, if you don't want to expose your packages publicly, and you have access to the poudriere packages directory (either because you are using poudriere on the same system that built these packages, or you've exposed it over the network with NFS), you can make your package repository point directly to your package directory:
+
+[.programlisting]
+....
+custom: {
+	url: "file:///usr/local/poudriere/data/packages/11amd64",
+	enabled: yes,
+}
+....
+
 [[ports-nextsteps]]
 == Post-Installation Considerations
 


### PR DESCRIPTION
This adds a small section to the "Configuring pkg Clients to Use a Poudriere Repository" showing the user how to point to their packages repository (package directory in this case) via `file://`. Allowing the user to not have to publicly expose their packages over the internet.