### PR TITLE
Update _index.adoc

### DIFF
--- a/documentation/content/en/books/handbook/linuxemu/_index.adoc
+++ b/documentation/content/en/books/handbook/linuxemu/_index.adoc
@@ -89,7 +89,7 @@ This is enough for statically linked Linux binaries to work.
 They can be started in the same way native FreeBSD binaries can; they behave almost exactly like native processes and can be traced and debugged the usual way.
 
 Linux binaries linked dynamically (which is the vast majority) also require Linux shared libraries to be installed - they can run on top of the FreeBSD kernel, but they cannot use FreeBSD libraries; this is similar to how 32-bit binaries cannot use native 64-bit libraries.
-There are several ways of providing those libraries: one can copy them over from an existing Linux installation using the same architecture, install them from FreeBSD packages, or install using man:deboostrap[8] (from package:sysutils/debootstrap[]), and others.
+There are several ways of providing those libraries: one can copy them over from an existing Linux installation using the same architecture, install them from FreeBSD packages, or install using man:debootstrap[8] (from package:sysutils/debootstrap[]), and others.
 
 [[linuxemu-packages]]
 == CentOS Base System from FreeBSD Packages
@@ -120,7 +120,7 @@ An alternative way of providing Linux shared libraries is by using package:sysut
 This has the advantage of providing a full Debian or Ubuntu distribution.
 To use it, follow the instructions at FreeBSD Wiki: https://wiki.freebsd.org/LinuxJails[FreeBSD Wiki - Linux Jails].
 
-After deboostrapping, man:chroot[8] into the newly created directory and install software in a way typical for the Linux distribution inside, for example:
+After debootstrapping, man:chroot[8] into the newly created directory and install software in a way typical for the Linux distribution inside, for example:
 
 [source,shell]
 ....


### PR DESCRIPTION
Fix "deboostrap" typos on lines 92 and 123 that lead to a "not found page" to "deBOOTstrap" so that it links to the correct command

"Sorry, no data found for `deboostrap(8)'. Please try a keyword search"