### PR TITLE
Remove duplicated AMD64 Virtual Machine Images link

### DIFF
--- a/website/content/en/where.adoc
+++ b/website/content/en/where.adoc
@@ -57,7 +57,6 @@ a|
 * link:{url-rel}/VM-IMAGES/{rel131-current}-RELEASE/i386/Latest/[i386]
 * link:{url-rel}/VM-IMAGES/{rel131-current}-RELEASE/aarch64/Latest/[aarch64]
 * link:{url-rel}/VM-IMAGES/{rel131-current}-RELEASE/riscv64/Latest/[riscv64]
-* link:{url-rel}/CI-IMAGES/{rel131-current}-RELEASE/amd64/Latest/[amd64]
 
 a|
 * aarch64


### PR DESCRIPTION
AMD64  Virtual Machine Images link for FreeBSD 13.1-RELEASE is referenced twice, the link to the CI-IMAGES doesn't appear in the previous 13.0-RELEASE links so I removed that one.