### PR TITLE
Fix grammar and make text more concise.

### DIFF
--- a/documentation/content/en/books/handbook/bsdinstall/_index.adoc
+++ b/documentation/content/en/books/handbook/bsdinstall/_index.adoc
@@ -568,13 +568,13 @@ Selecting btn:[Partition] creates a partition layout from the unused space on th
 .Selecting Entire Disk or Partition
 image::bsdinstall-part-entire-part.png[]
 
-After btn:[Entire Disk] is chosen bsdinstall displays a dialog indicating that the disk will be erased.
+After btn:[Entire Disk] is chosen, bsdinstall displays a dialog indicating that the disk will be erased.
 
 [[bsdinstall-ufs-warning]]
 .Confirmation
 image::bsdinstall-ufs-warning.png[]
 
-The next menu shows a list with the partition schemes types.
+The next menu shows a list with the available partition scheme types.
 GPT is usually the most appropriate choice for amd64 computers.
 Older computers that are not compatible with GPT should use MBR.
 The other partition schemes are generally used for uncommon or older computers.
@@ -585,7 +585,7 @@ More information is available in <<partition-schemes>>.
 image::bsdinstall-part-manual-partscheme.png[]
 
 After the partition layout has been created, review it to ensure it meets the needs of the installation.
-Selecting btn:[Revert] will reset the partitions to their original values and pressing btn:[Auto] will recreate the automatic FreeBSD partitions.
+Selecting btn:[Revert] will reset the partitions to their original values. Pressing btn:[Auto] will recreate the automatic FreeBSD partitions.
 Partitions can also be manually created, modified, or deleted.
 When the partitioning is correct, select btn:[Finish] to continue with the installation.
 
@@ -596,13 +596,13 @@ image::bsdinstall-part-review.png[]
 Once the disks are configured, the next menu provides the last chance to make changes before the selected drives are formatted.
 If changes need to be made, select btn:[Back] to return to the main partitioning menu.
 btn:[Revert & Exit] exits the installer without making any changes to the drive.
-Select btn:[Commit] to start the installation process.
+Otherwise, select btn:[Commit] to start the installation process.
 
 [[bsdinstall-ufs-final-confirmation]]
 .Final Confirmation
 image::bsdinstall-final-confirmation.png[]
 
-To continue with the installation process go to <<bsdinstall-fetching-distribution>>.
+To continue with the installation process, go to <<bsdinstall-fetching-distribution>>.
 
 [[bsdinstall-part-manual]]
 === Manual Partitioning
@@ -659,7 +659,7 @@ A standard FreeBSD GPT installation uses at least three partitions:
 
 Refer to man:gpart[8] for descriptions of the available GPT partition types.
 
-Multiple file system partitions can be created and some people prefer a traditional layout with separate partitions for [.filename]#/#, [.filename]#/var#, [.filename]#/tmp#, and [.filename]#/usr#.
+Multiple file system partitions can be created. Some people prefer a traditional layout with separate partitions for [.filename]#/#, [.filename]#/var#, [.filename]#/tmp#, and [.filename]#/usr#.
 See <<bsdinstall-part-manual-splitfs>> for an example.
 
 The `Size` may be entered with common abbreviations: _K_ for kilobytes, _M_ for megabytes, or _G_ for gigabytes.
@@ -750,19 +750,19 @@ The main ZFS configuration menu offers a number of options to control the creati
 .ZFS Partitioning Menu
 image::bsdinstall-zfs-menu.png[]
 
-Here is a summary of the options which can be used in this menu:
+Here is a summary of the options in this menu:
 
 * `Install` - Proceed with the installation with the selected options.
-* `Pool Type/Disks` - Allow to configure the `Pool Type` and the disk(s) that will constitute the pool. The automatic ZFS installer currently only supports the creation of a single top level vdev, except in stripe mode. To create more complex pools, use the instructions in <<bsdinstall-part-shell>> to create the pool.
+* `Pool Type/Disks` - Configure the `Pool Type` and the disk(s) that will constitute the pool. The automatic ZFS installer currently only supports the creation of a single top level vdev, except in stripe mode. To create more complex pools, use the instructions in <<bsdinstall-part-shell>> to create the pool.
 * `Rescan Devices` - Repopulate the list of available disks.
-* `Disk Info` - Disk Info menu can be used to inspect each disk, including its partition table and various other information such as the device model number and serial number, if available.
+* `Disk Info` - This menu can be used to inspect each disk, including its partition table and various other information such as the device model number and serial number, if available.
 * `Pool Name` - Establish the name of the pool. The default name is _zroot_.
 * `Force 4K Sectors?` - Force the use of 4K sectors. By default, the installer will automatically create partitions aligned to 4K boundaries and force ZFS to use 4K sectors. This is safe even with 512 byte sector disks, and has the added benefit of ensuring that pools created on 512 byte disks will be able to have 4K sector disks added in the future, either as additional storage space or as replacements for failed disks. Press the kbd:[Enter] key to chose to activate it or not.
 * `Encrypt Disks?` - Encrypting the disks allows the user to encrypt the disks using GELI. More information about disk encryption is available in crossref:disks[disks-encrypting-geli,“Disk Encryption with geli”]. Press the kbd:[Enter] key to chose activate it or not.
-* `Partition Scheme` - Allow to choose the partition scheme. GPT is the recommended option in most cases. Press the kbd:[Enter] key to chose between the different options.
+* `Partition Scheme` - Choose the partition scheme. GPT is the recommended option in most cases. Press the kbd:[Enter] key to chose between the different options.
 * `Swap Size` - Establish the amount of swap space.
-* `Mirror Swap?` - Allows the user to mirror the swap between the disks. Be aware, enabling mirror swap will break crash dumps. Press the kbd:[Enter] key to activate it or not.
-* `Encrypt Swap?` - Allow the user the possibility to encrypt the swap. Encrypts the swap with a temporary key each time that the system boots and discards it on reboot. Press the kbd:[Enter] key to chose activate it or not. More information about swap encryption in crossref:disks[swap-encrypting,“Encrypting Swap”].
+* `Mirror Swap?` - Whether to mirror the swap between the disks. Be aware that enabling mirror swap will break crash dumps. Press the kbd:[Enter] key to activate it or not.
+* `Encrypt Swap?` - Whether to encrypt the swap. This will encrypt the swap with a temporary key each time the system boots, and discards it on reboot. Press the kbd:[Enter] key to chose activate it or not. More information about swap encryption in crossref:disks[swap-encrypting,“Encrypting Swap”].
 
 Select kbd:[T] to configure the `Pool Type` and the disk(s) that will constitute the pool.
 
@@ -770,18 +770,18 @@ Select kbd:[T] to configure the `Pool Type` and the disk(s) that will constitute
 .ZFS Pool Type
 image::bsdinstall-zfs-vdev_type.png[]
 
-Here is a summary of the `Pool Type` which can be selected in this menu:
+Here is a summary of the `Pool Type` that can be selected in this menu:
 
 * `stripe` - Striping provides maximum storage of all connected devices, but no redundancy. If just one disk fails the data on the pool is lost irrevocably.
-* `mirror` - Mirroring stores a complete copy of all data on every disk. Mirroring provides a good read performance because data is read from all disks in parallel. Write performance is slower as the data must be written to all disks in the pool. Allows all but one disk to fail. This option requires at least two disks.
+* `mirror` - Mirroring stores a complete copy of all data on every disk. Mirroring provides good read performance because data is read from all disks in parallel. Write performance is slower as the data must be written to all disks in the pool. Allows all but one disk to fail. This option requires at least two disks.
 * `raid10` - Striped mirrors. Provides the best performance, but the least storage. This option needs at least an even number of disks and a minimum of four disks.
 * `raidz1` - Single Redundant RAID. Allow one disk to fail concurrently. This option needs at least three disks.
 * `raidz2` - Double Redundant RAID. Allows two disks to fail concurrently. This option needs at least four disks.
 * `raidz3` - Triple Redundant RAID. Allows three disks to fail concurrently. This option needs at least five disks.
 
 Once a `Pool Type` has been selected, a list of available disks is displayed, and the user is prompted to select one or more disks to make up the pool.
-The configuration is then validated, to ensure enough disks are selected.
-If not, select btn:[<Change Selection>] to return to the list of disks, or btn:[<Back>] to change the `Pool Type`.
+The configuration is then validated to ensure that enough disks are selected.
+If validation fails, select btn:[<Change Selection>] to return to the list of disks or btn:[<Back>] to change the `Pool Type`.
 
 [[bsdinstall-zfs-disk_select]]
 .Disk Selection
@@ -804,14 +804,14 @@ To avoid accidentally erasing the wrong disk, the btn:[- Disk Info] menu can be 
 image::bsdinstall-zfs-disk_info.png[]
 
 Select kbd:[N] to configure the `Pool Name`.
-Enter the desired name then select btn:[<OK>] to establish it or btn:[<Cancel>] to return to the main menu and leave the default name.
+Enter the desired name, then select btn:[<OK>] to establish it or btn:[<Cancel>] to return to the main menu and leave the default name.
 
 [[bsdinstall-zfs-pool-name]]
 .Pool Name
 image::bsdinstall-zfs-pool-name.png[]
 
 Select kbd:[S] to set the amount of swap.
-Enter the desired amount of swap and then select btn:[<OK>] to establish it or btn:[<Cancel>] to return to the main menu and let the default amount.
+Enter the desired amount of swap, then select btn:[<OK>] to establish it or btn:[<Cancel>] to return to the main menu and let the default amount.
 
 [[bsdinstall-zfs-swap-amount]]
 .Swap Amount
@@ -825,7 +825,7 @@ The installer then offers a last chance to cancel before the contents of the sel
 image::bsdinstall-zfs-warning.png[]
 
 If GELI disk encryption was enabled, the installer will prompt twice for the passphrase to be used to encrypt the disks.
-And after that the initializing of the encryption begins.
+Initialization of the encryption then begins.
 
 [[bsdinstall-zfs-geli_password]]
 .Disk Encryption Password
@@ -836,7 +836,7 @@ image::bsdinstall-zfs-geli_password.png[]
 image::bsdinstall-zfs-init-encription.png[]
 
 The installation then proceeds normally.
-To continue with the installation go to <<bsdinstall-fetching-distribution>>.
+To continue with the installation, go to <<bsdinstall-fetching-distribution>>.
 
 [[bsdinstall-part-shell]]
 === Shell Mode Partitioning
@@ -881,8 +881,7 @@ The available post-configuration options are described in the next section.
 
 First, the `root` password must be set.
 While entering the password, the characters being typed are not displayed on the screen.
-After the password has been entered, it must be entered again.
-This helps prevent typing errors.
+The password must be entered twice to prevent typing errors.
 
 [[bsdinstall-post-set-root-passwd]]
 .Setting the `root` Password
@@ -946,7 +945,7 @@ Only start the services that are needed for the system to function.
 .Selecting Additional Services to Enable
 image::bsdinstall-config-services.png[]
 
-Here is a summary of the services which can be enabled in this menu:
+Here is a summary of the services that can be enabled in this menu:
 
 * `local_unbound` - Enable the DNS local unbound. It is necessary to keep in mind that this is the unbound of the base system and is only meant for use as a local caching forwarding resolver. If the objective is to set up a resolver for the entire network install package:dns/unbound[].
 * `sshd` - The Secure Shell (SSH) daemon is used to remotely access a system over an encrypted connection. Only enable this service if the system should be available for remote logins.
@@ -954,7 +953,7 @@ Here is a summary of the services which can be enabled in this menu:
 * `ntpdate` - Enable the automatic clock synchronization at boot time. The functionality of this program is now available in the man:ntpd[8] daemon. After a suitable period of mourning, the man:ntpdate[8] utility will be retired.
 * `ntpd` - The Network Time Protocol (NTP) daemon for automatic clock synchronization. Enable this service if there is a Windows(R), Kerberos, or LDAP server on the network.
 * `powerd` - System power control utility for power control and energy saving.
-* `dumpdev` - Enabling crash dumps is useful in debugging issues with the system, so users are encouraged to enable crash dumps.
+* `dumpdev` - Crash dumps are useful when debugging issues with the system, so users are encouraged to enable them.
 
 [[bsdinstall-hardening]]
 === Enabling Hardening Security Options
@@ -967,19 +966,19 @@ But their use is encouraged.
 .Selecting Hardening Security Options
 image::bsdinstall-hardening.png[]
 
-Here is a summary of the options which can be enabled in this menu:
+Here is a summary of the options that can be enabled in this menu:
 
-* `hide_uids` - Hide processes running as other users to prevent the unprivileged users to see other running processes in execution by other users (UID) preventing information leakage.
-* `hide_gids` - Hide processes running as other groups to prevent the unprivileged users to see other running processes in execution by other groups (GID) preventing information leakage.
-* `hide_jail` - Hide processes running in jails to prevent the unprivileged users to see processes running inside the jails.
-* `read_msgbuf` - Disabling reading kernel message buffer for unprivileged users prevent from using man:dmesg[8] to view messages from the kernel's log buffer.
-* `proc_debug` - Disabling process debugging facilities for unprivileged users disables a variety of unprivileged inter-process debugging services, including some procfs functionality, ptrace(), and ktrace(). Please note that this will also prevent debugging tools, for instance man:lldb[1], man:truss[1], man:procstat[1], as well as some built-in debugging facilities in certain scripting language like PHP, etc., from working for unprivileged users.
-* `random_pid` - Randomize the PID of newly created processes.
+* `hide_uids` - Hide processes running as other users (UID). This prevents unprivileged users from seeing running processes from other users.
+* `hide_gids` - Hide processes running as other groups (GID). This prevents unprivileged users from seeing running processes from other groups.
+* `hide_jail` - Hide processes running in jails. This prevents unprivileged users from seeing processes running inside jails.
+* `read_msgbuf` - Disable reading kernel message buffer for unprivileged users. Prevent unprivileged users from using man:dmesg[8] to view messages from the kernel's log buffer.
+* `proc_debug` - Disable process debugging facilities for unprivileged users. Disables a variety of unprivileged inter-process debugging services, including some procfs functionality, `ptrace()`, and `ktrace()`. Please note that this will also prevent debugging tools such as man:lldb[1], man:truss[1] and man:procstat[1], as well as some built-in debugging facilities in certain scripting language like PHP.
+* `random_pid` - Randomize the PID of processes.
 * `clear_tmp` - Clean [.filename]#/tmp# when the system starts up.
-* `disable_syslogd` - Disable opening syslogd network socket. By default FreeBSD runs syslogd in a secure way with `-s`. That prevents the daemon from listening for incoming UDP requests at port 514. With this option enabled syslogd will run with the flag `-ss` which prevents syslogd from opening any port. To get more information consult man:syslogd[8].
+* `disable_syslogd` - Disable opening the syslogd network socket. By default, FreeBSD runs syslogd in a secure way with `-s`. This prevents the daemon from listening for incoming UDP requests on port 514. With this option enabled, syslogd will instead run with `-ss`, which prevents syslogd from opening any port. For more information, see man:syslogd[8].
 * `disable_sendmail` - Disable the sendmail mail transport agent.
-* `secure_console` - When this option is enabled, the prompt requests the `root` password when entering single-user mode.
-* `disable_ddtrace` - DTrace can run in a mode that will actually affect the running kernel. Destructive actions may not be used unless they have been explicitly enabled. To enable this option when using DTrace use `-w`. To get more information consult man:dtrace[1].
+* `secure_console` - Make the command prompt request the `root` password when entering single-user mode.
+* `disable_ddtrace` - DTrace can run in a mode that affects the running kernel. Destructive actions may not be used unless explicitly enabled. Use `-w` to enable this option when using DTrace. For more information, see man:dtrace[1].
 
 [[bsdinstall-addusers]]
 === Add Users

--- a/documentation/content/en/books/handbook/bsdinstall/_index.adoc
+++ b/documentation/content/en/books/handbook/bsdinstall/_index.adoc
@@ -363,7 +363,7 @@ The following options are available.
 * `Escape to loader prompt`: This will boot the system into a repair prompt that contains a limited number of low-level commands. This prompt is described in crossref:boot[boot-loader,“Stage Three”]. Press kbd:[3] or kbd:[Esc] to boot into this prompt.
 * `Reboot`: Reboots the system.
 * `Kernel`: Loads a different kernel.
-* `Configure Boot Options`: Opens the menu shown in, and described under, <<bsdinstall-boot-options-menu>>.
+* `Boot Options`: Opens the menu shown in, and described under, <<bsdinstall-boot-options-menu>>.
 
 [[bsdinstall-boot-options-menu]]
 .FreeBSD Boot Options Menu
@@ -419,7 +419,7 @@ Before starting the process, bsdinstall will load the keymap files as show in <<
 .Keymap Loading
 image::bsdinstall-keymap-loading.png[]
 
-After the keymaps have been loaded bsdinstall displays the menu shown in <<bsdinstall-keymap-10>>.
+After the keymaps have been loaded, bsdinstall displays the menu shown in <<bsdinstall-keymap-10>>.
 Use the up and down arrows to select the keymap that most closely represents the mapping of the keyboard attached to the system.
 Press kbd:[Enter] to save the selection.
 
@@ -433,7 +433,7 @@ Pressing kbd:[Esc] will exit this menu and use the default keymap.
 If the choice of keymap is not clear, [.guimenuitem]#United States of America ISO-8859-1# is also a safe option.
 ====
 
-In addition, when selecting a different keymap, the user can try the keymap and ensure it is correct before proceeding as shown in <<bsdinstall-keymap-testing>>.
+In addition, when selecting a different keymap, the user can try the keymap and ensure it is correct before proceeding, as shown in <<bsdinstall-keymap-testing>>.
 
 [[bsdinstall-keymap-testing]]
 .Keymap Testing Menu
@@ -464,7 +464,7 @@ Deciding which components to install will depend largely on the intended use of 
 The FreeBSD kernel and userland, collectively known as the _base system_, are always installed.
 Depending on the architecture, some of these components may not appear:
 
-* `base-dbg` - Base tools like cat, ls among many others with debug symbols activated.
+* `base-dbg` - Base tools like cat and ls, among many others, with debug symbols activated.
 * `kernel-dbg` - Kernel and modules with debug symbols activated.
 * `lib32-dbg` - Compatibility libraries for running 32-bit applications on a 64-bit version of FreeBSD with debug symbols activated.
 * `lib32` - Compatibility libraries for running 32-bit applications on a 64-bit version of FreeBSD.
@@ -483,9 +483,9 @@ The FreeBSD Ports Collection takes up about {ports-size} of disk space.
 [[bsdinstall-netinstall]]
 === Installing from the Network
 
-The menu shown in <<bsdinstall-netinstall-notify>> only appears when installing from a [.filename]#-bootonly.iso# or [.filename]#-mini-memstick.img# as this installation media does not hold copies of the installation files.
+The menu shown in <<bsdinstall-netinstall-notify>> only appears when installing from a [.filename]#-bootonly.iso# or [.filename]#-mini-memstick.img#, as this installation media does not hold copies of the installation files.
 Since the installation files must be retrieved over a network connection, this menu indicates that the network interface must be configured first.
-If this menu is shown in any step of the process remember to follow the instructions in <<bsdinstall-config-network-dev>>.
+If this menu is shown in any step of the process, remember to follow the instructions in <<bsdinstall-config-network-dev>>.
 
 [[bsdinstall-netinstall-notify]]
 .Installing from the Network
@@ -541,13 +541,13 @@ Configuring too little swap can lead to inefficiencies in the VM page scanning c
 
 On larger systems with multiple SCSI disks or multiple IDE disks operating on different controllers, it is recommended that swap be configured on each drive, up to four drives.
 The swap partitions should be approximately the same size.
-The kernel can handle arbitrary sizes but internal data structures scale to 4 times the largest swap partition.
+The kernel can handle arbitrary sizes, but internal data structures scale to 4 times the largest swap partition.
 Keeping the swap partitions near the same size will allow the kernel to optimally stripe swap space across disks.
 Large swap sizes are fine, even if swap is not used much.
 It might be easier to recover from a runaway program before being forced to reboot.
 
 By properly partitioning a system, fragmentation introduced in the smaller write heavy partitions will not bleed over into the mostly read partitions. 
-Keeping the write loaded partitions closer to the disk's edge will increase I/O performance in the partitions where it occurs the most.
+Keeping the write-loaded partitions closer to the disk's edge will increase I/O performance in the partitions where it occurs the most.
 While I/O performance in the larger partitions may be needed, shifting them more toward the edge of the disk will not lead to a significant performance improvement over moving [.filename]#/var# to the edge.
 
 [[bsdinstall-part-guided]]

--- a/documentation/content/en/books/handbook/bsdinstall/_index.adoc
+++ b/documentation/content/en/books/handbook/bsdinstall/_index.adoc
@@ -546,7 +546,7 @@ Keeping the swap partitions near the same size will allow the kernel to optimall
 Large swap sizes are fine, even if swap is not used much.
 It might be easier to recover from a runaway program before being forced to reboot.
 
-By properly partitioning a system, fragmentation introduced in the smaller write heavy partitions will not bleed over into the mostly read partitions. 
+By properly partitioning a system, fragmentation introduced in the smaller write-heavy partitions will not bleed over into the mostly read partitions. 
 Keeping the write-loaded partitions closer to the disk's edge will increase I/O performance in the partitions where it occurs the most.
 While I/O performance in the larger partitions may be needed, shifting them more toward the edge of the disk will not lead to a significant performance improvement over moving [.filename]#/var# to the edge.
 
@@ -972,7 +972,7 @@ Here is a summary of the options that can be enabled in this menu:
 * `hide_gids` - Hide processes running as other groups (GID). This prevents unprivileged users from seeing running processes from other groups.
 * `hide_jail` - Hide processes running in jails. This prevents unprivileged users from seeing processes running inside jails.
 * `read_msgbuf` - Disable reading kernel message buffer for unprivileged users. Prevent unprivileged users from using man:dmesg[8] to view messages from the kernel's log buffer.
-* `proc_debug` - Disable process debugging facilities for unprivileged users. Disables a variety of unprivileged inter-process debugging services, including some procfs functionality, `ptrace()`, and `ktrace()`. Please note that this will also prevent debugging tools such as man:lldb[1], man:truss[1] and man:procstat[1], as well as some built-in debugging facilities in certain scripting language like PHP.
+* `proc_debug` - Disable process debugging facilities for unprivileged users. Disables a variety of unprivileged inter-process debugging services, including some procfs functionality, `ptrace()`, and `ktrace()`. Please note that this will also prevent debugging tools such as man:lldb[1], man:truss[1] and man:procstat[1], as well as some built-in debugging facilities in certain scripting languages like PHP.
 * `random_pid` - Randomize the PID of processes.
 * `clear_tmp` - Clean [.filename]#/tmp# when the system starts up.
 * `disable_syslogd` - Disable opening the syslogd network socket. By default, FreeBSD runs syslogd in a secure way with `-s`. This prevents the daemon from listening for incoming UDP requests on port 514. With this option enabled, syslogd will instead run with `-ss`, which prevents syslogd from opening any port. For more information, see man:syslogd[8].
@@ -984,7 +984,7 @@ Here is a summary of the options that can be enabled in this menu:
 === Add Users
 
 The next menu prompts to create at least one user account.
-It is recommended to log in to the system using a user account rather than as `root`.
+It is recommended to log into the system using a user account rather than as `root`.
 When logged in as `root`, there are essentially no limits or protection on what can be done.
 Logging in as a normal user is safer and more secure.
 
@@ -1013,7 +1013,7 @@ Here is a summary of the information to input:
 * `Home directory` - The user's home directory. The default is usually correct.
 * `Home directory permissions` - Permissions on the user's home directory. The default is usually correct.
 * `Use password-based authentication?` - Typically `yes` so that the user is prompted to input their password at login.
-* `Use an empty password?` - Typically `no` for security.
+* `Use an empty password?` - Typically `no` as empty or blank passwords are insecure.
 * `Use a random password?` - Typically `no` so that the user can set their own password in the next prompt.
 * `Enter password` - The password for this user. Typed-in characters will not be shown on the screen.
 * `Enter password again` - The password must be typed again for verification.
@@ -1082,7 +1082,7 @@ When finished, press kbd:[Scroll-Lock] again to unlock the display and return to
 To review these messages once the system has been up for some time, type `less /var/run/dmesg.boot` from a command prompt.
 Press kbd:[q] to return to the command line after viewing.
 
-If sshd was enabled in <<bsdinstall-config-serv>>, the first boot might be a bit slower as the system generates RSA and DSA keys.
+If sshd was enabled in <<bsdinstall-config-serv>>, the first boot might be a bit slower as the system generates SSH host keys.
 Subsequent boots will be faster.
 The fingerprints of the keys are then displayed as in the following example:
 

--- a/documentation/content/en/books/handbook/bsdinstall/_index.adoc
+++ b/documentation/content/en/books/handbook/bsdinstall/_index.adoc
@@ -984,7 +984,7 @@ Here is a summary of the options that can be enabled in this menu:
 === Add Users
 
 The next menu prompts to create at least one user account.
-It is recommended to login to the system using a user account rather than as `root`.
+It is recommended to log in to the system using a user account rather than as `root`.
 When logged in as `root`, there are essentially no limits or protection on what can be done.
 Logging in as a normal user is safer and more secure.
 
@@ -1005,23 +1005,23 @@ Here is a summary of the information to input:
 
 * `Username` - The name the user will enter to log in. A common convention is to use the first letter of the first name combined with the last name, as long as each username is unique for the system. The username is case sensitive and should not contain any spaces.
 * `Full name` - The user's full name. This can contain spaces and is used as a description for the user account.
-* `Uid` - User ID. Typically, this is left blank so the system will assign a value.
-* `Login group` - The user's group. Typically this is left blank to accept the default.
+* `Uid` - User ID. This is typically left blank so the system automatically assigns a value.
+* `Login group` - The user's group. This is typically left blank to accept the default.
 * `Invite _user_ into other groups?` - Additional groups to which the user will be added as a member. If the user needs administrative access, type `wheel` here.
 * `Login class` - Typically left blank for the default.
-* `Shell` - Type in one of the listed values to set the interactive shell for the user. Refer to crossref:basics[shells,“Shells”] for more information about shells.
+* `Shell` - Type in one of the listed values to set the interactive shell for the user. Refer to crossref:basics[shells,Shells] for more information about shells.
 * `Home directory` - The user's home directory. The default is usually correct.
 * `Home directory permissions` - Permissions on the user's home directory. The default is usually correct.
 * `Use password-based authentication?` - Typically `yes` so that the user is prompted to input their password at login.
-* `Use an empty password?` - Typically `no` as it is insecure to have a blank password.
+* `Use an empty password?` - Typically `no` for security.
 * `Use a random password?` - Typically `no` so that the user can set their own password in the next prompt.
-* `Enter password` - The password for this user. Characters typed will not show on the screen.
+* `Enter password` - The password for this user. Typed-in characters will not be shown on the screen.
 * `Enter password again` - The password must be typed again for verification.
-* `Lock out the account after creation?` - Typically `no` so that the user can login.
+* `Lock out the account after creation?` - Typically `no` so that the user can log in.
 
-After entering everything, a summary is shown for review.
-If a mistake was made, enter `no` and try again.
-If everything is correct, enter `yes` to create the new user.
+After entering all the details, a summary is shown for review.
+If a mistake was made, enter `no` to correct it.
+Once everything is correct, enter `yes` to create the new user.
 
 [[bsdinstall-add-user3]]
 .Exit User and Group Management
@@ -1030,7 +1030,7 @@ image::bsdinstall-adduser3.png[]
 If there are more users to add, answer the `Add another user?` question with `yes`.
 Enter `no` to finish adding users and continue the installation.
 
-For more information on adding users and user management, see crossref:basics[users-synopsis,“Users and Basic Account Management”].
+For more information on adding users and user management, see crossref:basics[users-synopsis,Users and Basic Account Management].
 
 [[bsdinstall-final-conf]]
 === Final Configuration
@@ -1041,7 +1041,7 @@ After everything has been installed and configured, a final chance is provided t
 .Final Configuration
 image::bsdinstall-finalconfiguration.png[]
 
-Use this menu to make any changes or do any additional configuration before completing the installation.
+Use this menu to make any changes or to do any additional configuration before completing the installation.
 
 * `Add User` - Described in <<bsdinstall-addusers>>.
 * `Root Password` - Described in <<bsdinstall-post-root>>.
@@ -1052,13 +1052,13 @@ Use this menu to make any changes or do any additional configuration before comp
 * `Time Zone` - Described in <<bsdinstall-timezone>>.
 * `Handbook` - Download and install the FreeBSD Handbook.
 
-After any final configuration is complete, select btn:[Exit].
+Once configuration is complete, select btn:[Exit].
 
 [[bsdinstall-final-modification-shell]]
 .Manual Configuration
 image::bsdinstall-final-modification-shell.png[]
 
-bsdinstall will prompt if there are any additional configuration that needs to be done before rebooting into the new system.
+bsdinstall will prompt for any additional configuration that needs to be done before rebooting into the new system.
 Select btn:[Yes] to exit to a shell within the new system or btn:[No] to proceed to the last step of the installation.
 
 [[bsdinstall-final-main]]
@@ -1068,23 +1068,23 @@ image::bsdinstall-mainexit.png[]
 If further configuration or special setup is needed, select btn:[Live CD] to boot the install media into Live CD mode.
 
 If the installation is complete, select btn:[Reboot] to reboot the computer and start the new FreeBSD system.
-Do not forget to remove the FreeBSD install media or the computer may boot from it again.
+Do not forget to remove the FreeBSD install media or the computer might boot from it again.
 
 As FreeBSD boots, informational messages are displayed.
 After the system finishes booting, a login prompt is displayed.
 At the `login:` prompt, enter the username added during the installation.
 Avoid logging in as `root`.
-Refer to crossref:basics[users-superuser,“The Superuser Account”] for instructions on how to become the superuser when administrative access is needed.
+Refer to crossref:basics[users-superuser,The Superuser Account] for instructions on how to become the superuser when administrative access is needed.
 
-The messages that appeared during boot can be reviewed by pressing kbd:[Scroll-Lock] to turn on the scroll-back buffer.
+The messages that appear during boot can be reviewed by pressing kbd:[Scroll-Lock] to turn on the scroll-back buffer.
 The kbd:[PgUp], kbd:[PgDn], and arrow keys can be used to scroll back through the messages.
 When finished, press kbd:[Scroll-Lock] again to unlock the display and return to the console.
 To review these messages once the system has been up for some time, type `less /var/run/dmesg.boot` from a command prompt.
 Press kbd:[q] to return to the command line after viewing.
 
-If sshd was enabled in <<bsdinstall-config-serv>>, the first boot may be a bit slower as the system will generate the RSA and DSA keys.
+If sshd was enabled in <<bsdinstall-config-serv>>, the first boot might be a bit slower as the system generates RSA and DSA keys.
 Subsequent boots will be faster.
-The fingerprints of the keys will be displayed, as seen in this example:
+The fingerprints of the keys are then displayed as in the following example:
 
 [source,shell]
 ....
@@ -1132,7 +1132,7 @@ Refer to crossref:x11[x11,The X Window System] for more information about instal
 
 Proper shutdown of a FreeBSD computer helps protect data and hardware from damage.
 _Do not turn off the power before the system has been properly shut down!_ If the user is a member of the `wheel` group, become the superuser by typing `su` at the command line and entering the `root` password.
-Then, type `shutdown -p now` and the system will shut down cleanly, and if the hardware supports it, turn itself off.
+Then, type `shutdown -p now` and the system will shut down cleanly, and, if the hardware supports it, turn itself off.
 
 [[bsdinstall-network]]
 == Network Interfaces
@@ -1165,7 +1165,7 @@ Rescan after each change is made.
 image::bsdinstall-configure-wireless-accesspoints.png[]
 
 Next, enter the encryption information for connecting to the selected wireless network.
-WPA2 encryption is strongly recommended as older encryption types, like WEP, offer little security.
+WPA2 encryption is strongly recommended over older encryption types such as WEP, which offer little security.
 If the network uses WPA2, input the password, also known as the Pre-Shared Key (PSK).
 For security reasons, the characters typed into the input box are displayed as asterisks.
 
@@ -1202,7 +1202,7 @@ If a DHCP server is not available, select btn:[No] and input the following addre
 .IPv4 Static Configuration
 image::bsdinstall-configure-network-interface-ipv4-static.png[]
 
-* `IP Address` - The IPv4 address assigned to this computer. The address must be unique and not already in use by another piece of equipment on the local network.
+* `IP Address` - The IPv4 address assigned to this computer. The address must be unique and not already in use by another device on the local network.
 * `Subnet Mask` - The subnet mask for the network.
 * `Default Router` - The IP address of the network's default gateway.
 
@@ -1230,7 +1230,7 @@ If an IPv6 router is not available, select btn:[No] and input the following addr
 .IPv6 Static Configuration
 image::bsdinstall-configure-network-interface-ipv6-static.png[]
 
-* `IPv6 Address` - The IPv6 address assigned to this computer. The address must be unique and not already in use by another piece of equipment on the local network.
+* `IPv6 Address` - The IPv6 address assigned to this computer. The address must be unique and not already in use by another device on the local network.
 * `Default Router` - The IPv6 address of the network's default gateway.
 
 The last network configuration menu is used to configure the Domain Name System (DNS) resolver, which converts hostnames to and from network addresses.
@@ -1256,7 +1256,7 @@ image::bsdinstall-netinstall-mirrorselect.png[]
 This section covers basic installation troubleshooting, such as common problems people have reported.
 
 Check the Hardware Notes (link:https://www.FreeBSD.org/releases/[https://www.freebsd.org/releases/]) document for the version of FreeBSD to make sure the hardware is supported.
-If the hardware is supported and lock-ups or other problems occur, build a custom kernel using the instructions in crossref:kernelconfig[kernelconfig,Configuring the FreeBSD Kernel] to add support for devices which are not present in the [.filename]#GENERIC# kernel. 
+If the hardware is supported and locks up or other problems occur, build a custom kernel using the instructions in crossref:kernelconfig[kernelconfig,Configuring the FreeBSD Kernel] to add support for devices which are not present in the [.filename]#GENERIC# kernel. 
 The default kernel assumes that most hardware devices are in their factory default configuration in terms of IRQs, I/O addresses, and DMA channels.
 If the hardware has been reconfigured, a custom kernel configuration file can tell FreeBSD where to find things.
 
@@ -1270,7 +1270,7 @@ Manufacturers generally advise against upgrading the motherboard BIOS unless the
 The upgrade process _can_ go wrong, leaving the BIOS incomplete and the computer inoperative.
 ====
 
-If the system hangs while probing hardware during boot, or it behaves strangely during install, ACPI may be the culprit.
+If the system hangs while probing hardware during boot or behaves strangely during the installation process, ACPI may be the culprit.
 FreeBSD makes extensive use of the system ACPI service on the i386 and amd64 platforms to aid in system configuration if it is detected during boot. 
 Unfortunately, some bugs still exist in both the ACPI driver and within system motherboards and BIOS firmware.
 ACPI can be disabled by setting the `hint.acpi.0.disabled` hint in the third stage boot loader:


### PR DESCRIPTION
- Change `Configure Boot Options` to `Boot Options` so that it matches the menu option in the image above.
- Make text constructs more consistent across the document.
- Various [which vs that](https://owl.purdue.edu/owl/general_writing/grammar/that_vs_which.html) fixes.
- `may` vs `might`.
- `login`/`log in` noun vs verb.
- Remove quotes from a handful of cross-references for consistency with others.
- A few commas here and there.