### PR TITLE
arch-handbook: BUS_DMA_ISA no longer exists

### DIFF
--- a/documentation/content/en/books/arch-handbook/isa/_index.adoc
+++ b/documentation/content/en/books/arch-handbook/isa/_index.adoc
@@ -364,10 +364,9 @@ highaddr = BUS_SPACE_MAXADDR
 ** _maxsize_ - the maximal size of memory (in bytes) that may be allocated through this tag. In case it is difficult to estimate or could be arbitrarily big, the value for ISA devices would be `BUS_SPACE_MAXSIZE_24BIT`.
 ** _nsegments_ - maximal number of scatter-gather segments supported by the device. If unrestricted then the value `BUS_SPACE_UNRESTRICTED` should be used. This value is recommended for the parent tags, the actual restrictions would then be specified for the descendant tags. Tags with nsegments equal to `BUS_SPACE_UNRESTRICTED` may not be used to actually load maps, they may be used only as parent tags. The practical limit for nsegments seems to be about 250-300, higher values will cause kernel stack overflow (the hardware can not normally support that many scatter-gather buffers anyway).
 ** _maxsegsz_ - maximal size of a scatter-gather segment supported by the device. The maximal value for ISA device would be `BUS_SPACE_MAXSIZE_24BIT`.
-** _flags_ - a bitmap of flags. The only interesting flags are:
+** _flags_ - a bitmap of flags. The only interesting flag is:
 
 *** _BUS_DMA_ALLOCNOW_ - requests to allocate all the potentially needed bounce pages when creating the tag.
-*** _BUS_DMA_ISA_ - mysterious flag used only on Alpha machines. It is not defined for the i386 machines. Probably it should be used by all the ISA drivers for Alpha machines but it looks like there are no such drivers yet.
 
 ** _dmat_ - pointer to the storage for the new tag to be returned.
 


### PR DESCRIPTION
The BUS_DMA_ISA flag was removed in March 2008.