### PR TITLE
Fixed URL on LV Mirror.

### DIFF
--- a/documentation/content/en/books/handbook/mirrors/_index.adoc
+++ b/documentation/content/en/books/handbook/mirrors/_index.adoc
@@ -193,7 +193,7 @@ Mirror list maintained by the community and other companies:
 
 | Latvia icon:envelope[link=mailto:{mirrors-latvia-email}, title="mirror contact"]
 | ftp.lv.FreeBSD.org
-| link:http://ftp.lv.FreeBSD.org/pub/FreeBSD[http] link:ftp://ftp.lv.FreeBSD.org/pub/FreeBSD[ftp]
+| link:http://ftp.lv.FreeBSD.org/freebsd[http] link:ftp://ftp.lv.FreeBSD.org/pub/FreeBSD[ftp]
 
 | Netherlands icon:envelope[link=mailto:{mirrors-netherlands-email}, title="mirror contact"]
 | ftp.nl.FreeBSD.org


### PR DESCRIPTION
The HTTP URL of LV mirror was giving a 404 error. Hence I have fixed/updated it with a working one.