### PR TITLE
[32.3.4.1.1. How to Find Access Points] Update _index.adoc

### DIFF
--- a/documentation/content/en/books/handbook/advanced-networking/_index.adoc
+++ b/documentation/content/en/books/handbook/advanced-networking/_index.adoc
@@ -530,7 +530,8 @@ Only the superuser can initiate a scan:
 [source,shell]
 ....
 # ifconfig wlan0 create wlandev ath0
-# ifconfig wlan0 up scan
+# ifconfig wlan0 up
+# ifconfig wlan0 scan
 SSID/MESH ID    BSSID              CHAN RATE   S:N     INT CAPS
 dlinkap         00:13:46:49:41:76   11   54M -90:96   100 EPS  WPA WME
 freebsdap       00:11:95:c3:0d:ac    1   54M -83:96   100 EPS  WPA


### PR DESCRIPTION
As noted below: "The interface must be `up` before it can scan", so under certain **proven** conditions, "up" and "scan" do not work together and should be run separately.