### PR TITLE
Committer's Guide: metadata: group and team names

### DIFF
--- a/documentation/content/en/articles/committers-guide/_index.adoc
+++ b/documentation/content/en/articles/committers-guide/_index.adoc
@@ -3082,7 +3082,7 @@ Relnotes:	yes
 |Group name in Phabricator |Team name for commit
 
 |Ports Committers
-|
+|ports-committers
 
 |ports secteam
 |ports-secteam

--- a/documentation/content/en/articles/committers-guide/_index.adoc
+++ b/documentation/content/en/articles/committers-guide/_index.adoc
@@ -3089,6 +3089,9 @@ Relnotes:	yes
 
 |releng
 |re
+
+|vbox
+|
 |===
 
 

--- a/documentation/content/en/articles/committers-guide/_index.adoc
+++ b/documentation/content/en/articles/committers-guide/_index.adoc
@@ -3075,6 +3075,23 @@ Relnotes:	yes
 
 ====
 
+==== Group and team names
+
+[cols="1,1"]
+|===
+|Group name in Phabricator |Team name for commit
+
+|Ports Committers
+|
+
+|ports secteam
+|ports-secteam
+
+|releng
+|re
+|===
+
+
 [[pref-license]]
 == Preferred License for New Files
 

--- a/documentation/content/en/articles/committers-guide/_index.adoc
+++ b/documentation/content/en/articles/committers-guide/_index.adoc
@@ -3081,6 +3081,9 @@ Relnotes:	yes
 |===
 |Group name in Phabricator |Team name for commit
 
+|Doc Committers
+|doc
+
 |Ports Committers
 |ports-committers
 


### PR DESCRIPTION
Team names should be discoverable.

Add a table, to appear under <https://docs.freebsd.org/en/articles/committers-guide/#_include_appropriate_metadata_in_a_footer>. 