### PR TITLE
Corrected broken links to /support/bugreports/

### DIFF
--- a/website/content/en/commercial/consult.adoc
+++ b/website/content/en/commercial/consult.adoc
@@ -7,6 +7,6 @@ grouped: false
 
 The power, flexibility, and reliability of FreeBSD attract a wide variety of users and vendors. Here you will find vendors offering commercial products and/or services for FreeBSD.
 
-For your convenience, we have divided our growing commercial listing into several sections. If your company supports a FreeBSD related product, service, consulting, or support that should be added to this page, please fill out a https://www.freebsd.org/en/support/bugreports/[problem report] in category Documentation->Website. Submissions should contain a medium-sized paragraph in length, describing your company. Please note that the inclusion of vendors in our list does not signify our endorsement of their products or services by the FreeBSD Project.
+For your convenience, we have divided our growing commercial listing into several sections. If your company supports a FreeBSD related product, service, consulting, or support that should be added to this page, please fill out a https://www.freebsd.org/support/bugreports/[problem report] in category Documentation->Website. Submissions should contain a medium-sized paragraph in length, describing your company. Please note that the inclusion of vendors in our list does not signify our endorsement of their products or services by the FreeBSD Project.
 
 == Consulting Services

--- a/website/content/en/commercial/consult_bycat.adoc
+++ b/website/content/en/commercial/consult_bycat.adoc
@@ -7,7 +7,7 @@ grouped: true
 
 The power, flexibility, and reliability of FreeBSD attract a wide variety of users and vendors. Here you will find vendors offering commercial products and/or services for FreeBSD.
 
-For your convenience, we have divided our growing commercial listing into several sections. If your company supports a FreeBSD related product, service, consulting, or support that should be added to this page, please fill out a https://www.freebsd.org/en/support/bugreports/[problem report] in category Documentation->Website. Submissions should contain a medium-sized paragraph in length, describing your company. Please note that the inclusion of vendors in our list does not signify our endorsement of their products or services by the FreeBSD Project.
+For your convenience, we have divided our growing commercial listing into several sections. If your company supports a FreeBSD related product, service, consulting, or support that should be added to this page, please fill out a https://www.freebsd.org/support/bugreports/[problem report] in category Documentation->Website. Submissions should contain a medium-sized paragraph in length, describing your company. Please note that the inclusion of vendors in our list does not signify our endorsement of their products or services by the FreeBSD Project.
 
 == Consulting Services
 

--- a/website/content/en/commercial/hardware.adoc
+++ b/website/content/en/commercial/hardware.adoc
@@ -6,6 +6,6 @@ vendor: hardware
 
 The power, flexibility, and reliability of FreeBSD attract a wide variety of users and vendors. Here you will find vendors offering commercial products and/or services for FreeBSD.
 
-For your convenience, we have divided our growing commercial listing into several sections. If your company supports a FreeBSD related product, service, consulting, or support that should be added to this page, please fill out a https://www.freebsd.org/en/support/bugreports/[problem report] in category Documentation->Website. Submissions should contain a medium-sized paragraph in length, describing your company. Please note that the inclusion of vendors in our list does not signify our endorsement of their products or services by the FreeBSD Project.
+For your convenience, we have divided our growing commercial listing into several sections. If your company supports a FreeBSD related product, service, consulting, or support that should be added to this page, please fill out a https://www.freebsd.org/support/bugreports/[problem report] in category Documentation->Website. Submissions should contain a medium-sized paragraph in length, describing your company. Please note that the inclusion of vendors in our list does not signify our endorsement of their products or services by the FreeBSD Project.
 
 == Hardware Vendors

--- a/website/content/en/commercial/isp.adoc
+++ b/website/content/en/commercial/isp.adoc
@@ -6,6 +6,6 @@ vendor: isp
 
 The power, flexibility, and reliability of FreeBSD attract a wide variety of users and vendors. Here you will find vendors offering commercial products and/or services for FreeBSD.
 
-For your convenience, we have divided our growing commercial listing into several sections. If your company supports a FreeBSD related product, service, consulting, or support that should be added to this page, please fill out a https://www.freebsd.org/en/support/bugreports/[problem report] in category Documentation->Website. Submissions should contain a medium-sized paragraph in length, describing your company. Please note that the inclusion of vendors in our list does not signify our endorsement of their products or services by the FreeBSD Project.
+For your convenience, we have divided our growing commercial listing into several sections. If your company supports a FreeBSD related product, service, consulting, or support that should be added to this page, please fill out a https://www.freebsd.org/support/bugreports/[problem report] in category Documentation->Website. Submissions should contain a medium-sized paragraph in length, describing your company. Please note that the inclusion of vendors in our list does not signify our endorsement of their products or services by the FreeBSD Project.
 
 == Internet Service Providers

--- a/website/content/en/commercial/misc.adoc
+++ b/website/content/en/commercial/misc.adoc
@@ -6,6 +6,6 @@ vendor: misc
 
 The power, flexibility, and reliability of FreeBSD attract a wide variety of users and vendors. Here you will find vendors offering commercial products and/or services for FreeBSD.
 
-For your convenience, we have divided our growing commercial listing into several sections. If your company supports a FreeBSD related product, service, consulting, or support that should be added to this page, please fill out a https://www.freebsd.org/en/support/bugreports/[problem report] in category Documentation->Website. Submissions should contain a medium-sized paragraph in length, describing your company. Please note that the inclusion of vendors in our list does not signify our endorsement of their products or services by the FreeBSD Project.
+For your convenience, we have divided our growing commercial listing into several sections. If your company supports a FreeBSD related product, service, consulting, or support that should be added to this page, please fill out a https://www.freebsd.org/support/bugreports/[problem report] in category Documentation->Website. Submissions should contain a medium-sized paragraph in length, describing your company. Please note that the inclusion of vendors in our list does not signify our endorsement of their products or services by the FreeBSD Project.
 
 == Miscellaneous Vendors

--- a/website/content/en/commercial/software.adoc
+++ b/website/content/en/commercial/software.adoc
@@ -7,6 +7,6 @@ grouped: false
 
 The power, flexibility, and reliability of FreeBSD attract a wide variety of users and vendors. Here you will find vendors offering commercial products and/or services for FreeBSD.
 
-For your convenience, we have divided our growing commercial listing into several sections. If your company supports a FreeBSD related product, service, consulting, or support that should be added to this page, please fill out a https://www.freebsd.org/en/support/bugreports/[problem report] in category Documentation->Website. Submissions should contain a medium-sized paragraph in length, describing your company. Please note that the inclusion of vendors in our list does not signify our endorsement of their products or services by the FreeBSD Project.
+For your convenience, we have divided our growing commercial listing into several sections. If your company supports a FreeBSD related product, service, consulting, or support that should be added to this page, please fill out a https://www.freebsd.org/support/bugreports/[problem report] in category Documentation->Website. Submissions should contain a medium-sized paragraph in length, describing your company. Please note that the inclusion of vendors in our list does not signify our endorsement of their products or services by the FreeBSD Project.
 
 == Software Vendors

--- a/website/content/en/commercial/software_bycat.adoc
+++ b/website/content/en/commercial/software_bycat.adoc
@@ -7,6 +7,6 @@ grouped: true
 
 The power, flexibility, and reliability of FreeBSD attract a wide variety of users and vendors. Here you will find vendors offering commercial products and/or services for FreeBSD.
 
-For your convenience, we have divided our growing commercial listing into several sections. If your company supports a FreeBSD related product, service, consulting, or support that should be added to this page, please fill out a https://www.freebsd.org/en/support/bugreports/[problem report] in category Documentation->Website. Submissions should contain a medium-sized paragraph in length, describing your company. Please note that the inclusion of vendors in our list does not signify our endorsement of their products or services by the FreeBSD Project.
+For your convenience, we have divided our growing commercial listing into several sections. If your company supports a FreeBSD related product, service, consulting, or support that should be added to this page, please fill out a https://www.freebsd.org/support/bugreports/[problem report] in category Documentation->Website. Submissions should contain a medium-sized paragraph in length, describing your company. Please note that the inclusion of vendors in our list does not signify our endorsement of their products or services by the FreeBSD Project.
 
 == Software Vendors

--- a/website/content/ja/commercial/consult.adoc
+++ b/website/content/ja/commercial/consult.adoc
@@ -7,6 +7,6 @@ grouped: false
 
 The power, flexibility, and reliability of FreeBSD attract a wide variety of users and vendors. Here you will find vendors offering commercial products and/or services for FreeBSD.
 
-For your convenience, we have divided our growing commercial listing into several sections. If your company supports a FreeBSD related product, service, consulting, or support that should be added to this page, please fill out a https://www.freebsd.org/en/support/bugreports/[problem report] in category Documentation->Website. Submissions should contain a medium-sized paragraph in length, describing your company. Please note that the inclusion of vendors in our list does not signify our endorsement of their products or services by the FreeBSD Project.
+For your convenience, we have divided our growing commercial listing into several sections. If your company supports a FreeBSD related product, service, consulting, or support that should be added to this page, please fill out a https://www.freebsd.org/ja/support/bugreports/[problem report] in category Documentation->Website. Submissions should contain a medium-sized paragraph in length, describing your company. Please note that the inclusion of vendors in our list does not signify our endorsement of their products or services by the FreeBSD Project.
 
 == Consulting Services

--- a/website/content/ja/commercial/consult_bycat.adoc
+++ b/website/content/ja/commercial/consult_bycat.adoc
@@ -7,7 +7,7 @@ grouped: true
 
 The power, flexibility, and reliability of FreeBSD attract a wide variety of users and vendors. Here you will find vendors offering commercial products and/or services for FreeBSD.
 
-For your convenience, we have divided our growing commercial listing into several sections. If your company supports a FreeBSD related product, service, consulting, or support that should be added to this page, please fill out a https://www.freebsd.org/en/support/bugreports/[problem report] in category Documentation->Website. Submissions should contain a medium-sized paragraph in length, describing your company. Please note that the inclusion of vendors in our list does not signify our endorsement of their products or services by the FreeBSD Project.
+For your convenience, we have divided our growing commercial listing into several sections. If your company supports a FreeBSD related product, service, consulting, or support that should be added to this page, please fill out a https://www.freebsd.org/ja/support/bugreports/[problem report] in category Documentation->Website. Submissions should contain a medium-sized paragraph in length, describing your company. Please note that the inclusion of vendors in our list does not signify our endorsement of their products or services by the FreeBSD Project.
 
 == Consulting Services
 

--- a/website/content/ja/commercial/hardware.adoc
+++ b/website/content/ja/commercial/hardware.adoc
@@ -6,6 +6,6 @@ vendor: hardware
 
 The power, flexibility, and reliability of FreeBSD attract a wide variety of users and vendors. Here you will find vendors offering commercial products and/or services for FreeBSD.
 
-For your convenience, we have divided our growing commercial listing into several sections. If your company supports a FreeBSD related product, service, consulting, or support that should be added to this page, please fill out a https://www.freebsd.org/en/support/bugreports/[problem report] in category Documentation->Website. Submissions should contain a medium-sized paragraph in length, describing your company. Please note that the inclusion of vendors in our list does not signify our endorsement of their products or services by the FreeBSD Project.
+For your convenience, we have divided our growing commercial listing into several sections. If your company supports a FreeBSD related product, service, consulting, or support that should be added to this page, please fill out a https://www.freebsd.org/ja/support/bugreports/[problem report] in category Documentation->Website. Submissions should contain a medium-sized paragraph in length, describing your company. Please note that the inclusion of vendors in our list does not signify our endorsement of their products or services by the FreeBSD Project.
 
 == Hardware Vendors

--- a/website/content/ja/commercial/isp.adoc
+++ b/website/content/ja/commercial/isp.adoc
@@ -6,6 +6,6 @@ vendor: isp
 
 The power, flexibility, and reliability of FreeBSD attract a wide variety of users and vendors. Here you will find vendors offering commercial products and/or services for FreeBSD.
 
-For your convenience, we have divided our growing commercial listing into several sections. If your company supports a FreeBSD related product, service, consulting, or support that should be added to this page, please fill out a https://www.freebsd.org/en/support/bugreports/[problem report] in category Documentation->Website. Submissions should contain a medium-sized paragraph in length, describing your company. Please note that the inclusion of vendors in our list does not signify our endorsement of their products or services by the FreeBSD Project.
+For your convenience, we have divided our growing commercial listing into several sections. If your company supports a FreeBSD related product, service, consulting, or support that should be added to this page, please fill out a https://www.freebsd.org/ja/support/bugreports/[problem report] in category Documentation->Website. Submissions should contain a medium-sized paragraph in length, describing your company. Please note that the inclusion of vendors in our list does not signify our endorsement of their products or services by the FreeBSD Project.
 
 == Internet Service Providers

--- a/website/content/ja/commercial/misc.adoc
+++ b/website/content/ja/commercial/misc.adoc
@@ -6,6 +6,6 @@ vendor: misc
 
 The power, flexibility, and reliability of FreeBSD attract a wide variety of users and vendors. Here you will find vendors offering commercial products and/or services for FreeBSD.
 
-For your convenience, we have divided our growing commercial listing into several sections. If your company supports a FreeBSD related product, service, consulting, or support that should be added to this page, please fill out a https://www.freebsd.org/en/support/bugreports/[problem report] in category Documentation->Website. Submissions should contain a medium-sized paragraph in length, describing your company. Please note that the inclusion of vendors in our list does not signify our endorsement of their products or services by the FreeBSD Project.
+For your convenience, we have divided our growing commercial listing into several sections. If your company supports a FreeBSD related product, service, consulting, or support that should be added to this page, please fill out a https://www.freebsd.org/ja/support/bugreports/[problem report] in category Documentation->Website. Submissions should contain a medium-sized paragraph in length, describing your company. Please note that the inclusion of vendors in our list does not signify our endorsement of their products or services by the FreeBSD Project.
 
 == Miscellaneous Vendors

--- a/website/content/ja/commercial/software.adoc
+++ b/website/content/ja/commercial/software.adoc
@@ -7,6 +7,6 @@ grouped: false
 
 The power, flexibility, and reliability of FreeBSD attract a wide variety of users and vendors. Here you will find vendors offering commercial products and/or services for FreeBSD.
 
-For your convenience, we have divided our growing commercial listing into several sections. If your company supports a FreeBSD related product, service, consulting, or support that should be added to this page, please fill out a https://www.freebsd.org/en/support/bugreports/[problem report] in category Documentation->Website. Submissions should contain a medium-sized paragraph in length, describing your company. Please note that the inclusion of vendors in our list does not signify our endorsement of their products or services by the FreeBSD Project.
+For your convenience, we have divided our growing commercial listing into several sections. If your company supports a FreeBSD related product, service, consulting, or support that should be added to this page, please fill out a https://www.freebsd.org/ja/support/bugreports/[problem report] in category Documentation->Website. Submissions should contain a medium-sized paragraph in length, describing your company. Please note that the inclusion of vendors in our list does not signify our endorsement of their products or services by the FreeBSD Project.
 
 == Software Vendors

--- a/website/content/ja/commercial/software_bycat.adoc
+++ b/website/content/ja/commercial/software_bycat.adoc
@@ -7,6 +7,6 @@ grouped: true
 
 The power, flexibility, and reliability of FreeBSD attract a wide variety of users and vendors. Here you will find vendors offering commercial products and/or services for FreeBSD.
 
-For your convenience, we have divided our growing commercial listing into several sections. If your company supports a FreeBSD related product, service, consulting, or support that should be added to this page, please fill out a https://www.freebsd.org/en/support/bugreports/[problem report] in category Documentation->Website. Submissions should contain a medium-sized paragraph in length, describing your company. Please note that the inclusion of vendors in our list does not signify our endorsement of their products or services by the FreeBSD Project.
+For your convenience, we have divided our growing commercial listing into several sections. If your company supports a FreeBSD related product, service, consulting, or support that should be added to this page, please fill out a https://www.freebsd.org/ja/support/bugreports/[problem report] in category Documentation->Website. Submissions should contain a medium-sized paragraph in length, describing your company. Please note that the inclusion of vendors in our list does not signify our endorsement of their products or services by the FreeBSD Project.
 
 == Software Vendors


### PR DESCRIPTION
English locale used links prefixed with `/en/`, which are broken. This removes the prefix, which is correct.

Japanese locale also used links prefixed with `/en/`. This changes the prefix to `/ja/`, which is correct.