### PR TITLE
Add tip: ftp.freebsd.org automatic routing

### DIFF
--- a/documentation/content/en/books/handbook/bsdinstall/_index.adoc
+++ b/documentation/content/en/books/handbook/bsdinstall/_index.adoc
@@ -1257,6 +1257,11 @@ image::bsdinstall-configure-network-ipv4-dns.png[]
 Once the interface is configured, select a mirror site that is located in the same region of the world as the computer on which FreeBSD is being installed.
 Files can be retrieved more quickly when the mirror is close to the target computer, reducing installation time.
 
+[TIP]
+====
+Selecting `ftp://ftp.freebsd.org (Main Site)` will automatically route you to the nearest mirror.
+====
+
 [[bsdinstall-netinstall-mirror]]
 .Choosing a Mirror
 image::bsdinstall-netinstall-mirrorselect.png[]


### PR DESCRIPTION
I found out that selecting the `ftp.freebsd.org (Main site)` item will automatically route you to the nearest/fastest mirror. I believe this would be a helpful item to have documented.