### PR TITLE
Vertically align table contents to improve position of step numbers

### DIFF
--- a/documentation/themes/beastie/assets/styles/global.scss
+++ b/documentation/themes/beastie/assets/styles/global.scss
@@ -410,6 +410,7 @@ blockquote {
 .colist td {
   padding-top: 4px;
   padding-bottom: 4px;
+  vertical-align: top;
 }
 
 .colist tr td b,


### PR DESCRIPTION
Top-aligned table cell contents would make [sections with step numbers](https://docs.freebsd.org/en/books/handbook/jails/#jails-install-source) easier to scan through. The numbers would line up with the beginning of the step text.

I can't figure out how to recompile the Sass to test this out, and I'm sure making a change of this scale will likely impact other tables, so I'd appreciate review and feedback on this change before it's implemented.

Current:

<img width="514" src="https://user-images.githubusercontent.com/1403649/219144083-05d5af69-2a60-4ced-b994-73511e35d985.png">

Proposed:

<img width="537" src="https://user-images.githubusercontent.com/1403649/219144115-5e48438c-22e9-4fe3-af2f-6d897e86c847.png">