### PR TITLE
Nvidia fixes

### DIFF
--- a/documentation/content/en/books/handbook/x11/_index.adoc
+++ b/documentation/content/en/books/handbook/x11/_index.adoc
@@ -259,12 +259,6 @@ Those with older cards will have to check below which version supports them.
 |===
 | Package | Supported hardware
 
-| x11/nvidia-driver-304
-| link:https://www.nvidia.com/Download/driverResults.aspx/123712/en-us/[supported hardware]
-
-| x11/nvidia-driver-340
-| link:https://www.nvidia.com/Download/driverResults.aspx/156167/en-us/[supported hardware]
-
 | x11/nvidia-driver-390
 | link:https://www.nvidia.com/Download/driverResults.aspx/191122/en-us/[supported hardware]
 
@@ -275,11 +269,6 @@ Those with older cards will have to check below which version supports them.
 | link:https://www.nvidia.com/Download/driverResults.aspx/187164/en-us/[supported hardware]
 
 |===
-
-[WARNING]
-====
-Version 304 of the NVIDIA(R) graphics driver (nvidia-driver-304) does not support xorg-server 1.20 or later.
-====
 
 The latest NVIDIA(R) driver can be installed by running the following command:
 
@@ -292,19 +281,8 @@ Then add the module to `/etc/rc.conf` file, executing the following command:
 
 [source,shell]
 ....
-# sysrc kld_list+=nvidia
+# sysrc kld_list+=nvidia-modeset
 ....
-
-[WARNING]
-====
-The `nvidia-modeset` driver must be used *only* as an alternative to `nvidia` if starting the X server results in a hang or these values are observed in `/var/log/Xorg.0.log`:
-
-[.programlisting]
-....
-(II) NVIDIA(0): Validated MetaModes:
-(II) NVIDIA(0):     "NULL"
-....
-====
 
 [[x-config]]
 == Xorg Configuration


### PR DESCRIPTION
1. 304, 340, 390 are out of support: https://nvidia.custhelp.com/app/answers/detail/a_id/3142/~/support-timeframes-for-unix-legacy-gpu-releases. In addition to that 304 and 340 are also completely broken.
2. The nvidia-modeset advice is simply _wrong_.