### PR TITLE
AsciiDoc text replacement: flanking '--' pairs of hyphens with spaces

### DIFF
--- a/documentation/content/en/articles/new-users/_index.adoc
+++ b/documentation/content/en/articles/new-users/_index.adoc
@@ -123,7 +123,7 @@ You can quit `adduser` any time by typing kbd:[Ctrl+C], and at the end you will 
 You might want to create a second new user so that when you edit `jack`'s login files, you will have a hot spare in case something goes wrong.
 
 Once you have done this, use `exit` to get back to a login prompt and log in as `jack`.
-In general, it is a good idea to do as much work as possible as an ordinary user who does not have the power-and risk-of `root`.
+In general, it is a good idea to do as much work as possible as an ordinary user who does not have the power -- and risk -- of `root`.
 
 If you already created a user and you want the user to be able to `su` to `root`, you can log in as `root` and edit the file [.filename]#/etc/group#, adding `jack` to the first line (the group `wheel`).
 But first you need to practice man:vi[1], the text editor-or use the simpler text editor, man:ee[1], installed on recent versions of FreeBSD.

--- a/documentation/content/pt-br/articles/new-users/_index.adoc
+++ b/documentation/content/pt-br/articles/new-users/_index.adoc
@@ -106,7 +106,7 @@ Isso tornará possível efetuar login como `jack` e usar o comando man:su[1] par
 
 Você pode sair do `adduser` a qualquer momento digitando kbd:[Ctrl+C], e no final você terá a chance de aprovar seu novo usuário ou simplesmente digitar kbd:[n] para não criá-lo. Você pode querer criar um segundo novo usuário para que ao editar os arquivos de login do `jack`, você tenha um login de reserva caso algo dê errado.
 
-Depois de fazer isso, use `exit` para voltar a um prompt de login e efetuar login como `jack`. Em geral, é uma boa ideia fazer o máximo possível de trabalho como um usuário comum que não tenha o poder --e o risco-- do usuário `root`.
+Depois de fazer isso, use `exit` para voltar a um prompt de login e efetuar login como `jack`. Em geral, é uma boa ideia fazer o máximo possível de trabalho como um usuário comum que não tenha o poder -- e o risco -- do usuário `root`.
 
 Se você já criou um usuário e deseja que o usuário seja capaz de executar o comando `su` para logar-se como `root`, é possível efetuar login como `root` e editar o arquivo [.filename]#/etc/group#, adicionando `jack` à primeira linha (no grupo `wheel`). Mas primeiro você precisa praticar com o man:vi[1], o editor de texto - ou usar um editor de texto mais simples, como por exemplo, o man:ee[1], instalado em versões recentes do FreeBSD.
 
@@ -123,7 +123,7 @@ Aqui estão descritos alguns comandos e o que eles fazem:
 Diz a você quem você é!
 
 `pwd`::
-Mostra onde você está--quanto ao diretório atual de trabalho.
+Mostra onde você está -- quanto ao diretório atual de trabalho.
 
 `ls`::
 Lista os arquivos presentes no diretório atual.
@@ -132,13 +132,13 @@ Lista os arquivos presentes no diretório atual.
 Lista os arquivos do diretório atual com um `*` depois dos executáveis, um `/` depois dos diretórios, e um `@` depois de links simbólicos.
 
 `ls -l`::
-Lista os arquivos em formatos estendidos--tamanho, data, permissões.
+Lista os arquivos em formatos estendidos -- tamanho, data, permissões.
 
 `ls -a`::
 Lista arquivos "dot" junto com os outros. Se você é `root`, os arquivos com nome iniciando por um "ponto" serão mostradas sem a opção `-a`.
 
 `cd`::
-Altera o diretório atual de trabalho. `cd ..` te leva ao diretório antecessor do atual; note o espaço depois de `cd`. `cd /usr/local` te leva a esse mesmo diretório. `cd ~` te leva ao diretório home do usuário que você está logado--exemplo: [.filename]#/usr/home/jack#. Tente `cd /cdrom`, e depois `ls`, para saber se o CDROM está montado e funcionando.
+Altera o diretório atual de trabalho. `cd ..` te leva ao diretório antecessor do atual; note o espaço depois de `cd`. `cd /usr/local` te leva a esse mesmo diretório. `cd ~` te leva ao diretório home do usuário que você está logado -- exemplo: [.filename]#/usr/home/jack#. Tente `cd /cdrom`, e depois `ls`, para saber se o CDROM está montado e funcionando.
 
 `less _filename_`::
 Te permite ver um arquivo (chamado _filename_) sem alterá-lo. Tente `less /etc/fstab`. Digite `q` para sair.
@@ -151,7 +151,7 @@ Você notará os aliases em [.filename]#.cshrc# para alguns dos comandos `ls`. (
 [[getting-help]]
 == Obtendo ajuda e informações
 
-Aqui estão algumas fontes úteis de ajuda. A palavra _Texto_ deve ser substituída por algo de sua escolha--geralmente um comando ou nome de arquivo.
+Aqui estão algumas fontes úteis de ajuda. A palavra _Texto_ deve ser substituída por algo de sua escolha -- geralmente um comando ou nome de arquivo.
 
 `apropos _texto_`::
 Tudo que contém a palavra _texto_ no `whatis database`.
@@ -171,7 +171,7 @@ Te informa o que o comando _texto_ faz e sua página de manual. Digitando `whati
 `whereis _texto_`::
 Encontra o arquivo _texto_, te informando seu path completo.
 
-Você pode experimentar usar `whatis` em alguns comandos utéis e comuns como `cat`, `more`, `grep`, `mv`, `find`, `tar`, `chmod`, `chown`, `date`, e `script`. `more` te permite ler uma página por vez como no DOS, exemplo: `ls -l | more` ou `more _filename_`. O símbolo * funciona como um caractere curinga--exemplo: `ls w*` mostrará os arquivos que começam com `w`.
+Você pode experimentar usar `whatis` em alguns comandos utéis e comuns como `cat`, `more`, `grep`, `mv`, `find`, `tar`, `chmod`, `chown`, `date`, e `script`. `more` te permite ler uma página por vez como no DOS, exemplo: `ls -l | more` ou `more _filename_`. O símbolo * funciona como um caractere curinga -- exemplo: `ls w*` mostrará os arquivos que começam com `w`.
 
 Alguns deles não estão funcionado muito bem? Ambos man:locate[1] e man:whatis[1] dependem de um banco de dados que é reconstruído semanalmente. Se a sua máquina não for ficar ligada nos fins de semana (e rodando FreeBSD), você pode executar os comandos a seguir para que ela execute manutenções diárias, semanais, mensais ou apenas de vez em quando. Execute-os como `root` e dê a cada comando o tempo necessário para ser finalizado antes de executar o próximo.
 
@@ -187,7 +187,7 @@ output omitted
 
 Se você se cansar de esperar, pressione kbd:[Alt+F2] para obter outro _console virtual_, e efetue seu login novamente. Afinal, é um sistema multi-usuário e multitarefa. No entanto, esses comandos provavelmente irão piscar mensagens na tela enquanto eles estiverem em execução; você pode digitar `clear` no prompt para limpar a tela. Uma vez executados, você pode querer olhar o conteúdo do [.filename]#/var/mail/root# e do [.filename]#/var/log/messages#.
 
-A execução de tais comandos faz parte da administração do sistema--e como usuário único de um sistema UNIX(R), você é seu próprio administrador de rede. Praticamente tudo o que você precisa para ser `root` é administrar o sistema. Tais responsabilidades não são abordadas nem mesmo naqueles livros gigantescos de UNIX(R), os quais parecem dedicar muito espaço para menus e gerenciadores de janelas. Você pode querer obter um dos dois principais livros sobre administração de sistemas, pode ser o Evi Nemeth et.al.'s UNIX System Administration Handbook (Prentice-Hall, 1995, ISBN 0-13-15051-7)--a segunda edição com a capa vermelha; ou o livro Æleen Frisch's Essential System Administration (O'Reilly & Associates, 2002, ISBN 0-596-00343-9). Eu usei Nemeth.
+A execução de tais comandos faz parte da administração do sistema -- e como usuário único de um sistema UNIX(R), você é seu próprio administrador de rede. Praticamente tudo o que você precisa para ser `root` é administrar o sistema. Tais responsabilidades não são abordadas nem mesmo naqueles livros gigantescos de UNIX(R), os quais parecem dedicar muito espaço para menus e gerenciadores de janelas. Você pode querer obter um dos dois principais livros sobre administração de sistemas, pode ser o Evi Nemeth et.al.'s UNIX System Administration Handbook (Prentice-Hall, 1995, ISBN 0-13-15051-7) -- a segunda edição com a capa vermelha; ou o livro Æleen Frisch's Essential System Administration (O'Reilly & Associates, 2002, ISBN 0-596-00343-9). Eu usei Nemeth.
 
 [[editing-text]]
 == Editando textos
@@ -265,7 +265,7 @@ para recarregar a tela
 kbd:[Ctrl+b] and kbd:[Ctrl+f]::
 retrocede e avança uma tela, como fazem com `more` e `view`.
 
-Pratique com o `vi` em seu diretório home criando um novo arquivo com `vi _filename_` e adicionando e excluindo texto, salvando o arquivo, e o chamando novamente. O `vi` oferece algumas surpresas porque ele realmente é muito complexo e, às vezes, você irá executar um comando que fará algo que você não espera. (Algumas pessoas realmente gostam do `vi`-- é mais poderoso que o DOS EDIT -- saiba mais sobre o comando `:r`). Use kbd:[Esc] uma ou mais vezes para ter certeza de que você está no modo de comando e prossiga dali quando ele lhe der problema, salve frequentemente com `:w`, e use `:q!` para sair e começar novamente (do seu último `:w`) quando você precisar.
+Pratique com o `vi` em seu diretório home criando um novo arquivo com `vi _filename_` e adicionando e excluindo texto, salvando o arquivo, e o chamando novamente. O `vi` oferece algumas surpresas porque ele realmente é muito complexo e, às vezes, você irá executar um comando que fará algo que você não espera. (Algumas pessoas realmente gostam do `vi` -- é mais poderoso que o DOS EDIT -- saiba mais sobre o comando `:r`). Use kbd:[Esc] uma ou mais vezes para ter certeza de que você está no modo de comando e prossiga dali quando ele lhe der problema, salve frequentemente com `:w`, e use `:q!` para sair e começar novamente (do seu último `:w`) quando você precisar.
 
 Agora você pode usar o comando `cd` para ir para o [.filename]#/etc#, use o comando `su` para logar como `root`, use o `vi` para editar o arquivo [.filename]#/etc/group#, e adicione um usuário ao grupo `wheel`, assim, o usuário terá privilégios de root. Basta adicionar uma vírgula e o nome do login do usuário ao final da primeira linha do arquivo, pressione kbd:[Esc], e use `:wq` para salvar as alterações no disco e sair. Instantaneamente eficaz. (Você não colocou um espaço após a vírgula, colocou?)
 


### PR DESCRIPTION
## Reference

<https://docs.asciidoctor.org/asciidoc/latest/syntax-quick-reference/#text-replacements> under _AsciiDoc Syntax Quick Reference | Asciidoctor Docs_.

One of the criteria, paraphrased: 

* wherever a pair of hyphens should be automatically replaced by an em dash, the pair may be flanked by spaces.

## Background

The (pt-br) Brazilian Portuguese case was found through running a `ripgrep` command:

```csh
rg '`.* -- .*`' /usr/doc
```

– in connection with: 

* https://github.com/freebsd/freebsd-doc/pull/113

The window to the right in this screenshot: 

![image](https://user-images.githubusercontent.com/192271/220054219-96dbd1fb-85c1-496a-b174-f3bc5c87fe3a.png)