### PR TITLE
handbook/ports: package database: backup, restore

### DIFF
--- a/documentation/content/en/books/handbook/ports/_index.adoc
+++ b/documentation/content/en/books/handbook/ports/_index.adoc
@@ -561,35 +561,31 @@ Marking an installed package as _not_ automatic can be done using:
 ....
 
 [[pkgng-backup]]
-=== Restoring the Package Database
+=== Database Backup and Restoration
 
-Unlike the traditional package management system, pkg includes its own package database backup mechanism.
-This functionality is enabled by default.
+By default, backups are performed daily. 
 
-[TIP]
-====
-To disable the periodic script from backing up the package database, set `daily_backup_pkgdb_enable="NO"` in man:periodic.conf[5].
-====
-
-To restore the contents of a previous package database backup,
-run the following command replacing _/path/to/pkg.sql_ with the location of the backup:
+To restore from the most recent daily backup, using man:xz[1] and man:pkg-shell[8]: 
 
 [source,shell]
 ....
-# pkg backup -r /path/to/pkg.sql
+# xzcat /var/backups/pkg.sql.xz | pkg shell
 ....
 
-[NOTE]
-====
-If restoring a backup taken by the periodic script, it must be decompressed prior to being restored.
-====
+To disable daily backups: set `daily_backup_pkgdb_enable="NO"` in man:periodic.conf[5].
 
-To run a manual backup of the pkg database, run the following command,
-replacing _/path/to/pkg.sql_ with a suitable file name and location:
+To backup manually: run the following command, replacing */path/to/pkg-database-backup.sqlite* with a suitable path and filename. 
 
 [source,shell]
 ....
-# pkg backup -d /path/to/pkg.sql
+# pkg shell .dump > /path/to/pkg-database-backup.sqlite
+....
+
+To restore from a manual backup: run the following command, replacing */path/to/pkg-database-backup.sqlite* with the path and filename. 
+
+[source,shell]
+....
+# cat /path/to/pkg-database-backup.sqlite | pkg shell
 ....
 
 [[pkgng-clean]]


### PR DESCRIPTION
Since pkg-backup(8) was removed in <https://github.com/FreeBSD/freebsd-ports/commit/6723c785931b141a93e35b6136c403cb59434882>, aim to correct and update this subsection of the FreeBSD Handbook.

Related: FreeBSD bug [269810 – ports-mgmt/pkg: how to restore pkg database](https://bugs.freebsd.org/bugzilla/show_bug.cgi?id=269810)