### PR TITLE
Fix Handbook OpenSSH Examples

### DIFF
--- a/documentation/content/en/books/handbook/security/_index.adoc
+++ b/documentation/content/en/books/handbook/security/_index.adoc
@@ -1747,14 +1747,11 @@ The following command tells `ssh` to create a tunnel for telnet:
 
 [source,shell]
 ....
-% ssh -2 -N -f -L 5023:localhost:23 user@foo.example.com
+% ssh -N -f -L 5023:localhost:23 user@foo.example.com
 %
 ....
 
 This example uses the following options:
-
-`-2`::
-Forces `ssh` to use version 2 to connect to the server.
 
 `-N`::
 Indicates no command, or tunnel only.
@@ -1782,7 +1779,7 @@ This method can be used to wrap any number of insecure TCP protocols such as SMT
 
 [source,shell]
 ....
-% ssh -2 -N -f -L 5025:localhost:25 user@mailserver.example.com
+% ssh -N -f -L 5025:localhost:25 user@mailserver.example.com
 user@mailserver.example.com's password: *****
 % telnet localhost 5025
 Trying 127.0.0.1...
@@ -1803,7 +1800,7 @@ To check email in a secure manner, create an SSH connection to the SSH server an
 
 [source,shell]
 ....
-% ssh -2 -N -f -L 2110:mail.example.com:110 user@ssh-server.example.com
+% ssh -N -f -L 2110:mail.example.com:110 user@ssh-server.example.com
 user@ssh-server.example.com's password: ******
 ....
 
@@ -1822,7 +1819,7 @@ The solution is to create an SSH connection to a machine outside of the network'
 
 [source,shell]
 ....
-% ssh -2 -N -f -L 8888:music.example.com:8000 user@unfirewalled-system.example.org
+% ssh -N -f -L 8888:music.example.com:8000 user@unfirewalled-system.example.org
 user@unfirewalled-system.example.org's password: *******
 ....
 


### PR DESCRIPTION
The Handbook contains some obsolete and unnecessary uses of SSH.  These two commits fix them.