### PR TITLE
GitHub Actions: Add a labeler action

### DIFF
--- a/.github/conf/label-pull-requests.yml
+++ b/.github/conf/label-pull-requests.yml
@@ -1,0 +1,2 @@
+status report:
+- website/content/en/status/**

--- a/.github/workflows/label-pull-requests.yml
+++ b/.github/workflows/label-pull-requests.yml
@@ -1,0 +1,15 @@
+name: "Label pull requests"
+on: [pull_request_target]
+
+jobs:
+
+  label-pull-requests:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
+    steps:
+    - uses: actions/labeler@v4
+      with:
+        repo-token: "${{ secrets.GITHUB_TOKEN }}"
+        configuration-path: ".github/conf/label-pull-requests.yml"


### PR DESCRIPTION
Use the following GitHub action to automatically label pull requests based on the paths of the modified files:
https://github.com/marketplace/actions/labeler

Use it to label pull requests introducing new status reports with the 'status report' label.

---

I have tested the action in my fork. You can see the results at the following links:
https://github.com/lsalvadore/freebsd-doc/pull/1
https://github.com/lsalvadore/freebsd-doc/pull/2
https://github.com/lsalvadore/freebsd-doc/pull/3
https://github.com/lsalvadore/freebsd-doc/actions