### PR TITLE
Update _index.adoc

### DIFF
--- a/website/content/ja/copyright/_index.adoc
+++ b/website/content/ja/copyright/_index.adoc
@@ -15,8 +15,6 @@ sidenav: about
 
 == link:daemon[BSD デーモン]
 
-== https://cgit.FreeBSD.org/ports/plain/LEGAL[FreeBSD Ports を再配布する際の制限]
-
 == link:https://www.FreeBSD.org/copyright/COPYING[GNU GENERAL PUBLIC LICENSE]
 
 == link:https://www.FreeBSD.org/copyright/COPYING.LIB[GNU LIBRARY GENERAL PUBLIC LICENSE]


### PR DESCRIPTION
per https://bugs.freebsd.org/bugzilla/show_bug.cgi?id=270229, removing invalid link for now until a replacement is in place