### PR TITLE
developers-handbook: ipv6: Use ping -6 instead of ping6

### DIFF
--- a/documentation/content/en/books/developers-handbook/ipv6/_index.adoc
+++ b/documentation/content/en/books/developers-handbook/ipv6/_index.adoc
@@ -220,7 +220,7 @@ Programs that use these APIs have to be prepared about differences in kernels an
 
 When you specify scoped address to the command line, NEVER write the embedded form (such as ff02:1::1 or fe80:2::fedc).
 This is not supposed to work.
-Always use standard form, like ff02::1 or fe80::fedc, with command line option for specifying interface (like `ping6 -I ne0 ff02::1`).
+Always use standard form, like ff02::1 or fe80::fedc, with command line option for specifying interface (like `ping -6 -I ne0 ff02::1`).
 In general, if a command does not have command line option to specify outgoing interface, that command is not ready to accept scoped address.
 This may seem to be opposite from IPv6's premise to support "dentist office" situation.
 We believe that specifications need some improvements for this.
@@ -380,13 +380,13 @@ If you want to try jumbo payloads, you first have to reconfigure the kernel so t
 
 and recompile the new kernel.
 
-Then you can test jumbo payloads by the man:ping6[8] command with -b and -s options.
+Then you can test jumbo payloads by the man:ping[8] command with -6, -b and -s options.
 The -b option must be specified to enlarge the size of the socket buffer and the -s option specifies the length of the packet, which should be more than 65,535.
 For example, type as follows:
 
 [source,bash]
 ....
-% ping6 -b 70000 -s 68000 ::1
+% ping -6 -b 70000 -s 68000 ::1
 ....
 
 The IPv6 specification requires that the Jumbo Payload option must not be used in a packet that carries a fragment header.


### PR DESCRIPTION
Although the command `ping6` is still supported, its man page has been disconnected from the build.

Replace occurrences of `ping6` with `ping -6`.