### PR TITLE
Release notes: reduce duplication and verbosity

### DIFF
--- a/website/content/en/releases/13.2R/relnotes.adoc
+++ b/website/content/en/releases/13.2R/relnotes.adoc
@@ -31,10 +31,11 @@ This document contains the release notes for FreeBSD {releaseCurrent}.
 It describes recently added, changed, or deleted features of FreeBSD.
 It also provides some notes on upgrading from previous versions of FreeBSD.
 
-The {releaseType} distribution to which these release notes apply represents the latest point along the {releaseBranch} development branch since {releaseBranch} was created.
-Information regarding pre-built, binary {releaseType} distributions along this branch can be found at https://www.FreeBSD.org/releases/[].
+The {releaseType} distribution to which these notes apply represents: 
 
-The {releaseType} distribution to which these release notes apply represents a point along the {releaseBranch} development branch between {releasePrev} and the future {releaseNext}.
+* the latest point along the {releaseBranch} development branch since {releaseBranch} was created
+* a point along the {releaseBranch} development branch between {releasePrev} and the future {releaseNext}.
+
 Information regarding pre-built, binary {releaseType} distributions along this branch can be found at https://www.FreeBSD.org/releases/[].
 
 This distribution of FreeBSD {releaseCurrent} is a {releaseType} distribution.


### PR DESCRIPTION
With some existing duplication: it becomes difficult to tell, at a glance, the reason for duplication.

Make the generic parts of the notes more concise, and easier to digest. 