### PR TITLE
status: 2023q1: core: clarity, consistency

### DIFF
--- a/website/content/en/status/report-2023-01-2023-03/core.adoc
+++ b/website/content/en/status/report-2023-01-2023-03/core.adoc
@@ -6,14 +6,14 @@ The FreeBSD Core Team is the governing body of FreeBSD.
 
 ==== Items
 
-===== Core Team Charter
+===== Core Team Charter: Draft
 
-At the first Core Team meeting of the new year, the Core Team delegation that was in Boulder, US in December presented the conclusions of the meeting to the entire Core Team.
-The Core Team will continue to discuss the issues and work together with the FreeBSD Foundation.
+At the first Core Team meeting of 2023, Team delegates from the December 2022 meeting in Boulder, US presented the delegation's conclusions to the entire Team.
+The Team will continue to discuss the issues and work together with the FreeBSD Foundation.
 
 ===== FreeBSD annual developers survey
 
-The FreeBSD Core Team together with the FreeBSD Foundation have decided that the FreeBSD Foundation will be in charge of conducting the annual developers survey.
+The Core Team together with the FreeBSD Foundation have decided that the FreeBSD Foundation will be in charge of conducting the annual developers survey.
 
 ===== Matrix IM solution
 
@@ -23,4 +23,4 @@ An instance has already been prepared and tests are underway.
 ==== Commit bits
 
 * Core approved the src commit bit for Cheng Cui (cc@)
-* Core approved the restore of the source commit bit for Joseph Koshy (jkoshy@).
+* Core approved the restore of the src commit bit for Joseph Koshy (jkoshy@).


### PR DESCRIPTION
Respond to <https://lists.freebsd.org/archives/dev-commits-doc-all/2023-March/001806.html> from @ceri. 

Whilst here: 

* first and third items use the phrase Core Team, the second item might reasonably do the same

* where the fourth item uses shorter phrases Core, src and source, source can be shortened to src.