### PR TITLE
events2023: BSDCan: add FreeBSD Developer Summit

### DIFF
--- a/website/data/en/events/events2023.toml
+++ b/website/data/en/events/events2023.toml
@@ -43,7 +43,7 @@ countryCode = "CA"
 country = "Canada"
 city = "Ottawa"
 site = "University of Ottawa"
-description = "A four day BSD conference held in Ottawa, Canada. BSDCan hosts talks and tutorials on a range of topics based around the BSD family of operating systems."
+description = "<a href=\"https://wiki.freebsd.org/DevSummit/202305\">This year's FreeBSD Developer Summit</a> will be held in Ottawa, Canada, during the first two days of BSDCan. BSDCan hosts talks and tutorials on a range of topics based around the BSD family of operating systems."
 
 [[events]]
 id = "eurobsdcon-2023"


### PR DESCRIPTION
Expand the BSDCan entry; include a link to the FreeBSD wiki page for the colocated FreeBSD Developer Summit.

Affects: <https://www.freebsd.org/events/#bsdcan-2023>.

Reviewers here may include @bsdjhb, who drew the attention of `developers@` to the recently added page. 