### PR TITLE
handbook: Add GitHub as another source for src pull requests

### DIFF
--- a/documentation/content/en/books/handbook/mirrors/_index.adoc
+++ b/documentation/content/en/books/handbook/mirrors/_index.adoc
@@ -378,7 +378,7 @@ For information about write access to repositories see the extref:{committers-gu
 
 Those mirrors are not hosted in FreeBSD.org but still maintained by the project members.
 Users and developers are welcome to pull or browse repositories on those mirrors.
-Pull requests for the `doc` GitHub repository are being accepted; otherwise, the project workflow with those mirrors is still under discussion.
+Pull requests for the `doc` and `src` GitHub repositories are being accepted; otherwise, the project workflow with those mirrors is still under discussion.
 
 Codeberg::
   - doc: https://codeberg.org/FreeBSD/freebsd-doc


### PR DESCRIPTION
As mentioned in CONTRIBUTING.md, GitHub is also another source for src pull requests.