### PR TITLE
administration/: Core Team: mention the Secretary

### DIFF
--- a/website/content/en/administration.adoc
+++ b/website/content/en/administration.adoc
@@ -68,6 +68,8 @@ The Core Team is elected by the active developers in the project.
 * {tcberner} (Clusteradm Liaison)
 * {0mp} (Bugmeister Team Liaison)
 
+Core Team Secretary: please link:#t-core-secretary[see below].
+
 [[t-doceng]]
 == FreeBSD Documentation Engineering Team <doceng@FreeBSD.org>
 


### PR DESCRIPTION
<https://www.freebsd.org/administration/#t-doceng> and <https://www.freebsd.org/administration/#t-portmgr> both mention a Secretary. 

<https://www.freebsd.org/administration/#t-core> does not mention the Core Team Secretary. 

Add a mention, refer to <https://www.freebsd.org/administration/#t-core-secretary>.

----

@sergio-carlavilla to review, thanks. 