### PR TITLE
internal/about: update URLs for providers

### DIFF
--- a/website/content/en/internal/about.adoc
+++ b/website/content/en/internal/about.adoc
@@ -15,18 +15,18 @@ image:../../gifs/powerlogo.gif[Powered by FreeBSD]
 Naturally, all systems in the FreeBSD.org cluster run FreeBSD. The hardware and network connection have been generously provided by:
 
 * https://www.bytemark.co.uk/[Bytemark Hosting]
-* https://www.bbtower.co.jp[Cloud and SDN Laboratory at BroadBand Tower, Inc]
-* https://www.cs.nycu.edu.tw[Department of Computer Science, National Yang Ming Chiao Tung University]
-* https://metal.equinix.com[Equinix]
+* Cloud and SDN Laboratory at https://www.bbtower.co.jp/en/corporate/[BroadBand Tower, Inc]
+* https://www.cs.nycu.edu.tw/[Department of Computer Science, National Yang Ming Chiao Tung University]
+* https://metal.equinix.com/[Equinix]
 * https://internet.asn.au/[Internet Association of Australia]
 * https://www.isc.org/[Internet Systems Consortium]
-* https://www.inx.net.za[INX-ZA]
-* https://www.kddi-webcommunications.co.jp/[KDDI Web Communications Inc]
-* https://myren.net.my[Malaysian Research & Education Network]
-* https://www.metapeer.com[MetaPeer]
+* https://www.inx.net.za/[INX-ZA]
+* https://www.kddi-webcommunications.co.jp/english/[KDDI Web Communications Inc]
+* https://www.mohe.gov.my/en/services/research/myren[Malaysian Research & Education Network]
+* https://www.metapeer.com/[MetaPeer]
 * https://www.nyi.net/[New York Internet]
-* https://nic.br[Nic.br]
-* https://your.org[Your.org]
+* https://nic.br/[NIC.br]
+* https://your.org/[Your.Org]
 
 and other link:../../donations/donors[contributors] to the FreeBSD project.
 

--- a/website/content/en/internal/about.adoc
+++ b/website/content/en/internal/about.adoc
@@ -17,7 +17,7 @@ Naturally, all systems in the FreeBSD.org cluster run FreeBSD. The hardware and 
 * https://www.bytemark.co.uk/[Bytemark Hosting]
 * Cloud and SDN Laboratory at https://www.bbtower.co.jp/en/corporate/[BroadBand Tower, Inc]
 * https://www.cs.nycu.edu.tw/[Department of Computer Science, National Yang Ming Chiao Tung University]
-* https://metal.equinix.com/[Equinix]
+* https://deploy.equinix.com/[Equinix]
 * https://internet.asn.au/[Internet Association of Australia]
 * https://www.isc.org/[Internet Systems Consortium]
 * https://www.inx.net.za/[INX-ZA]


### PR DESCRIPTION
<https://github.com/freebsd/freebsd-doc/pull/155>, for a status report, corrected use of uppercase for NIC.br and for Your.Org. 

<https://github.com/freebsd/freebsd-doc/pull/156>, for the same report, found a working alternative to a page that is no longer reachable; and English alternatives for two Japanese pages. 

