### PR TITLE
status: 2023q1: Foundation: last, this …

### DIFF
--- a/website/content/en/status/report-2023-01-2023-03/freebsd-foundation.adoc
+++ b/website/content/en/status/report-2023-01-2023-03/freebsd-foundation.adoc
@@ -30,7 +30,7 @@ When we received our first million dollar donation, the plan was to use up to 10
 
 The 2023 budget is in the process of being approved by the board of directors and will be published once it is approved.
 
-Last quarter we received donations from Juniper, Tarsnap, Microsoft, and Stormshield.
+This quarter we received donations from Juniper, Tarsnap, Microsoft, and Stormshield.
 So, we are already off to a great start!
 But, we definitely need more to support our planned efforts for 2023.
 
@@ -81,7 +81,7 @@ We support the non-FreeBSD events to promote and raise awareness of FreeBSD, to 
 We are back to attending events mostly in person and began planning the in person May 2023 Developer Summit, co-located with BSDCan.
 In addition to attending and planning events, we are continually working on new training initiatives and updating our selection of link:https://freebsdfoundation.org/freebsd-project/resources/[how-to guides] to facilitate getting more folks to try out FreeBSD.
 
-Check out some of the advocacy and education work we did last quarter:
+Check out some of our advocacy and education work:
 
 * Hosted a stand at FOSDEM 2023, February 4-5, 2023 in Brussels, Belgium.  Check out the link:https://freebsdfoundation.org/blog/fosdem-2023-conference-report/[trip report].
 * Hosted a table at State of Open Con 2023, February, 7-8, 2023, in London, England.  link:https://freebsdfoundation.org/blog/advocating-for-freebsd-around-the-world/[Read more] about it.


### PR DESCRIPTION
Consider the last report, entitled _FreeBSD Status Report Fourth Quarter 2022_. 

Expect this overall report to fall under a main heading (and HTML page title): 

> # FreeBSD Status Report First Quarter 2023

In this context – this report for this (first) quarter – the _last_ quarter is 2022q4 (that's what I thought when reviewing <https://reviews.freebsd.org/D39461>). 

jrm @Jehops clarified at <https://reviews.freebsd.org/D39461#898412>.  

Reduce ambiguity here. 

_During the first quarter of 2023, …_ is already non-ambiguous. 

Where _Last quarter_ is changed to _This quarter_, it's clear enough because it's in the midst of paragraphs that are solely about 2023.