### PR TITLE
releases: Fix OpenSSH version

### DIFF
--- a/website/content/en/releases/13.2R/announce.adoc
+++ b/website/content/en/releases/13.2R/announce.adoc
@@ -21,7 +21,7 @@ The FreeBSD Release Engineering Team is pleased to announce the availability of 
 
 Some of the highlights:
 
-* OpenSSH has been updated to version 9.2p1.
+* OpenSSH has been updated to version 9.3p1.
 * OpenSSL has been updated to version 1.1.1t.
 * The bhyve hypervisor now supports more than 16 vCPUs in a guest.
 * Address Space Layout Randomization (ASLR) is now enabled for 64-bit executables by default.

--- a/website/content/en/releases/13.2R/announce.asc
+++ b/website/content/en/releases/13.2R/announce.asc
@@ -11,7 +11,7 @@ Hash: SHA1
 
    Some of the highlights:
 
-     * OpenSSH has been updated to version 9.2p1.
+     * OpenSSH has been updated to version 9.3p1.
 
      * OpenSSL has been updated to version 1.1.1t.
 

--- a/website/content/en/releases/13.2R/relnotes.adoc
+++ b/website/content/en/releases/13.2R/relnotes.adoc
@@ -194,7 +194,7 @@ Supported `LLVM` sanitizers are now enabled on `powerpc64` and variants.
 
 `mandoc` has been upgraded to version 1.14.6.
 
-`OpenSSH` has been upgraded to version 9.2p1.
+`OpenSSH` has been upgraded to version 9.3p1.
 
 `OpenSSL` has been upgraded to version 1.1.1t.
 


### PR DESCRIPTION
Commit https://github.com/freebsd/freebsd-src/commit/43ad40718af1a94abc2fb3fb932b08a91a56f291 updated to OpenSSH 9.3p1.