### PR TITLE
releases: Fix tzdata version

### DIFF
--- a/website/content/en/releases/13.2R/relnotes.adoc
+++ b/website/content/en/releases/13.2R/relnotes.adoc
@@ -205,7 +205,7 @@ gitref:68e86d5265bc[repository=src]
 
 `tzcode` has been upgraded to version 2022g with improved timezone change detection and reliability fixes.
 
-`tzdata` has been upgraded to version 2023b.
+`tzdata` has been upgraded to version 2023c.
 
 `unbound` has been upgraded to version 1.17.1.
 


### PR DESCRIPTION
Commit https://github.com/freebsd/freebsd-src/commit/57472c9a30abce230797fcf1e9435fb603d7425e updated to tzdata 2023c.