### PR TITLE
status: 2023q1: portmgr: corrections, suggestions

### DIFF
--- a/website/content/en/status/report-2023-01-2023-03/portmgr.adoc
+++ b/website/content/en/status/report-2023-01-2023-03/portmgr.adoc
@@ -11,10 +11,10 @@ Contact: René Ladan <portmgr-secretary@FreeBSD.org> +
 Contact: FreeBSD Ports Management Team <portmgr@FreeBSD.org>
 
 The Ports Management Team is responsible for overseeing the overall direction of the Ports Tree, building packages (through its subsidiary pkgmgr), and personnel matters.
-Below is what happened in the last quarter.
+Below is what happened in this quarter.
 
 Currently we have around 33,500 ports in the tree.
-For these ports, there are 3,021 open PRs of which 764 are unassigned.
+For these ports, there are 3,021 open problem reports, of which 764 are unassigned.
 The first three months of this year saw 9,021 commits by 163 committers for the `main` branch and 701 commits by 55 committers for the `2023Q1` branch.
 Compared to 2022Q4, this means a slight increase in the number of ports, port PRs, ports commits, and active port committers.
 
@@ -22,14 +22,16 @@ During the last quarter, we welcomed Robert Clausecker (fuz@), Vladimir Druzenko
 Portgmr added Muhammad Moinur Rahman (bofh@) as a new member after a successful lurkership.
 
 During the bi-weekly portmgr meetings, the following topics were discussed:
-* improving the situation of binary packages for kernel modules
-* ways to measure the impact of ports on its dependencies and how to maintain high-impact ports
 
-During the last quarter, 32 exp-runs were run to test port updates, updating default versions (LLVM to 15, MySQL to 8.0, Ruby to 3.1), and updating byacc in base.
+* improving the situation of binary packages for kernel modules
+* ways to measure the impact of ports on their dependencies and how to maintain high-impact ports.
+
+During this quarter, 32 exp-runs were run to test port updates, updating default versions (LLVM to 15, MySQL to 8.0, Ruby to 3.1), and updating byacc in base.
 Furthermore, the default version of Go switched to 1.20 and that of Lazarus to 2.2.6.
 
 Four new USES were introduced:
-* budgie to support ports related to the Budgie Desktop
-* ldap to provide support for OpenLDAP, with a new default version of 26 (i.e. 2.6)
-* nextcloud to support Nextcloud applications
-* ruby to provide support for Ruby ports (formerly bsd.ruby.mk)
+
+* `budgie` to support ports related to the Budgie Desktop
+* `ldap` to provide support for OpenLDAP, with a new default version of 26 (i.e. 2.6)
+* `nextcloud` to support Nextcloud applications
+* `ruby` to provide support for Ruby ports (formerly `bsd.ruby.mk`).

--- a/website/content/en/status/report-2023-01-2023-03/portmgr.adoc
+++ b/website/content/en/status/report-2023-01-2023-03/portmgr.adoc
@@ -16,7 +16,7 @@ Below is what happened in this quarter.
 Currently we have around 33,500 ports in the tree.
 For these ports, there are 3,021 open problem reports, of which 764 are unassigned.
 The first three months of this year saw 9,021 commits by 163 committers for the `main` branch and 701 commits by 55 committers for the `2023Q1` branch.
-Compared to 2022Q4, this means a slight increase in the number of ports, port PRs, ports commits, and active port committers.
+Compared to `2022Q4`, this means a slight increase in the number of ports, port PRs, ports commits, and active port committers.
 
 During the last quarter, we welcomed Robert Clausecker (fuz@), Vladimir Druzenko (vvd@), Robert Nagy (rnagy@), welcomed back Norikatsu Shigemura (nork@), and said goodbye to Marius Strobl (marius@).
 Portgmr added Muhammad Moinur Rahman (bofh@) as a new member after a successful lurkership.

--- a/website/content/en/status/report-2023-01-2023-03/portmgr.adoc
+++ b/website/content/en/status/report-2023-01-2023-03/portmgr.adoc
@@ -18,7 +18,7 @@ For these ports, there are 3,021 open problem reports, of which 764 are unassign
 The first three months of this year saw 9,021 commits by 163 committers for the `main` branch and 701 commits by 55 committers for the `2023Q1` branch.
 Compared to `2022Q4`, this means a slight increase in the number of ports, port PRs, ports commits, and active port committers.
 
-During the last quarter, we welcomed Robert Clausecker (fuz@), Vladimir Druzenko (vvd@), Robert Nagy (rnagy@), welcomed back Norikatsu Shigemura (nork@), and said goodbye to Marius Strobl (marius@).
+During this quarter, we welcomed Robert Clausecker (fuz@), Vladimir Druzenko (vvd@), Robert Nagy (rnagy@), welcomed back Norikatsu Shigemura (nork@), and said goodbye to Marius Strobl (marius@).
 Portgmr added Muhammad Moinur Rahman (bofh@) as a new member after a successful lurkership.
 
 During the bi-weekly portmgr meetings, the following topics were discussed:


### PR DESCRIPTION
Fix both lists. 

The phrase 'ports on its dependencies' sounds wrong, I assume that it should be 'ports on their dependencies'. 

As noted in another recent PR, 'last quarter' is ambiguous; easily misinterpreted as 2022q4, which is not the subject of this (first) quarter's report. 

Character formatting for the four new USES, and bsd.ruby.mk.

Full stops for the final list item, where the first is preceded by a sentence with a colon.