### PR TITLE
[.filename]#⋯#" superfluous quotation marks

### DIFF
--- a/documentation/content/en/books/fdp-primer/writing-style/_index.adoc
+++ b/documentation/content/en/books/fdp-primer/writing-style/_index.adoc
@@ -72,7 +72,7 @@ Avoid Latin terms like "i.e.," or "cf.", which may be unknown outside of academi
 
 Write in a formal style.
 Avoid addressing the reader as "you".
-For example, say "copy the file to [.filename]#/tmp#" rather than "you can copy the file to [.filename]#/tmp#".
+For example, say "copy the file to [.filename]#/tmp# rather than "you can copy the file to [.filename]#/tmp#.
 
 Give clear, correct, _tested_ examples.
 A trivial example is better than no example.
@@ -305,7 +305,7 @@ The following table describes the current rule names and respective severity.
 
 . BrandTerms: Like The FreeBSD Project every major vendors and Companies have specific rules on writing their Brand Name. according to the Copyright rules of The FreeBSD Foundation *freebsd* should be written as *FreeBSD*.
 Similar to that care should be taken to be respective to other's brand value and write PostgreSQL, Node.js, Let's Encrypt etc.
-Missing brand names should be added to the [.filename]#.vale/styles/FreeBSD/BrandTerms.yml#" in the `doc` repository.
+Missing brand names should be added to the [.filename]#.vale/styles/FreeBSD/BrandTerms.yml# in the `doc` repository.
 
 . Contractions: Contracted words should not be used. This rule avoids all contractions and suggests full words.
 
@@ -317,7 +317,7 @@ This rule finds repeated words and warns the users.
 
 . Weasel: This rule handles avoiding weasel words.
 The uses of weasel words is controversial so at the moment the list of words are being evaluated and the severity level is marked as warning on.
-In case a frequently used word is marked as weasel word it should be removed from [.filename]#.vale/styles/FreeBSD/Weasel.yml#" in the `doc` repository.
+In case a frequently used word is marked as weasel word it should be removed from [.filename]#.vale/styles/FreeBSD/Weasel.yml# in the `doc` repository.
 
 . ConsciousLanguage: This rule proposes uses of conscious languages like avoiding the words white/black/master/slave.
 
@@ -330,7 +330,7 @@ In case a frequently used word is marked as weasel word it should be removed fro
 . Spelling: At the moment there is a mix of en_US and en_UK spellings in the documentation and website.
 A custom dictionary from link:https://wordlist.aspell.net[Aspell] has been added which uses strictly en_US and do not accept the en_UK variant of any words.
 It has also an exception list to ignore the FreeBSD specific terms.
-At the moment the list is a basic one with minimal words just as a proof of concept but if any word is found to be correct and not available in the dictionary the word should be added to the [.filename]#.vale/styles/FreeBSD/spelling-exceptions.txt#" in the `doc` repository.
+At the moment the list is a basic one with minimal words just as a proof of concept but if any word is found to be correct and not available in the dictionary the word should be added to the [.filename]#.vale/styles/FreeBSD/spelling-exceptions.txt# in the `doc` repository.
 
 More rules will be introduced in the upcoming days when and where required.
 
@@ -348,7 +348,7 @@ $ pkg install vale
 [[writing-style-using-vale-commandline]]
 ==== Using Vale in command line
 
-Considering the fact that `doc` repository was cloned into [.filename]#~/doc#" the following commands are required to run:
+Considering the fact that `doc` repository was cloned into [.filename]#~/doc# the following commands are required to run:
 
 [source, shell]
 ....

--- a/documentation/content/en/books/fdp-primer/writing-style/_index.adoc
+++ b/documentation/content/en/books/fdp-primer/writing-style/_index.adoc
@@ -72,7 +72,7 @@ Avoid Latin terms like "i.e.," or "cf.", which may be unknown outside of academi
 
 Write in a formal style.
 Avoid addressing the reader as "you".
-For example, say "copy the file to [.filename]#/tmp# rather than "you can copy the file to [.filename]#/tmp#.
+For example, say "copy the file to [.filename]#/tmp#" rather than "you can copy the file to [.filename]#/tmp#".
 
 Give clear, correct, _tested_ examples.
 A trivial example is better than no example.

--- a/documentation/content/pt-br/books/fdp-primer/writing-style/_index.adoc
+++ b/documentation/content/pt-br/books/fdp-primer/writing-style/_index.adoc
@@ -261,7 +261,7 @@ A tabela a seguir descreve os nomes das regras atuais e a respectiva severidade.
 [[writing-style-linting-vale-rules]]
 === Current Vale Rules
 
-. BrandTerms: Como o Projeto FreeBSD, todos os principais fornecedores e empresas têm regras específicas para escrever seu nome de marca. de acordo com as regras de Copyright da Fundação FreeBSD, *freebsd* deve ser escrito como *FreeBSD*. Da mesma forma, deve-se tomar cuidado para respeitar a escrita da marca de outros e escrever PostgreSQL, Node.js, Let's Encrypt, etc. Nomes de marcas ausentes devem ser adicionados ao [.filename]#.vale/styles/FreeBSD/BrandTerms.yml# " no repositório `doc`.
+. BrandTerms: Como o Projeto FreeBSD, todos os principais fornecedores e empresas têm regras específicas para escrever seu nome de marca. de acordo com as regras de Copyright da Fundação FreeBSD, *freebsd* deve ser escrito como *FreeBSD*. Da mesma forma, deve-se tomar cuidado para respeitar a escrita da marca de outros e escrever PostgreSQL, Node.js, Let's Encrypt, etc. Nomes de marcas ausentes devem ser adicionados ao [.filename]#.vale/styles/FreeBSD/BrandTerms.yml# no repositório `doc`.
 
 . Contractions: Palavras contraídas não devem ser usadas. Esta regra evita todas as contrações e sugere palavras completas.
 
@@ -269,7 +269,7 @@ A tabela a seguir descreve os nomes das regras atuais e a respectiva severidade.
 
 . Repetition: Muitas vezes, as mesmas palavras são digitadas duas vezes ao sair do teclado e voltar ao trabalho novamente. Esta regra encontra palavras repetidas e avisa os usuários.
 
-. Weasel: Esta regra trata de evitar palavras de coloquiais. O uso de palavras coloquiais é controverso, então no momento a lista de palavras está sendo avaliada e o nível de gravidade está marcado como warning. No caso de uma palavra usada ser marcada com frequência como palavra coloquial, ela deve ser removida de [.filename]#.vale/styles/FreeBSD/Weasel.yml#" no repositório `doc`.
+. Weasel: Esta regra trata de evitar palavras de coloquiais. O uso de palavras coloquiais é controverso, então no momento a lista de palavras está sendo avaliada e o nível de gravidade está marcado como warning. No caso de uma palavra usada ser marcada com frequência como palavra coloquial, ela deve ser removida de [.filename]#.vale/styles/FreeBSD/Weasel.yml# no repositório `doc`.
 
 . ConsciousLanguage: Esta regra propõe usos de linguagens conscientes como evitar as palavras white/black/master/slave - branco/negro/mestre/escravo.
 
@@ -296,7 +296,7 @@ $ pkg install vale
 [[writing-style-using-vale-commandline]]
 ==== Usando o Vale na linha de comando
 
-Considerando o fato de que o repositório `doc` foi clonado em [.filename]#~/doc#" os seguintes comandos são necessários para executar:
+Considerando o fato de que o repositório `doc` foi clonado em [.filename]#~/doc# os seguintes comandos são necessários para executar:
 
 [source, shell]
 ....


### PR DESCRIPTION
Remove superfluous quotation marks from rendered phrases such as: 

> … **.vale/styles/FreeBSD/BrandTerms.yml**" …

– under <https://docs.freebsd.org/en/books/fdp-primer/writing-style/#writing-style-linting-vale-rules>. 