### PR TITLE
shared/en/mailing-lists.adoc: improvements

### DIFF
--- a/shared/en/mailing-lists.adoc
+++ b/shared/en/mailing-lists.adoc
@@ -7,11 +7,11 @@
 :mailing-lists-url: https://lists.freebsd.org
 :mailing-lists: {mailing-lists-url}[{mailing-lists-desc}]
 
-:freebsd-accessibility-desc: FreeBSD accessibility discussions
+:freebsd-accessibility-desc: FreeBSD accessibility mailing list
 :freebsd-accessibility-url: https://lists.FreeBSD.org/subscription/freebsd-accessibility
 :freebsd-accessibility: {freebsd-accessibility-url}[{freebsd-accessibility-desc}]
 
-:freebsd-acpi-desc: FreeBSD ACPI mailing list
+:freebsd-acpi-desc: FreeBSD ACPI and power management development mailing list
 :freebsd-acpi-url: https://lists.FreeBSD.org/subscription/freebsd-acpi
 :freebsd-acpi: {freebsd-acpi-url}[{freebsd-acpi-desc}]
 
@@ -23,7 +23,7 @@
 :freebsd-aic7xxx-url: https://lists.FreeBSD.org/subscription/aic7xxx
 :freebsd-aic7xxx: {freebsd-aic7xxx-url}[{freebsd-aic7xxx-desc}]
 
-:freebsd-amd64-desc: Porting FreeBSD to AMD64 systems
+:freebsd-amd64-desc: Porting FreeBSD to AMD64 systems mailing list
 :freebsd-amd64-url: https://lists.FreeBSD.org/subscription/freebsd-amd64
 :freebsd-amd64: {freebsd-amd64-url}[{freebsd-amd64-desc}]
 
@@ -63,11 +63,11 @@
 :freebsd-chat-url: https://lists.FreeBSD.org/subscription/freebsd-chat
 :freebsd-chat: {freebsd-chat-url}[{freebsd-chat-desc}]
 
-:freebsd-chromium-desc: FreeBSD-specific Chromium issues
+:freebsd-chromium-desc: FreeBSD-specific Chromium issues mailing list
 :freebsd-chromium-url: https://lists.FreeBSD.org/subscription/freebsd-chromium
 :freebsd-chromium: {freebsd-chromium-url}[{freebsd-chromium-desc}]
 
-:freebsd-cloud-desc: FreeBSD on cloud platforms (EC2, GCE, Azure, etc.)
+:freebsd-cloud-desc: FreeBSD on cloud platforms (EC2, GCE, Azure, etc.) mailing list
 :freebsd-cloud-url: https://lists.FreeBSD.org/subscription/freebsd-cloud
 :freebsd-cloud: {freebsd-cloud-url}[{freebsd-cloud-desc}]
 
@@ -79,7 +79,7 @@
 :freebsd-current-url: https://lists.FreeBSD.org/subscription/freebsd-current
 :freebsd-current: {freebsd-current-url}[{freebsd-current-desc}]
 
-:ctm-announce-desc: CTM announcements
+:ctm-announce-desc: CTM announcements mailing list
 :ctm-announce-url: https://lists.FreeBSD.org/subscription/ctm-announce
 :ctm-announce: {ctm-announce-url}[{ctm-announce-desc}]
 
@@ -91,7 +91,7 @@
 :freebsd-database-url: https://lists.FreeBSD.org/subscription/freebsd-database
 :freebsd-database: {freebsd-database-url}[{freebsd-database-desc}]
 
-:freebsd-desktop-desc: Using and improving FreeBSD on the desktop
+:freebsd-desktop-desc: Using and improving FreeBSD on the desktop mailing list
 :freebsd-desktop-url: https://lists.FreeBSD.org/subscription/freebsd-desktop
 :freebsd-desktop: {freebsd-desktop-url}[{freebsd-desktop-desc}]
 
@@ -135,15 +135,15 @@
 :freebsd-doc-url: https://lists.FreeBSD.org/subscription/freebsd-doc
 :freebsd-doc: {freebsd-doc-url}[{freebsd-doc-desc}]
 
-:freebsd-drivers-desc: Writing device drivers for FreeBSD
+:freebsd-drivers-desc: Writing device drivers for FreeBSD mailing list
 :freebsd-drivers-url: https://lists.FreeBSD.org/subscription/freebsd-drivers
 :freebsd-drivers: {freebsd-drivers-url}[{freebsd-drivers-desc}]
 
-:freebsd-dtrace-desc: Using and working on DTrace in FreeBSD
+:freebsd-dtrace-desc: Using and working on DTrace in FreeBSD mailing list
 :freebsd-dtrace-url: https://lists.FreeBSD.org/subscription/freebsd-dtrace
 :freebsd-dtrace: {freebsd-dtrace-url}[{freebsd-dtrace-desc}]
 
-:freebsd-eclipse-desc: FreeBSD users of Eclipse IDE, tools, rich client applications and ports
+:freebsd-eclipse-desc: FreeBSD users of Eclipse IDE, tools, rich client applications and ports mailing list
 :freebsd-eclipse-url: https://lists.FreeBSD.org/subscription/freebsd-eclipse
 :freebsd-eclipse: {freebsd-eclipse-url}[{freebsd-eclipse-desc}]
 
@@ -195,7 +195,7 @@
 :freebsd-geom-url: https://lists.FreeBSD.org/subscription/freebsd-geom
 :freebsd-geom: {freebsd-geom-url}[{freebsd-geom-desc}]
 
-:freebsd-git-desc: Discussion of git use in the FreeBSD project
+:freebsd-git-desc: FreeBSD Project use of Git mailing list
 :freebsd-git-url: https://lists.FreeBSD.org/subscription/freebsd-git
 :freebsd-git: {freebsd-git-url}[{freebsd-git-desc}]
 
@@ -203,7 +203,7 @@
 :freebsd-gnome-url: https://lists.FreeBSD.org/subscription/freebsd-gnome
 :freebsd-gnome: {freebsd-gnome-url}[{freebsd-gnome-desc}]
 
-:freebsd-hackers-desc: FreeBSD technical discussions mailing list
+:freebsd-hackers-desc: FreeBSD technical mailing list
 :freebsd-hackers-url: https://lists.FreeBSD.org/subscription/freebsd-hackers
 :freebsd-hackers: {freebsd-hackers-url}[{freebsd-hackers-desc}]
 
@@ -211,11 +211,11 @@
 :freebsd-hardware-url: https://lists.FreeBSD.org/subscription/freebsd-hardware
 :freebsd-hardware: {freebsd-hardware-url}[{freebsd-hardware-desc}]
 
-:freebsd-haskell-desc: FreeBSD-specific Haskell issues and discussions
+:freebsd-haskell-desc: FreeBSD-specific Haskell issues mailing list
 :freebsd-haskell-url: https://lists.FreeBSD.org/subscription/freebsd-haskell
 :freebsd-haskell: {freebsd-haskell-url}[{freebsd-haskell-desc}]
 
-:freebsd-hubs-desc: FreeBSD mirror sites mailing lists
+:freebsd-hubs-desc: FreeBSD mirror sites mailing list
 :freebsd-hubs-url: https://lists.FreeBSD.org/subscription/freebsd-hubs
 :freebsd-hubs: {freebsd-hubs-url}[{freebsd-hubs-desc}]
 
@@ -227,7 +227,7 @@
 :freebsd-i386-url: https://lists.FreeBSD.org/subscription/freebsd-i386
 :freebsd-i386: {freebsd-i386-url}[{freebsd-i386-desc}]
 
-:freebsd-infiniband-desc: Infiniband on FreeBSD
+:freebsd-infiniband-desc: Infiniband on FreeBSD mailing list
 :freebsd-infiniband-url: https://lists.FreeBSD.org/subscription/freebsd-infiniband
 :freebsd-infiniband: {freebsd-infiniband-url}[{freebsd-infiniband-desc}]
 
@@ -267,11 +267,11 @@
 :freebsd-mips-url: https://lists.FreeBSD.org/subscription/freebsd-mips
 :freebsd-mips: {freebsd-mips-url}[{freebsd-mips-desc}]
 
-:mirror-announce-desc: FreeBSD mirror site administrators
+:mirror-announce-desc: FreeBSD mirror site administrators mailing list
 :mirror-announce-url: https://lists.FreeBSD.org/subscription/mirror-announce
 :mirror-announce: {mirror-announce-url}[{mirror-announce-desc}]
 
-:freebsd-mono-desc: Mono and C# applications on FreeBSD
+:freebsd-mono-desc: Mono and C# applications on FreeBSD mailing list
 :freebsd-mono-url: https://lists.FreeBSD.org/subscription/freebsd-mono
 :freebsd-mono: {freebsd-mono-url}[{freebsd-mono-desc}]
 
@@ -291,19 +291,19 @@
 :freebsd-new-bus-url: https://lists.FreeBSD.org/subscription/freebsd-new-bus
 :freebsd-new-bus: {freebsd-new-bus-url}[{freebsd-new-bus-desc}]
 
-:freebsd-numerics-desc: Discussions of high quality implementation of libm functions
+:freebsd-numerics-desc: High quality implementation of libm functions mailing list
 :freebsd-numerics-url: https://lists.FreeBSD.org/subscription/freebsd-numerics
 :freebsd-numerics: {freebsd-numerics-url}[{freebsd-numerics-desc}]
 
-:freebsd-ocaml-desc: FreeBSD-specific OCaml discussions
+:freebsd-ocaml-desc: FreeBSD-specific OCaml mailing list
 :freebsd-ocaml-url: https://lists.FreeBSD.org/subscription/freebsd-ocaml
 :freebsd-ocaml: {freebsd-ocaml-url}[{freebsd-ocaml-desc}]
 
-:freebsd-office-desc: Office applications on FreeBSD
+:freebsd-office-desc: Office applications on FreeBSD mailing list
 :freebsd-office-url: https://lists.FreeBSD.org/subscription/freebsd-office
 :freebsd-office: {freebsd-office-url}[{freebsd-office-desc}]
 
-:freebsd-ops-announce-desc: Project Infrastructure Announcements
+:freebsd-ops-announce-desc: Project infrastructure announcements mailing list
 :freebsd-ops-announce-url: https://lists.FreeBSD.org/subscription/freebsd-ops-announce
 :freebsd-ops-announce: {freebsd-ops-announce-url}[{freebsd-ops-announce-desc}]
 
@@ -319,7 +319,7 @@
 :freebsd-pf-url: https://lists.FreeBSD.org/subscription/freebsd-pf
 :freebsd-pf: {freebsd-pf-url}[{freebsd-pf-desc}]
 
-:freebsd-pkg-desc: Binary package management and package tools discussion
+:freebsd-pkg-desc: Binary package management and package tools mailing list
 :freebsd-pkg-url: https://lists.FreeBSD.org/subscription/freebsd-pkg
 :freebsd-pkg: {freebsd-pkg-url}[{freebsd-pkg-desc}]
 
@@ -327,7 +327,7 @@
 :freebsd-pkg-fallout-url: https://lists.FreeBSD.org/subscription/freebsd-pkg-fallout
 :freebsd-pkg-fallout: {freebsd-pkg-fallout-url}[{freebsd-pkg-fallout-desc}]
 
-:freebsd-pkgbase-desc: Packaging the FreeBSD base system
+:freebsd-pkgbase-desc: Packaging the FreeBSD base system mailing list
 :freebsd-pkgbase-url: https://lists.FreeBSD.org/subscription/freebsd-pkgbase
 :freebsd-pkgbase: {freebsd-pkgbase-url}[{freebsd-pkgbase-desc}]
 
@@ -351,7 +351,7 @@
 :freebsd-ppc-url: https://lists.FreeBSD.org/subscription/freebsd-ppc
 :freebsd-ppc: {freebsd-ppc-url}[{freebsd-ppc-desc}]
 
-:freebsd-proliant-desc: Technical discussion of FreeBSD on HP ProLiant server platforms
+:freebsd-proliant-desc: FreeBSD on HP ProLiant server platforms technical mailing list
 :freebsd-proliant-url: https://lists.FreeBSD.org/subscription/freebsd-proliant
 :freebsd-proliant: {freebsd-proliant-url}[{freebsd-proliant-desc}]
 
@@ -359,7 +359,7 @@
 :freebsd-python-url: https://lists.FreeBSD.org/subscription/freebsd-python
 :freebsd-python: {freebsd-python-url}[{freebsd-python-desc}]
 
-:freebsd-quarterly-calls-desc: Calls for quarterly FreeBSD status reports
+:freebsd-quarterly-calls-desc: Calls for quarterly FreeBSD status reports mailing list
 :freebsd-quarterly-calls-url: https://lists.FreeBSD.org/subscription/freebsd-quarterly-calls
 :freebsd-quarterly-calls: {freebsd-quarterly-calls-url}[{freebsd-quarterly-calls-desc}]
 
@@ -395,7 +395,7 @@
 :freebsd-security-notifications-url: https://lists.FreeBSD.org/subscription/freebsd-security-notifications
 :freebsd-security-notifications: {freebsd-security-notifications-url}[{freebsd-security-notifications-desc}]
 
-:freebsd-snapshots-desc: FreeBSD Development Snapshot Announcements
+:freebsd-snapshots-desc: FreeBSD development snapshot announcements mailing list
 :freebsd-snapshots-url: https://lists.FreeBSD.org/subscription/freebsd-snapshots
 :freebsd-snapshots: {freebsd-snapshots-url}[{freebsd-snapshots-desc}]
 
@@ -515,7 +515,7 @@
 :freebsd-sysinstall-url: https://lists.FreeBSD.org/subscription/freebsd-sysinstall
 :freebsd-sysinstall: {freebsd-sysinstall-url}[{freebsd-sysinstall-desc}]
 
-:freebsd-tcltk-desc: FreeBSD-specific Tcl/Tk discussions
+:freebsd-tcltk-desc: FreeBSD-specific Tcl/Tk mailing list
 :freebsd-tcltk-url: https://lists.FreeBSD.org/subscription/freebsd-tcltk
 :freebsd-tcltk: {freebsd-tcltk-url}[{freebsd-tcltk-desc}]
 
@@ -527,11 +527,11 @@
 :freebsd-test-url: https://lists.FreeBSD.org/subscription/freebsd-test
 :freebsd-test: {freebsd-test-url}[{freebsd-test-desc}]
 
-:freebsd-testing-desc: Testing on FreeBSD
+:freebsd-testing-desc: Testing on FreeBSD mailing list
 :freebsd-testing-url: https://lists.FreeBSD.org/subscription/freebsd-testing
 :freebsd-testing: {freebsd-testing-url}[{freebsd-testing-desc}]
 
-:freebsd-tex-desc: Porting TeX and its applications to FreeBSD
+:freebsd-tex-desc: Porting TeX and its applications to FreeBSD mailing list
 :freebsd-tex-url: https://lists.FreeBSD.org/subscription/freebsd-tex
 :freebsd-tex: {freebsd-tex-url}[{freebsd-tex-desc}]
 
@@ -567,23 +567,23 @@
 :freebsd-vendors-url: https://lists.FreeBSD.org/subscription/freebsd-vendors
 :freebsd-vendors: {freebsd-vendors-url}[{freebsd-vendors-desc}]
 
-:freebsd-virtualization-desc: Discussion of various virtualization techniques supported by FreeBSD
+:freebsd-virtualization-desc: Virtualization techniques supported by FreeBSD mailing list
 :freebsd-virtualization-url: https://lists.FreeBSD.org/subscription/freebsd-virtualization
 :freebsd-virtualization: {freebsd-virtualization-url}[{freebsd-virtualization-desc}]
 
-:freebsd-vuxml-desc: Discussion on the VuXML infrastructure
+:freebsd-vuxml-desc: VuXML infrastructure mailing list
 :freebsd-vuxml-url: https://lists.FreeBSD.org/subscription/freebsd-vuxml
 :freebsd-vuxml: {freebsd-vuxml-url}[{freebsd-vuxml-desc}]
 
-:freebsd-wip-status-desc: FreeBSD Work-In-Progress Status
+:freebsd-wip-status-desc: FreeBSD work-in-progress status mailing list
 :freebsd-wip-status-url: https://lists.FreeBSD.org/subscription/freebsd-wip-status
 :freebsd-wip-status: {freebsd-wip-status-url}[{freebsd-wip-status-desc}]
 
-:freebsd-wireless-desc: Discussions of 802.11 stack, tools, device driver development
+:freebsd-wireless-desc: 802.11 stack, tools and device driver development mailing list
 :freebsd-wireless-url: https://lists.FreeBSD.org/subscription/freebsd-wireless
 :freebsd-wireless: {freebsd-wireless-url}[{freebsd-wireless-desc}]
 
-:freebsd-women-desc: FreeBSD advocacy for women
+:freebsd-women-desc: FreeBSD advocacy for women mailing list
 :freebsd-women-url: https://lists.FreeBSD.org/subscription/freebsd-women
 :freebsd-women: {freebsd-women-url}[{freebsd-women-desc}]
 
@@ -616,19 +616,19 @@
 :developers-name: FreeBSD developers mailing list
 :developers: {committers-developers}
 
-:doc-committers-name: FreeBSD doc/ committer's mailing list
+:doc-committers-name: FreeBSD doc/ committers mailing list
 :doc-committers: {doc-committers-name}
 
 :doc-developers-name: FreeBSD doc/ developers mailing list
 :doc-developers: {doc-developers-name}
 
-:ports-committers-name: FreeBSD ports/ committer's mailing list
+:ports-committers-name: FreeBSD ports/ committers mailing list
 :ports-committers: {ports-committers-name}
 
 :ports-developers-name: FreeBSD ports/ developers mailing list
 :ports-developers: {ports-developers-name}
 
-:src-committers-name: FreeBSD src/ committer's mailing list
+:src-committers-name: FreeBSD src/ committers mailing list
 :src-committers: {src-committers-name}
 
 :src-developers-name: FreeBSD src/ developers mailing list
@@ -649,7 +649,7 @@
 :freebsd-alpha-url: https://lists.FreeBSD.org/subscription/freebsd-alpha
 :freebsd-alpha: {freebsd-alpha-url}[{freebsd-alpha-desc}]
 
-:freebsd-qa-desc: FreeBSD Quality Assurance mailing list
+:freebsd-qa-desc: FreeBSD quality assurance mailing list
 :freebsd-qa-url: https://lists.FreeBSD.org/subscription/freebsd-qa
 :freebsd-qa: {freebsd-qa-url}[{freebsd-qa-desc}]
 


### PR DESCRIPTION
Consistency, and more.

The need for this became apparent whilst drafting https://github.com/freebsd/freebsd-doc/commit/e63798df73d7d956d8c3ce3f81225421fdd1db23 … there remains a mismatch between: 

* 'the FreeBSD ACPI mailing list' at <https://docs.freebsd.org/en/books/handbook/config/#ACPI-submitdebug> and elsewhere
* the broader, true name 'ACPI and power management development' at <https://lists.freebsd.org/archives/freebsd-acpi/>. 