### PR TITLE
articles/hubs: looking for official mirrors

### DIFF
--- a/documentation/content/en/articles/hubs/_index.adoc
+++ b/documentation/content/en/articles/hubs/_index.adoc
@@ -56,7 +56,7 @@ toc::[]
 
 [NOTE]
 ====
-We are not accepting new mirrors at this time.
+We are not accepting new community mirrors at this time.
 ====
 
 [[mirror-contact]]
@@ -402,7 +402,8 @@ If Mirror1 does not update for a while, lower tier mirrors will begin to mirror 
 [[mirror-official-become]]
 === How to Become Official Then?
 
-We are not accepting any new mirrors at this time.
+Please contact the Cluster Administrators as documented at
+https://www.FreeBSD.org/administration/#t-clusteradm.
 
 [[mirror-statpages]]
 == Some Statistics from Mirror Sites


### PR DESCRIPTION
Hi there, I have been told the FreeBSD project is now looking for official mirrors (as opposed to community mirrors).
I figured I would update the documentation to that effect. About the exact procedure, ISTM that e-mailing `clusteradm@` is the way to go.