### PR TITLE
A small note about rc.conf and kld_list

### DIFF
--- a/documentation/content/en/books/handbook/x11/_index.adoc
+++ b/documentation/content/en/books/handbook/x11/_index.adoc
@@ -218,6 +218,11 @@ To install the package execute the following command:
 ....
 ====
 
+[TIP]
+====
+If you're unfamiliar with the `/etc/rc.conf` file and the `kld_list` option, then checkout the link:https://man.freebsd.org/cgi/man.cgi?rc.conf[`rc.conf`] manpage and search for `kld_list`. Given the importance of this flag, it's important you make yourself familiar with its format in case you need to load multiple kernel modules in the future.
+====
+
 [[x-configuration-amd]]
 === AMD(R)
 


### PR DESCRIPTION
I believe this small note could be beneficial. It introduces the reader to the potentially new idea of man pages, and it helps them appreciate that kld_list has a particular format and can actually be used to load multiple kernel modules.

See the #community channel on Discord @ 2030 AEST for an example of a potential failure on our part to explain this correctly (at a time when it could be important.)