### PR TITLE
Community and Support menus and content: update

### DIFF
--- a/website/content/en/community/_index.adoc
+++ b/website/content/en/community/_index.adoc
@@ -7,31 +7,31 @@ include::shared/en/urls.adoc[]
 
 = Community
 
-FreeBSD's community is diverse and extensive, and can be found everywhere great conversations and activity takes place.
+FreeBSD's community is diverse and extensive, and can be found everywhere that great conversations and activity takes place.
 You'll find our community and spaces intelligent, welcoming and approachable.
 
-The project maintains several official community spaces where developers, contributors and users can find help and support, stay up to date, coordinate and collaborate or just kick back, relax and socialise.
+The Project maintains official community spaces where developers, contributors and users can find help and support, stay up to date, coordinate and collaborate, or just kick back, relax and socialise.
 
-If you prefer asynchronous and long-lived communications channels, FreeBSD offers over one hundred https://lists.freebsd.org[mailing lists] covering a vast range of topics, and provides web-based https://forums.freebsd.org/[forums] and several Usenet link:{handbook}eresources/#eresources-news[newsgroups].
+If you prefer asynchronous and long-lived communication, we have https://lists.freebsd.org[more than one hundred mailing lists], a https://forums.freebsd.org/[forum], and Usenet link:{handbook}eresources/#eresources-news[newsgroups].
 
-For more real-time collaboration, we have a number of https://wiki.freebsd.org/IRC/[FreeBSD IRC channels] and an instance on https://wiki.freebsd.org/Discord[Discord] where you can find support, learn to contribute, watch live streams and a whole lot more.
+For real-time collaboration, we have https://wiki.freebsd.org/IRC/[IRC channels] and a https://wiki.freebsd.org/Discord[Discord instance] where you can find support, learn to contribute, watch live streams, and a whole lot more.
 
-If you are interested in professional development and networking opportunities then follow us on https://www.linkedin.com/company/freebsd/[LinkedIn] and join our official https://www.linkedin.com/groups/47628[FreeBSD LinkedIn Group].
+If you are interested in professional development and networking opportunities with LinkedIn, see our https://www.linkedin.com/company/freebsd/[company] and https://www.linkedin.com/groups/47628[group] pages.
 
-For regularly run in-person and online meets, you might like to look into our https://www.freebsd.org/events[FreeBSD Events] where we maintain a feed and calendar of upcoming events.
-Last year there were {{< get-event-last-year-info "events" >}} events around the world.
+For in-person and online meets, see our https://www.freebsd.org/events[Events] page.
+Last year there were {{< get-event-last-year-info "events" >}} events worldwide.
 ////
 Last year there were {{< get-event-last-year-info "events" >}} events in {{< get-event-last-year-info "countries" >}} different countries around the world.
 ////
 
-On twitter, you can follow https://twitter.com/freebsd[@freebsd], https://twitter.com/freebsdhelp[@freebsdhelp], or https://twitter.com/freebsdcore[@freebsdcore].
+On Twitter, you can follow https://twitter.com/freebsd[@freebsd], https://twitter.com/freebsdhelp[@freebsdhelp], and https://twitter.com/freebsdcore[@freebsdcore].
 
-On Reddit, you can find the FreeBSD community link:https://www.reddit.com/r/freebsd/[here].
+The https://www.youtube.com/FreeBSDProject[FreeBSD channel] on YouTube includes developer summits and "office hours" events. The  https://www.youtube.com/bsdconferences[BSD Conferences] channel includes presentations from technical conferences.
 
-Beyond officially run community spaces, there are https://www.freebsd.org/usergroups/[User Groups] in {{< get-usergroups-info "countries" >}} countries, along with highly active FreeBSD communities on https://twitter.com/search?q=freebsd[Twitter], https://stackoverflow.com/questions/tagged/freebsd[StackOverflow], https://serverfault.com/questions/tagged/freebsd[ServerFault], and https://www.meetup.com/topics/freebsd/[MeetUp.com], among many other technology-related spaces.
+The https://wiki.freebsd.org/[FreeBSD wiki] includes information about development and related projects.
 
-The https://wiki.freebsd.org/[FreeBSD wiki] contains information about development and related projects.
+Non-official spaces include: 
 
-== Video Content
-
-On YouTube, we host an official link:https://www.youtube.com/FreeBSDProject[FreeBSD] channel with developer summits and "office hours" events, and a link:https://www.youtube.com/bsdconferences[BSD Conferences] channel with full taped presentations from FreeBSD technical conferences.
+* https://www.freebsd.org/usergroups/[User Groups] in {{< get-usergroups-info "countries" >}} countries
+* https://www.reddit.com/r/freebsd/[/r/freebsd] in Reddit
+* https://www.meetup.com/topics/freebsd/[FreeBSD groups in MeetUp].

--- a/website/content/en/support/webresources.adoc
+++ b/website/content/en/support/webresources.adoc
@@ -12,10 +12,11 @@ sidenav: support
 [[general]]
 == General UNIX(R) Information
 
-* https://distrowatch.com/table.php?distribution=freebsd[FreeBSD Distrowatch page]
-* https://www.freebsdnews.com/[FreeBSD News]
+* `freebsd` tagged in https://unix.stackexchange.com/questions/tagged/freebsd[Unix & Linux Stack Exchange], https://serverfault.com/questions/tagged/freebsd[Server Fault] and https://stackoverflow.com/questions/tagged/freebsd[Stack Overflow]
 * https://www.bsdnow.tv/[BSD Now podcasts]
-* https://www.oreilly.com/[O'Reilly Media, Inc.]
+* https://github.com/DiscoverBSD/awesome-bsd#readme[DiscoverBSD/awesome-bsd] -- a collection of awesome BSD related stuff
+* https://distrowatch.com/table.php?distribution=freebsd[DistroWatch.com: FreeBSD]
+* UNIX-related content at https://www.oreilly.com/[O'Reilly(R)]
 
 [[xwin]]
 == The X Window System

--- a/website/themes/beastie/i18n/en.toml
+++ b/website/themes/beastie/i18n/en.toml
@@ -112,9 +112,6 @@ other = "Events"
 [FreeBSDJournal]
 other = "FreeBSD Journal"
 
-[QA]
-other = "Q&A (external)"
-
 [developers]
 other = "Developers"
 


### PR DESCRIPTION
Bugs <https://bugs.freebsd.org/261258> and <https://bugs.freebsd.org/260968>, respectively: 

> Q&A Link on home page points to wrong web site

> Support: Web resources (page update)