### PR TITLE
doc: Fix a typo (add a missing period)

### DIFF
--- a/documentation/content/en/articles/explaining-bsd/_index.adoc
+++ b/documentation/content/en/articles/explaining-bsd/_index.adoc
@@ -151,7 +151,7 @@ They are divided into three kinds:
 It is at the individual committer's discretion whether they should obtain authority before committing changes to the source tree.
 In general, an experienced committer may make changes which are obviously correct without obtaining consensus.
 For example, a documentation project committer may correct typographical or grammatical errors without review.
-On the other hand, developers making far-reaching or complicated changes are expected to submit their changes for review before committing them
+On the other hand, developers making far-reaching or complicated changes are expected to submit their changes for review before committing them.
 In extreme cases, a core team member with a function such as Principal Architect may order that changes be removed from the tree, a process known as _backing out_.
 All committers receive mail describing each individual commit, so it is not possible to commit secretly.
 * The _Core team_. FreeBSD and NetBSD each have a core team which manages the project. The core teams developed in the course of the projects, and their role is not always well-defined. It is not necessary to be a developer to be a core team member, though it is normal. The rules for the core team vary from one project to the other, but in general they have more say in the direction of the project than non-core team members have.


### PR DESCRIPTION
A section on [*Explaining BSD*](https://docs.freebsd.org/en/articles/explaining-bsd/#_how_is_bsd_developed_and_updated) (`... before committing them In extreme cases, a core team member ...`) is missing a period. This commit just adds that period.