### PR TITLE
status: 2023q2: memory compaction: fixes, grammar

### DIFF
--- a/website/content/en/status/report-2023-04-2023-06/compaction.adoc
+++ b/website/content/en/status/report-2023-04-2023-06/compaction.adoc
@@ -2,15 +2,15 @@
 
 Links: +
 link:https://wiki.freebsd.org/SummerOfCode2023Projects/PhysicalMemoryAntiFragmentationMechanisms[GSoC project wiki page] URL: link:https://wiki.freebsd.org/SummerOfCode2023Projects/PhysicalMemoryAntiFragmentationMechanisms[] +
-link:https://reviews.freebsd.org/D40575[Differential revision 40575] URL: link:https://reviews.freebsd.org/D40575[]
-link:https://reviews.freebsd.org/D40772[Differential revision 407725] URL: link:https://reviews.freebsd.org/D407724[]
+link:https://reviews.freebsd.org/D40575[Differential revision 40575] URL: link:https://reviews.freebsd.org/D40575[] +
+link:https://reviews.freebsd.org/D40772[Differential revision 40772] URL: link:https://reviews.freebsd.org/D40772[]
 
 Contact: Bojan Novković <bnovkov@FreeBSD.org>
 
-Most modern CPU architectures offer performance boosts by supporting pages that are larger than the standard page size. 
+Most modern CPU architectures offer performance boosts by supporting pages that are larger than the standard page size.
 Unfortunately, allocating such pages can fail due to a high degree of physical memory fragmentation.
 This work implements physical memory compaction as a means of actively reducing fragmentation in running systems.
-This work is part of an ongoing Google Summer of Code project whose goal is to add various physical memory anti-fragmentation measures to the virtual memory subsystem.
+This work is part of an ongoing Google Summer of Code project, the goal of which is to add various physical memory anti-fragmentation measures to the virtual memory subsystem.
 
 Differential link:https://reviews.freebsd.org/D40575[D40575] implements a well-known metric used for quantifying the degree of physical memory fragmentation.
 Differential link:https://reviews.freebsd.org/D40772[D40772] implements physical memory compaction and adds a daemon that monitors the system and performs compaction when needed.


### PR DESCRIPTION
Add a missing line break.

<https://reviews.freebsd.org/D407724> and <https://reviews.freebsd.org/D407725> are non-existent. 

For a non-person, use something other than 'whose'.