### PR TITLE
Release errata errata (punctuation) and markup

### DIFF
--- a/website/content/en/releases/13.0R/errata.adoc
+++ b/website/content/en/releases/13.0R/errata.adoc
@@ -11,7 +11,9 @@ sidenav: download
 
 == Abstract
 
-This document lists errata items for FreeBSD {release}, containing significant information discovered after the release or too late in the release cycle to be otherwise included in the release documentation. This information includes security advisories, as well as news relating to the software or documentation that could affect its operation or usability. An up-to-date version of this document should always be consulted before installing this version of FreeBSD.
+This document lists errata items for FreeBSD {release}, containing significant information discovered after the release or too late in the release cycle to be otherwise included in the release documentation.
+This information includes security advisories, as well as news relating to the software or documentation that could affect its operation or usability.
+An up-to-date version of this document should always be consulted before installing this version of FreeBSD.
 
 This errata document for FreeBSD {release} will be maintained until the release of FreeBSD {releaseNext}.
 
@@ -26,9 +28,11 @@ This errata document for FreeBSD {release} will be maintained until the release 
 [[intro]]
 == Introduction
 
-This errata document contains "late-breaking news" about FreeBSD {release} Before installing this version, it is important to consult this document to learn about any post-release discoveries or problems that may already have been found and fixed.
+This errata document contains "late-breaking news" about FreeBSD {release}.
+Before installing this version, it is important to consult this document to learn about any post-release discoveries or problems that may already have been found and fixed.
 
-Any version of this errata document actually distributed with the release (for example, on a CDROM distribution) will be out of date by definition, but other copies are kept updated on the Internet and should be consulted as the "current errata" for this release. These other copies of the errata are located at https://www.FreeBSD.org/releases/, plus any sites which keep up-to-date mirrors of this location.
+Any version of this errata document actually distributed with the release (for example, on a CDROM distribution) will be out of date by definition, but other copies are kept updated on the Internet and should be consulted as the "current errata" for this release.
+These other copies of the errata are located at https://www.FreeBSD.org/releases/, plus any sites which keep up-to-date mirrors of this location.
 
 Source and binary snapshots of FreeBSD {releaseBranch} also contain up-to-date copies of this document (as of the time of the snapshot).
 

--- a/website/content/en/releases/13.1R/errata.adoc
+++ b/website/content/en/releases/13.1R/errata.adoc
@@ -11,7 +11,9 @@ sidenav: download
 
 == Abstract
 
-This document lists errata items for FreeBSD {release}, containing significant information discovered after the release or too late in the release cycle to be otherwise included in the release documentation. This information includes security advisories, as well as news relating to the software or documentation that could affect its operation or usability. An up-to-date version of this document should always be consulted before installing this version of FreeBSD.
+This document lists errata items for FreeBSD {release}, containing significant information discovered after the release or too late in the release cycle to be otherwise included in the release documentation.
+This information includes security advisories, as well as news relating to the software or documentation that could affect its operation or usability.
+An up-to-date version of this document should always be consulted before installing this version of FreeBSD.
 
 This errata document for FreeBSD {release} will be maintained until the release of FreeBSD {releaseNext}.
 
@@ -26,9 +28,11 @@ This errata document for FreeBSD {release} will be maintained until the release 
 [[intro]]
 == Introduction
 
-This errata document contains "late-breaking news" about FreeBSD {release} Before installing this version, it is important to consult this document to learn about any post-release discoveries or problems that may already have been found and fixed.
+This errata document contains "late-breaking news" about FreeBSD {release}.
+Before installing this version, it is important to consult this document to learn about any post-release discoveries or problems that may already have been found and fixed.
 
-Any version of this errata document actually distributed with the release (for example, on a CDROM distribution) will be out of date by definition, but other copies are kept updated on the Internet and should be consulted as the "current errata" for this release. These other copies of the errata are located at https://www.FreeBSD.org/releases/, plus any sites which keep up-to-date mirrors of this location.
+Any version of this errata document actually distributed with the release (for example, on a CDROM distribution) will be out of date by definition, but other copies are kept updated on the Internet and should be consulted as the "current errata" for this release.
+These other copies of the errata are located at https://www.FreeBSD.org/releases/, plus any sites which keep up-to-date mirrors of this location.
 
 Source and binary snapshots of FreeBSD {releaseBranch} also contain up-to-date copies of this document (as of the time of the snapshot).
 

--- a/website/content/en/releases/13.2R/errata.adoc
+++ b/website/content/en/releases/13.2R/errata.adoc
@@ -11,7 +11,9 @@ sidenav: download
 
 == Abstract
 
-This document lists errata items for FreeBSD {release}, containing significant information discovered after the release or too late in the release cycle to be otherwise included in the release documentation. This information includes security advisories, as well as news relating to the software or documentation that could affect its operation or usability. An up-to-date version of this document should always be consulted before installing this version of FreeBSD.
+This document lists errata items for FreeBSD {release}, containing significant information discovered after the release or too late in the release cycle to be otherwise included in the release documentation.
+This information includes security advisories, as well as news relating to the software or documentation that could affect its operation or usability.
+An up-to-date version of this document should always be consulted before installing this version of FreeBSD.
 
 This errata document for FreeBSD {release} will be maintained until the release of FreeBSD {releaseNext}.
 
@@ -26,9 +28,11 @@ This errata document for FreeBSD {release} will be maintained until the release 
 [[intro]]
 == Introduction
 
-This errata document contains "late-breaking news" about FreeBSD {release} Before installing this version, it is important to consult this document to learn about any post-release discoveries or problems that may already have been found and fixed.
+This errata document contains "late-breaking news" about FreeBSD {release}.
+Before installing this version, it is important to consult this document to learn about any post-release discoveries or problems that may already have been found and fixed.
 
-Any version of this errata document actually distributed with the release (for example, on a CDROM distribution) will be out of date by definition, but other copies are kept updated on the Internet and should be consulted as the "current errata" for this release. These other copies of the errata are located at https://www.FreeBSD.org/releases/, plus any sites which keep up-to-date mirrors of this location.
+Any version of this errata document actually distributed with the release (for example, on a CDROM distribution) will be out of date by definition, but other copies are kept updated on the Internet and should be consulted as the "current errata" for this release.
+These other copies of the errata are located at https://www.FreeBSD.org/releases/, plus any sites which keep up-to-date mirrors of this location.
 
 Source and binary snapshots of FreeBSD {releaseBranch} also contain up-to-date copies of this document (as of the time of the snapshot).
 


### PR DESCRIPTION
Add a missing full stop to the first paragraph of the introduction. 

Markup: line breaks.