### PR TITLE
Fixing typo in _index.adoc

### DIFF
--- a/documentation/content/en/books/handbook/ports/_index.adoc
+++ b/documentation/content/en/books/handbook/ports/_index.adoc
@@ -107,7 +107,7 @@ To keep track of updated ports, subscribe to the {freebsd-ports} and the {freebs
 ====
 Before installing an application, check https://vuxml.freebsd.org/[] for security issues related to the application.
 
-To check for known vulnerabilities of installed applications use use `pkg audit -F`.
+To check for known vulnerabilities of installed applications use `pkg audit -F`.
 ====
 
 The remainder of this chapter explains how to use packages and ports to install and manage third-party software on FreeBSD.


### PR DESCRIPTION
Typo fix in _index.adoc. Duplicated words were used and one has been removed.