### PR TITLE
add a 2023q2 report for pkgbase.live

### DIFF
--- a/website/content/en/status/report-2023-04-2023-06/pkgbase.live.adoc
+++ b/website/content/en/status/report-2023-04-2023-06/pkgbase.live.adoc
@@ -29,7 +29,7 @@ You may notice that RISCv64 is gone for now.
 The hardware is a powerful VPS in Vultr.
 The server and the jails running build jobs and serving packages are "self-hosting", meaning they were installed and are kept up-to-date with PkgBase.
 
-Because we haven't figured out yet how to configure Vultr's IPv6 in FreeBSD jails, PkgBase.live is not available over IPv6 for now.
+Because we have not figured out yet how to configure Vultr's IPv6 in FreeBSD jails, PkgBase.live is not available over IPv6 for now.
 If you have experience with that, please contact us!
 
 Along with users and testers, we still link:https://alpha.pkgbase.live/howto/howdo.html[highly encourage copy-cats].

--- a/website/content/en/status/report-2023-04-2023-06/pkgbase.live.adoc
+++ b/website/content/en/status/report-2023-04-2023-06/pkgbase.live.adoc
@@ -1,7 +1,7 @@
 === PkgBase.live
 
 Links: +
-link:https://alpha.pkgbase.live/[Website (archive.org)] URL: link:https://alpha.pkgbase.live/[] +
+link:https://alpha.pkgbase.live/[Website] URL: link:https://alpha.pkgbase.live/[] +
 link:https://codeberg.org/pkgbase[Source] URL: link:https://codeberg.org/pkgbase[]
 
 Contact: Mina Galić <freebsd@igalic.co>

--- a/website/content/en/status/report-2023-04-2023-06/pkgbase.live.adoc
+++ b/website/content/en/status/report-2023-04-2023-06/pkgbase.live.adoc
@@ -9,7 +9,7 @@ Contact: Mina Galić <freebsd@igalic.co>
 PkgBase.live, an unofficial repository for the FreeBSD link:https://wiki.freebsd.org/PkgBase[PkgBase project], is back alive.
 
 As a service, PkgBase.live was inspired by link:https://up.bsd.lv/[], which provided man:freebsd-update[8] for STABLE and CURRENT branches.
-up.bsd.live itself has gone on hiatus, so it was all the more reason to bring PkgBase.live back.
+up.bsd.live itself has gone on hiatus, so it was all the more reason to bring back PkgBase.live.
 
 Right now, we provide builds for:
 

--- a/website/content/en/status/report-2023-04-2023-06/pkgbase.live.adoc
+++ b/website/content/en/status/report-2023-04-2023-06/pkgbase.live.adoc
@@ -1,0 +1,37 @@
+=== PkgBase.live
+
+Links: +
+link:https://alpha.pkgbase.live/[Website (archive.org)] URL: link:https://alpha.pkgbase.live/[] +
+link:https://codeberg.org/pkgbase[Source] URL: link:https://codeberg.org/pkgbase[]
+
+Contact: Mina Galić <freebsd@igalic.co>
+
+PkgBase.live, an unofficial repository for the FreeBSD link:https://wiki.freebsd.org/PkgBase[PkgBase project], is back alive.
+
+As a service, PkgBase.live was inspired by link:https://up.bsd.lv/[], which provided man:freebsd-update[8] for STABLE and CURRENT branches.
+up.bsd.live itself has gone on hiatus, so it was all the more reason to bring PkgBase.live back.
+
+Right now, we provide builds for:
+
+- FreeBSD 13.2-RELEASE
+- FreeBSD 13-STABLE
+- FreeBSD 14-CURRENT
+
+each for the following platforms:
+
+- amd64
+- aarch64
+- armv7
+- i386
+
+You may notice that RISCv64 is gone for now.
+
+The hardware is a powerful VPS in Vultr.
+The server and the jails running build jobs and serving packages are "self-hosting", meaning they were installed and are kept up-to-date with PkgBase.
+
+Because we haven't figured out yet how to configure Vultr's IPv6 in FreeBSD jails, PkgBase.live is not available over IPv6 for now.
+If you have experience with that, please contact us!
+
+Along with users and testers, we still link:https://alpha.pkgbase.live/howto/howdo.html[highly encourage copy-cats].
+
+Hardware for PkgBase is kindly sponsored by a member of the FreeBSD community.


### PR DESCRIPTION
pkgbase.live is back alive.