### PR TITLE
status: 2023q2: Core: various changes

### DIFF
--- a/website/content/en/status/report-2023-04-2023-06/core.adoc
+++ b/website/content/en/status/report-2023-04-2023-06/core.adoc
@@ -15,11 +15,11 @@ The Core Team is working with the different teams to ensure that FreeBSD 14 will
 
 The Core Team has no objection to mark riscv64sf as unsupported in 14.
 
-==== Meetings with the FreeBSD Foundation
+==== Meetings with The FreeBSD Foundation
 
-The Core Team and the FreeBSD Foundation continue to meet regularly to discuss the next steps to take for the management and development of FreeBSD and its future.
-In 2023Q2, the Core Team had two meetings with the Boards of Directors of the FreeBSD Foundation and employees.
-They discussed how the FreeBSD Foundation can help the Core Team and the Project in general.
+The Core Team and The FreeBSD Foundation continue to meet regularly to discuss the next steps to take for the management and development of FreeBSD and its future.
+In 2023Q2, the Core Team had two meetings with the Boards of Directors of the Foundation and employees.
+They discussed how the Foundation can help the Core Team and the Project in general.
 
 ==== Matrix IM solution
 

--- a/website/content/en/status/report-2023-04-2023-06/core.adoc
+++ b/website/content/en/status/report-2023-04-2023-06/core.adoc
@@ -7,7 +7,7 @@ The FreeBSD Core Team is the governing body of FreeBSD.
 ==== DevSummit 202305
 
 The Core Team has presented the status update at the FreeBSD Developer Summit, 17th–18th May.
-Slides are available at link:https://wiki.freebsd.org/DevSummit/202305[]
+Slides are available at link:https://wiki.freebsd.org/DevSummit/202305[].
 
 ==== FreeBSD 14
 
@@ -27,7 +27,7 @@ One of the major items in the Core Team updates in DevSummit 202305 was proposin
 
 There is currently a testing instance at matrix-dev.FreeBSD.org setup by clusteradm.
 All developers can access it with their kerberos credentials, and some public channels can be joined through Matrix's federation feature.
-Please note this instance is for testing and evaluating so no backup and availability is guaranteed.
+Please note this instance is for testing and evaluating so no backup or availability is guaranteed.
 
 The Core Team is still discussing the scope and administration of this service, and collecting the feedback from community.
 

--- a/website/content/en/status/report-2023-04-2023-06/core.adoc
+++ b/website/content/en/status/report-2023-04-2023-06/core.adoc
@@ -6,7 +6,7 @@ The FreeBSD Core Team is the governing body of FreeBSD.
 
 ==== DevSummit 202305
 
-The Core Team has presented the status update at the DevSummit 202305.
+The Core Team has presented the status update at the FreeBSD Developer Summit, 17th–18th May.
 Slides are available at link:https://wiki.freebsd.org/DevSummit/202305[]
 
 ==== FreeBSD 14

--- a/website/content/en/status/report-2023-04-2023-06/core.adoc
+++ b/website/content/en/status/report-2023-04-2023-06/core.adoc
@@ -17,7 +17,7 @@ The Core Team has no objection to mark riscv64sf (64-bit RISC-V soft-float) as h
 
 ==== Meetings with The FreeBSD Foundation
 
-The Core Team and The FreeBSD Foundation continue to meet regularly to discuss the next steps to take for the management and development of FreeBSD and its future.
+The Core Team and The FreeBSD Foundation continue to meet regularly to discuss the next steps to take for the management, development, and future of FreeBSD.
 The Core Team had two meetings with the Board of Directors of, and employees of, the Foundation.
 They discussed how the Foundation can help the Core Team and the Project in general.
 

--- a/website/content/en/status/report-2023-04-2023-06/core.adoc
+++ b/website/content/en/status/report-2023-04-2023-06/core.adoc
@@ -25,8 +25,11 @@ They discussed how the Foundation can help the Core Team and the Project in gene
 
 One of the major items in the Core Team updates in DevSummit 202305 was proposing a new project communication channel.
 
-There is currently a testing instance at matrix-dev.FreeBSD.org setup by clusteradm.
-All developers can access it with their kerberos credentials, and some public channels can be joined through Matrix's federation feature.
+There is currently a testing instance at matrix-dev.FreeBSD.org setup by clusteradm. The lobby: 
+
+- https://matrix.to/#/#lobby:matrix-dev.freebsd.org[]
+
+All developers can access the instance with their kerberos credentials, and some public channels can be joined through Matrix's federation feature.
 Please note this instance is for testing and evaluating so no backup or availability is guaranteed.
 
 The Core Team is still discussing the scope and administration of this service, and collecting the feedback from community.

--- a/website/content/en/status/report-2023-04-2023-06/core.adoc
+++ b/website/content/en/status/report-2023-04-2023-06/core.adoc
@@ -40,4 +40,4 @@ Code of Conduct Committee (conduct@) is managed by the Core Team now.
 
 === Commit bits
 
-* Core approved the src commit bit for Christos Margiolis (christos@)
+Core approved the src commit bit for Christos Margiolis (christos@).

--- a/website/content/en/status/report-2023-04-2023-06/core.adoc
+++ b/website/content/en/status/report-2023-04-2023-06/core.adoc
@@ -18,12 +18,12 @@ The Core Team has no objection to mark riscv64sf as unsupported in 14.
 ==== Meetings with The FreeBSD Foundation
 
 The Core Team and The FreeBSD Foundation continue to meet regularly to discuss the next steps to take for the management and development of FreeBSD and its future.
-In 2023Q2, the Core Team had two meetings with the Boards of Directors of the Foundation and employees.
+The Core Team had two meetings with the Board of Directors of, and employees of, the Foundation.
 They discussed how the Foundation can help the Core Team and the Project in general.
 
 ==== Matrix IM solution
 
-One of the major items in the Core Team updates in DevSummit 202305 is proposing a new project communication channel.
+One of the major items in the Core Team updates in DevSummit 202305 was proposing a new project communication channel.
 
 There is currently a testing instance at matrix-dev.FreeBSD.org setup by clusteradm.
 All developers can access it with their kerberos credentials, and some public channels can be joined through Matrix's federation feature.

--- a/website/content/en/status/report-2023-04-2023-06/core.adoc
+++ b/website/content/en/status/report-2023-04-2023-06/core.adoc
@@ -11,9 +11,9 @@ Slides are available at link:https://wiki.freebsd.org/DevSummit/202305[].
 
 ==== FreeBSD 14
 
-The Core Team is working with the different teams to ensure that FreeBSD 14 will come out with the highest quality.
+The Core Team is working with other teams to ensure that FreeBSD 14.0-RELEASE will be of the highest quality.
 
-The Core Team has no objection to mark riscv64sf as unsupported in 14.
+The Core Team has no objection to mark riscv64sf (64-bit RISC-V soft-float) as https://www.freebsd.org/platforms/[unsupported in 14].
 
 ==== Meetings with The FreeBSD Foundation
 

--- a/website/content/en/status/report-2023-04-2023-06/core.adoc
+++ b/website/content/en/status/report-2023-04-2023-06/core.adoc
@@ -25,10 +25,7 @@ They discussed how the Foundation can help the Core Team and the Project in gene
 
 One of the major items in the Core Team updates in DevSummit 202305 was proposing a new project communication solution.
 
-There is currently a testing instance at matrix-dev.FreeBSD.org setup by clusteradm. The lobby: 
-
-- https://matrix.to/#/#lobby:matrix-dev.freebsd.org[]
-
+There is currently a testing instance at matrix-dev.FreeBSD.org setup by clusteradm.
 All developers can access the instance with their kerberos credentials, and some public rooms can be joined through Matrix's federation feature.
 Please note this instance is for testing and evaluating so no backup or availability is guaranteed.
 

--- a/website/content/en/status/report-2023-04-2023-06/core.adoc
+++ b/website/content/en/status/report-2023-04-2023-06/core.adoc
@@ -32,7 +32,7 @@ There is currently a testing instance at matrix-dev.FreeBSD.org setup by cluster
 All developers can access the instance with their kerberos credentials, and some public channels can be joined through Matrix's federation feature.
 Please note this instance is for testing and evaluating so no backup or availability is guaranteed.
 
-The Core Team is still discussing the scope and administration of this service, and collecting the feedback from community.
+The Core Team is still discussing the scope and administration of this service, and collecting feedback from the community.
 
 === Code of Conduct Committee
 

--- a/website/content/en/status/report-2023-04-2023-06/core.adoc
+++ b/website/content/en/status/report-2023-04-2023-06/core.adoc
@@ -23,7 +23,7 @@ They discussed how the Foundation can help the Core Team and the Project in gene
 
 ==== Matrix IM solution
 
-One of the major items in the Core Team updates in DevSummit 202305 was proposing a new project communication medium.
+One of the major items in the Core Team updates in DevSummit 202305 was proposing a new project communication solution.
 
 There is currently a testing instance at matrix-dev.FreeBSD.org setup by clusteradm. The lobby: 
 

--- a/website/content/en/status/report-2023-04-2023-06/core.adoc
+++ b/website/content/en/status/report-2023-04-2023-06/core.adoc
@@ -23,13 +23,13 @@ They discussed how the Foundation can help the Core Team and the Project in gene
 
 ==== Matrix IM solution
 
-One of the major items in the Core Team updates in DevSummit 202305 was proposing a new project communication channel.
+One of the major items in the Core Team updates in DevSummit 202305 was proposing a new project communication medium.
 
 There is currently a testing instance at matrix-dev.FreeBSD.org setup by clusteradm. The lobby: 
 
 - https://matrix.to/#/#lobby:matrix-dev.freebsd.org[]
 
-All developers can access the instance with their kerberos credentials, and some public channels can be joined through Matrix's federation feature.
+All developers can access the instance with their kerberos credentials, and some public rooms can be joined through Matrix's federation feature.
 Please note this instance is for testing and evaluating so no backup or availability is guaranteed.
 
 The Core Team is still discussing the scope and administration of this service, and collecting feedback from the community.


### PR DESCRIPTION
Uppercase T for 'The FreeBSD Foundation'. Board of Directors of the Foundation; not multiple boards.

Expand 'DevSummit'.

~~Matrix: simplify test instance onboarding.~~

Demystify riscv64sf, and link to the platforms support page.

Other minor suggestions; please see the commit messages.