### PR TITLE
FreeBSD Handbook: Appendix C: updates and corrections

### DIFF
--- a/documentation/content/en/books/handbook/eresources/_index.adoc
+++ b/documentation/content/en/books/handbook/eresources/_index.adoc
@@ -224,12 +224,12 @@ If text/plain does not accompany text/html:
 
 Alongside two FreeBSD-specific groups, other groups discuss FreeBSD or are otherwise relevant to users of FreeBSD.
 
-=== BSD-specific Groups
+=== BSD-oriented Groups
 
 * link:news:comp.unix.bsd.freebsd.announce[comp.unix.bsd.freebsd.announce] -- FreeBSD-specific
 * link:news:comp.unix.bsd.freebsd.misc[comp.unix.bsd.freebsd.misc] -- FreeBSD-specific
-* link:news:de.comp.os.unix.bsd[de.comp.os.unix.bsd] (German)
-* link:news:fr.comp.os.bsd[fr.comp.os.bsd] (French)
+* link:news:de.comp.os.unix.bsd[de.comp.os.unix.bsd] -- German
+* link:news:fr.comp.os.bsd[fr.comp.os.bsd] -- French
 
 === Other UNIX(R) Groups of Interest
 
@@ -238,7 +238,6 @@ Alongside two FreeBSD-specific groups, other groups discuss FreeBSD or are other
 * link:news:comp.unix.admin[comp.unix.admin]
 * link:news:comp.unix.programmer[comp.unix.programmer]
 * link:news:comp.unix.shell[comp.unix.shell]
-* link:news:comp.unix.misc[comp.unix.misc]
 * link:news:comp.unix.bsd[comp.unix.bsd]
 
 === The X Window System

--- a/documentation/content/en/books/handbook/eresources/_index.adoc
+++ b/documentation/content/en/books/handbook/eresources/_index.adoc
@@ -62,7 +62,7 @@ Please make the {freebsd-doc} aware of any resource that is either redundant, or
 * The free, professionally-edited link:https://freebsdfoundation.org/our-work/journal/browser-based-edition/[FreeBSD Journal] is published six times a year by link:https://freebsdfoundation.org[The FreeBSD Foundation].
 * link:https://www.freebsd.org/status/[FreeBSD Status Reports] appear four times a year.
 * The link:https://docs.FreeBSD.org/[FreeBSD Documentation Portal] offers more than forty articles and books -- including this Handbook -- and a handy link to manual pages.
-* The broad-ranging link:https://wiki.FreeBSD.org/[FreeBSD Wiki] can provide current information that is not yet in the portal or manual.
+* The link:https://wiki.FreeBSD.org/[FreeBSD Wiki] can provide current information that is not yet in the portal or manual.
 * link:https://papers.freebsd.org/[FreeBSD Presentations and Papers] -- the collected works of the FreeBSD community as presented at various conferences and summits.
 * link:https://forums.FreeBSD.org/[The FreeBSD Forums] host questions and technical discussion.
 * link:https://wiki.freebsd.org/Discord[Discord for FreeBSD] is a communications and community-building area where members can socialise, obtain support or support others, learn, contribute, collaborate, and stay up to date with all things FreeBSD-related.

--- a/documentation/content/en/books/handbook/eresources/_index.adoc
+++ b/documentation/content/en/books/handbook/eresources/_index.adoc
@@ -88,7 +88,7 @@ Some of the listed IRC servers offer bridging with link:https://matrix.org/[Matr
 [[eresources-matrix]]
 == Matrix
 
-An open network for secure, decentralized communication. 
+An open network for secure, decentralized communication.
 
 …
 ////
@@ -145,16 +145,23 @@ The message will be distributed to list members.
 [[eresources-charters]]
 === Rules
 
-All posters must adhere to these rules. 
+All posters must adhere to these rules.
 Failure to comply will result in two (2) written warnings from the link:https://www.freebsd.org/administration/#t-postmaster[Postmaster Team], after which, on a third offense, the poster will removed from all FreeBSD mailing lists and filtered from further posting.
 
 We regret that such rules and measures are necessary at all, but today's Internet is a pretty harsh environment, it would seem, and many fail to appreciate just how fragile some of its mechanisms are.
 
 Rules of the road:
 
-* The topic of any post should adhere to the description of the list to which it is posted. If the list is for technical issues, the post should contain technical discussion. Irrelevant chatter or flaming detracts from the value of a list for and will not be tolerated. For non-technical discussion relating to the community, aim for the {freebsd-chat}.
-* No post should address more than two lists, and two _only_ if there is a clear and obvious need to address both. For most lists, there is a great deal of subscriber overlap, and except for the most esoteric mixes (say "-stable & -scsi"), there really is no reason to post to more than one. If you receive an email with multiple lists on the `Cc` line, trim this line before replying. No matter who the originator was, _the person who replies is responsible for cross-posting._
-* Personal attacks and profanity (in the context of an argument) are not allowed. This applies to users and developers alike. Gross breaches of netiquette, such as excerpting or reposting private email when permission to do so was not and would not be forthcoming, are frowned upon but not specifically enforced.
+* The topic of any post should adhere to the description of the list to which it is posted.
+If the list is for technical issues, the post should contain technical discussion.
+Irrelevant chatter or flaming detracts from the value of a list for and will not be tolerated.
+For non-technical discussion relating to the community, aim for the {freebsd-chat}.
+* No post should address more than two lists, and two _only_ if there is a clear and obvious need to address both.
+For most lists, there is a great deal of subscriber overlap, and except for the most esoteric mixes (say "-stable & -scsi"), there really is no reason to post to more than one.
+If you receive an email with multiple lists on the `Cc` line, trim this line before replying.
+No matter who the originator was, _the person who replies is responsible for cross-posting._
+* Personal attacks and profanity (in the context of an argument) are not allowed.
+This applies to users and developers alike.Gross breaches of netiquette, such as excerpting or reposting private email when permission to do so was not and would not be forthcoming, are frowned upon but not specifically enforced.
 * Advertising of non-FreeBSD related products or services is strictly prohibited and will result in an immediate ban if it is clear that the offender is advertising by spam.
 
 [[eresources-mailfiltering]]

--- a/documentation/content/en/books/handbook/eresources/_index.adoc
+++ b/documentation/content/en/books/handbook/eresources/_index.adoc
@@ -142,10 +142,10 @@ Archive search interfaces include:
 - https://freebsd.markmail.org/[] (MarkMail)
 - https://www.mail-archive.com/search?l=all&q=freebsd.org[] (The Mail Archive)
 
-A brief comparison of archives (two examples): 
+A brief comparison of archives: 
 
-* https://markmail.org/message/amocmeuiepzm6onu[] appears to be the beginning of a thread, however the preceding ('yesterday') email is missing from all archives and link:[[eresources-mailfiltering]][documented filters] do not explain the absence
-* https://markmail.org/message/pikg6ra5cq52pecw[] later in the thread (the fourth email, excluding the one that's missing) presents two small [.filename]#.txt# attachments -- 17k, 9k
+. https://markmail.org/message/amocmeuiepzm6onu[] appeared to be the beginning of a thread, however the preceding ('yesterday') email is missing from all archives and link:[[eresources-mailfiltering]][documented filters] do not explain the absence
+. https://markmail.org/message/pikg6ra5cq52pecw[] later in the thread (the fourth email, excluding the one that's missing) presents two small [.filename]#.txt# attachments -- 17k, 9k
 ** the attachments are archived but invisible at https://lists.freebsd.org/archives/freebsd-current/2023-June/003866.html[]
 ** the email is missing from the tree of three at https://www.mail-archive.com/freebsd-current@freebsd.org/msg188127.html[]
 *** The Mail Archive does express https://www.mail-archive.com/faq.html#attachments[a policy regarding excessively large attachments (and images)], however this does not explain the absence of the email (and by modern standards, neither 17k nor 9k is _excessively_ large for a `text/plain` attachment).

--- a/documentation/content/en/books/handbook/eresources/_index.adoc
+++ b/documentation/content/en/books/handbook/eresources/_index.adoc
@@ -49,9 +49,6 @@ toc::[]
 include::../../../../../shared/asciidoctor.adoc[]
 endif::[]
 
-Development of FreeBSD is too rapid for print media to be practical for keeping people informed.
-For awareness of developments: electronic alternatives to print are best.
-
 The FreeBSD user community provides much technical support -- with forums, chat and email amongst the most popular and effective means of communication.
 
 Some of the most important areas are listed below.

--- a/documentation/content/en/books/handbook/eresources/_index.adoc
+++ b/documentation/content/en/books/handbook/eresources/_index.adoc
@@ -146,7 +146,7 @@ The message will be distributed to list members.
 === Rules
 
 All posters must adhere to these rules. 
-Failure to comply will result in two (2) written warnings from the FreeBSD Postmaster mailto:postmaster@FreeBSD.org[postmaster@FreeBSD.org], after which, on a third offense, the poster will removed from all FreeBSD mailing lists and filtered from further posting to them.
+Failure to comply will result in two (2) written warnings from the link:https://www.freebsd.org/administration/#t-postmaster[Postmaster Team], after which, on a third offense, the poster will removed from all FreeBSD mailing lists and filtered from further posting.
 
 We regret that such rules and measures are necessary at all, but today's Internet is a pretty harsh environment, it would seem, and many fail to appreciate just how fragile some of its mechanisms are.
 

--- a/documentation/content/en/books/handbook/eresources/_index.adoc
+++ b/documentation/content/en/books/handbook/eresources/_index.adoc
@@ -92,7 +92,6 @@ An open network for secure, decentralized communication.
 
 …
 ////
-
 [[eresources-mail]]
 == FreeBSD Mailing Lists
 

--- a/documentation/content/en/books/handbook/eresources/_index.adoc
+++ b/documentation/content/en/books/handbook/eresources/_index.adoc
@@ -54,24 +54,47 @@ For awareness of developments: electronic alternatives to print are best.
 
 The FreeBSD user community provides much technical support -- with forums, chat and email amongst the most popular and effective means of communication.
 
-The most important points of contact are outlined below.
-The link:https://wiki.freebsd.org/Community[Community wiki area] may be more up-to-date.
+Some of the most important areas are listed below.
+The link:https://wiki.freebsd.org/Community[Community wiki page] may include more up-to-date listings.
 
 Please make the {freebsd-doc} aware of any resource that is either redundant, or not yet listed below.
 
 [[eresources-www]]
 == Websites
 
-* The link:https://forums.FreeBSD.org/[FreeBSD Forums] provide a web based discussion forum for FreeBSD questions and technical discussion.
-* The link:https://wiki.FreeBSD.org/[FreeBSD Wiki] provides various bits of information that hadn't yet made it into the Handbook.
-* The link:https://docs.FreeBSD.org/[Documentation Portal] offers much more than the FreeBSD Handbook alone; there are more than forty books and articles.
-* The link:https://freebsdfoundation.org/our-work/journal/browser-based-edition/[FreeBSD Journal] is a free, professionally-edited, bi-monthly technical magazine released by link:https://freebsdfoundation.org[The FreeBSD Foundation].
-* The link:http://www.youtube.com/bsdconferences[BSDConferences YouTube Channel] provides a collection of high quality videos from BSD conferences around the world. This is a great way to watch key developers give presentations about new work in FreeBSD.
-* link:https://www.freebsd.org/status/[FreeBSD Status Reports] are released every three months and track progress of FreeBSD development.
-* There's a link:https://www.reddit.com/r/freebsd/[FreeBSD-focused Reddit group] at r/freebsd.
-* link:https://superuser.com/questions/tagged/freebsd[Super User] and link:https://serverfault.com/questions/tagged/freebsd[Server Fault], the Stack Exchange services for system administrators.
-* link:https://wiki.freebsd.org/Discord[FreeBSD Discord server], a communications and community-building service, where FreeBSD community members can socialise, obtain support or support others, learn, contribute, collaborate, and stay up to date with all things FreeBSD-related.
-* link:https://wiki.freebsd.org/IRC/Channels[IRC channels], a widely implemented, technically mature, open standard text chat.
+* The free, professionally-edited link:https://freebsdfoundation.org/our-work/journal/browser-based-edition/[FreeBSD Journal] is published six times a year by link:https://freebsdfoundation.org[The FreeBSD Foundation].
+* link:https://www.freebsd.org/status/[FreeBSD Status Reports] appear four times a year.
+* The link:https://docs.FreeBSD.org/[FreeBSD Documentation Portal] offers more than forty articles and books -- including this Handbook -- and a handy link to manual pages.
+* The broad-ranging link:https://wiki.FreeBSD.org/[FreeBSD Wiki] can provide current information that is not yet in the portal or manual.
+* link:https://papers.freebsd.org/[FreeBSD Presentations and Papers] -- the collected works of the FreeBSD community as presented at various conferences and summits.
+* link:https://forums.FreeBSD.org/[The FreeBSD Forums] host questions and technical discussion.
+* link:https://wiki.freebsd.org/Discord[Discord for FreeBSD] is a communications and community-building area where members can socialise, obtain support or support others, learn, contribute, collaborate, and stay up to date with all things FreeBSD-related.
+* The weekly link:https://www.bsdnow.tv/[BSD Now] podcast covers latest news, interviews people from all areas of the BSD community, includes tutorials, and serves as a platform for support and questions.
+The show aims to be helpful and informative for new users, but still be entertaining for people who are already pros.
+* link:http://www.youtube.com/bsdconferences[bsdconferences on YouTube] covers FreeBSD, NetBSD, OpenBSD, DragonFly BSD, macOS and more.
+* The link:https://community.unix.com/[Unix Linux Community] forum provides technical support for all UNIX and Linux users.
+* Reddit includes link:https://www.reddit.com/r/BSD/[r/BSD], link:https://www.reddit.com/r/dragonflybsd/[r/dragonflybsd], link:https://www.reddit.com/r/freebsd/[r/freebsd], link:https://www.reddit.com/r/GhostBSD/[r/GhostBSD], link:https://www.reddit.com/r/NetBSD/[r/NetBSD], link:https://www.reddit.com/r/openbsd/[r/openbsd], link:https://www.reddit.com/r/openzfs/[r/openzfs], link:https://www.reddit.com/r/truenas/[r/truenas], and link:https://www.reddit.com/r/unix/[r/unix].
+* The link:https://discourse.practicalzfs.com/[Practical ZFS] forum is complementary to r/openzfs.
+* link:https://github.com/DiscoverBSD/awesome-bsd[DiscoverBSD/awesome-bsd] is a GitHub-based collection of BSD-related information.
+* _freebsd_-tagged Stack Exchange areas for system administrators include link:https://superuser.com/questions/tagged/freebsd[Super User] and link:https://serverfault.com/questions/tagged/freebsd[Server Fault].
+
+[[eresources-irc]]
+== Internet Relay Chat
+
+IRC is a widely-implemented, technically mature, open standard for text chat.
+
+link:https://wiki.freebsd.org/IRC/Channels[] lists FreeBSD-related channels.
+
+Some of the listed IRC servers offer bridging with link:https://matrix.org/[Matrix] -- an open network for secure, decentralized communication.
+
+////
+[[eresources-matrix]]
+== Matrix
+
+An open network for secure, decentralized communication. 
+
+…
+////
 
 [[eresources-mail]]
 == Mailing Lists
@@ -128,6 +151,7 @@ The message will be redistributed to list members.
 
 _All_ FreeBSD mailing lists have certain basic rules which must be adhered to by anyone using them.
 Failure to comply with these guidelines will result in two (2) written warnings from the FreeBSD Postmaster mailto:postmaster@FreeBSD.org[postmaster@FreeBSD.org], after which, on a third offense, the poster will removed from all FreeBSD mailing lists and filtered from further posting to them.
+
 We regret that such rules and measures are necessary at all, but today's Internet is a pretty harsh environment, it would seem, and many fail to appreciate just how fragile some of its mechanisms are.
 
 Rules of the road:

--- a/documentation/content/en/books/handbook/eresources/_index.adoc
+++ b/documentation/content/en/books/handbook/eresources/_index.adoc
@@ -142,12 +142,6 @@ Archive search interfaces include:
 - https://freebsd.markmail.org/[] (MarkMail)
 - https://www.mail-archive.com/search?l=all&q=freebsd.org[] (The Mail Archive)
 
-FreeBSD-provided archives:
- 
-* do not present links as links
-* do not present inline images
-* do not present HTML content of HTML messages.
-
 A brief comparison of archives (two examples): 
 
 * https://markmail.org/message/amocmeuiepzm6onu[] appears to be the beginning of a thread, however the preceding ('yesterday') email is missing from all archives and link:[[eresources-mailfiltering]][documented filters] do not explain the absence
@@ -155,6 +149,12 @@ A brief comparison of archives (two examples):
 ** the attachments are archived but invisible at https://lists.freebsd.org/archives/freebsd-current/2023-June/003866.html[]
 ** the email is missing from the tree of three at https://www.mail-archive.com/freebsd-current@freebsd.org/msg188127.html[]
 *** The Mail Archive does express https://www.mail-archive.com/faq.html#attachments[a policy regarding excessively large attachments (and images)], however this does not explain the absence of the email (and by modern standards, neither 17k nor 9k is _excessively_ large).
+
+FreeBSD-provided archives:
+ 
+* do not present links as links
+* do not present inline images
+* do not present HTML content of HTML messages.
 
 ////
 [[eresources-summary]]

--- a/documentation/content/en/books/handbook/eresources/_index.adoc
+++ b/documentation/content/en/books/handbook/eresources/_index.adoc
@@ -234,7 +234,6 @@ Alongside two FreeBSD-specific groups, other groups discuss FreeBSD or are other
 === Other UNIX(R) Groups of Interest
 
 * link:news:comp.unix[comp.unix]
-* link:news:comp.unix.questions[comp.unix.questions]
 * link:news:comp.unix.admin[comp.unix.admin]
 * link:news:comp.unix.programmer[comp.unix.programmer]
 * link:news:comp.unix.shell[comp.unix.shell]

--- a/documentation/content/en/books/handbook/eresources/_index.adoc
+++ b/documentation/content/en/books/handbook/eresources/_index.adoc
@@ -140,12 +140,21 @@ Archive search interfaces include:
 - https://lists.freebsd.org/search[] (FreeBSD, experimental)
 - https://www.freebsd.org/search/[] (DuckDuckGo)
 - https://freebsd.markmail.org/[] (MarkMail)
+- https://www.mail-archive.com/search?l=all&q=freebsd.org[] (The Mail Archive)
 
 FreeBSD-provided archives:
  
 * do not present links as links
 * do not present inline images
 * do not present HTML content of HTML messages.
+
+A brief comparison of archives (two examples): 
+
+* https://markmail.org/message/amocmeuiepzm6onu[] appears to be the beginning of a thread, however the preceding ('yesterday') email is missing from all archives and link:[[eresources-mailfiltering]][documented filters] do not explain the absence
+* https://markmail.org/message/pikg6ra5cq52pecw[] later in the thread (the fourth email, excluding the one that's missing) presents two small .txt attachments – 17k, 9k
+** the attachments are archived but invisible at https://lists.freebsd.org/archives/freebsd-current/2023-June/003866.html[]
+** the email is missing from the tree of three at https://www.mail-archive.com/freebsd-current@freebsd.org/msg188127.html[]
+*** The Mail Archive does express https://www.mail-archive.com/faq.html#attachments[a policy regarding excessively large attachments (and images)], however this does not explain the absence of the email (and by modern standards, neither 17k nor 9k is _excessively_ large).
 
 ////
 [[eresources-summary]]

--- a/documentation/content/en/books/handbook/eresources/_index.adoc
+++ b/documentation/content/en/books/handbook/eresources/_index.adoc
@@ -145,10 +145,10 @@ Archive search interfaces include:
 A brief comparison of archives (two examples): 
 
 * https://markmail.org/message/amocmeuiepzm6onu[] appears to be the beginning of a thread, however the preceding ('yesterday') email is missing from all archives and link:[[eresources-mailfiltering]][documented filters] do not explain the absence
-* https://markmail.org/message/pikg6ra5cq52pecw[] later in the thread (the fourth email, excluding the one that's missing) presents two small .txt attachments – 17k, 9k
+* https://markmail.org/message/pikg6ra5cq52pecw[] later in the thread (the fourth email, excluding the one that's missing) presents two small [.filename]#.txt# attachments -- 17k, 9k
 ** the attachments are archived but invisible at https://lists.freebsd.org/archives/freebsd-current/2023-June/003866.html[]
 ** the email is missing from the tree of three at https://www.mail-archive.com/freebsd-current@freebsd.org/msg188127.html[]
-*** The Mail Archive does express https://www.mail-archive.com/faq.html#attachments[a policy regarding excessively large attachments (and images)], however this does not explain the absence of the email (and by modern standards, neither 17k nor 9k is _excessively_ large).
+*** The Mail Archive does express https://www.mail-archive.com/faq.html#attachments[a policy regarding excessively large attachments (and images)], however this does not explain the absence of the email (and by modern standards, neither 17k nor 9k is _excessively_ large for a `text/plain` attachment).
 
 FreeBSD-provided archives:
  

--- a/documentation/content/en/books/handbook/eresources/_index.adoc
+++ b/documentation/content/en/books/handbook/eresources/_index.adoc
@@ -59,21 +59,39 @@ Please make the {freebsd-doc} aware of any resource that is either redundant, or
 [[eresources-www]]
 == Websites
 
-* The free, professionally-edited link:https://freebsdfoundation.org/our-work/journal/browser-based-edition/[FreeBSD Journal] is published six times a year by link:https://freebsdfoundation.org[The FreeBSD Foundation].
-* link:https://www.freebsd.org/status/[FreeBSD Status Reports] appear four times a year.
-* The link:https://docs.FreeBSD.org/[FreeBSD Documentation Portal] offers more than forty articles and books -- including this Handbook -- and a handy link to manual pages.
-* The link:https://wiki.FreeBSD.org/[FreeBSD Wiki] can provide current information that is not yet in the portal or manual.
-* link:https://papers.freebsd.org/[FreeBSD Presentations and Papers] -- the collected works of the FreeBSD community as presented at various conferences and summits.
-* link:https://forums.FreeBSD.org/[The FreeBSD Forums] host questions and technical discussion.
-* link:https://wiki.freebsd.org/Discord[Discord for FreeBSD] is a communications and community-building area where members can socialise, obtain support or support others, learn, contribute, collaborate, and stay up to date with all things FreeBSD-related.
-* The weekly link:https://www.bsdnow.tv/[BSD Now] podcast covers latest news, interviews people from all areas of the BSD community, includes tutorials, and serves as a platform for support and questions.
-The show aims to be helpful and informative for new users, but still be entertaining for people who are already pros.
-* link:http://www.youtube.com/bsdconferences[bsdconferences on YouTube] covers FreeBSD, NetBSD, OpenBSD, DragonFly BSD, macOS and more.
-* The link:https://community.unix.com/[Unix Linux Community] forum provides technical support for all UNIX and Linux users.
-* Reddit includes link:https://www.reddit.com/r/BSD/[r/BSD], link:https://www.reddit.com/r/dragonflybsd/[r/dragonflybsd], link:https://www.reddit.com/r/freebsd/[r/freebsd], link:https://www.reddit.com/r/GhostBSD/[r/GhostBSD], link:https://www.reddit.com/r/NetBSD/[r/NetBSD], link:https://www.reddit.com/r/openbsd/[r/openbsd], link:https://www.reddit.com/r/openzfs/[r/openzfs], link:https://www.reddit.com/r/truenas/[r/truenas], and link:https://www.reddit.com/r/unix/[r/unix].
-* The link:https://discourse.practicalzfs.com/[Practical ZFS] forum is complementary to r/openzfs.
-* link:https://github.com/DiscoverBSD/awesome-bsd[DiscoverBSD/awesome-bsd] is a GitHub-based collection of BSD-related information.
-* _freebsd_-tagged Stack Exchange areas for system administrators include link:https://superuser.com/questions/tagged/freebsd[Super User] and link:https://serverfault.com/questions/tagged/freebsd[Server Fault].
+The free, professionally-edited link:https://freebsdfoundation.org/our-work/journal/browser-based-edition/[FreeBSD Journal] is published six times a year by link:https://freebsdfoundation.org[The FreeBSD Foundation].
+
+link:https://www.freebsd.org/status/[FreeBSD Status Reports] appear four times a year.
+
+The link:https://docs.FreeBSD.org/[FreeBSD Documentation Portal] offers:
+
+* more than forty articles and books -- including this Handbook
+* a handy link to manual pages.
+
+The link:https://wiki.FreeBSD.org/[FreeBSD Wiki] can provide current information that is not yet in the portal or manual.
+
+link:https://papers.freebsd.org/[FreeBSD Presentations and Papers] -- the collected works of the FreeBSD community as presented at various conferences and summits.
+
+link:https://forums.FreeBSD.org/[The FreeBSD Forums] host questions and technical discussion.
+
+link:https://wiki.freebsd.org/Discord[Discord for FreeBSD] is a communications and community-building area where members can socialise, obtain support or support others, learn, contribute, collaborate, and stay up to date with all things FreeBSD-related.
+
+The weekly link:https://www.bsdnow.tv/[BSD Now] podcast:
+
+* covers latest news, interviews people from all areas of the BSD community, includes tutorials, and serves as a platform for support and questions
+* aims to help and inform new users, whilst entertaining people who are already pros.
+
+link:http://www.youtube.com/bsdconferences[bsdconferences on YouTube] covers FreeBSD, NetBSD, OpenBSD, DragonFly BSD, macOS and more.
+
+The link:https://community.unix.com/[Unix Linux Community] forum provides technical support for all UNIX and Linux users.
+
+Reddit includes link:https://www.reddit.com/r/BSD/[r/BSD], link:https://www.reddit.com/r/dragonflybsd/[r/dragonflybsd], link:https://www.reddit.com/r/freebsd/[r/freebsd], link:https://www.reddit.com/r/GhostBSD/[r/GhostBSD], link:https://www.reddit.com/r/NetBSD/[r/NetBSD], link:https://www.reddit.com/r/openbsd/[r/openbsd], link:https://www.reddit.com/r/openzfs/[r/openzfs], link:https://www.reddit.com/r/truenas/[r/truenas], and link:https://www.reddit.com/r/unix/[r/unix].
+
+The link:https://discourse.practicalzfs.com/[Practical ZFS] forum is complementary to r/openzfs.
+
+link:https://github.com/DiscoverBSD/awesome-bsd[DiscoverBSD/awesome-bsd] is a GitHub-based collection of BSD-related information.
+
+_freebsd_-tagged Stack Exchange areas for system administrators include link:https://superuser.com/questions/tagged/freebsd[Super User] and link:https://serverfault.com/questions/tagged/freebsd[Server Fault].
 
 [[eresources-irc]]
 == Internet Relay Chat
@@ -82,7 +100,7 @@ IRC is a widely-implemented, technically mature, open standard for text chat.
 
 link:https://wiki.freebsd.org/IRC/Channels[] lists FreeBSD-related channels.
 
-Some of the listed IRC servers offer bridging with link:https://matrix.org/[Matrix] -- an open network for secure, decentralized communication.
+Some listed IRC servers offer bridging with link:https://matrix.org/[Matrix] -- an open network for secure, decentralized communication.
 
 ////
 [[eresources-matrix]]
@@ -160,7 +178,8 @@ For most lists, there is a great deal of subscriber overlap, and except for the 
 If you receive an email with multiple lists on the `Cc` line, trim this line before replying.
 No matter who the originator was, _the person who replies is responsible for cross-posting._
 * Personal attacks and profanity (in the context of an argument) are not allowed.
-This applies to users and developers alike.Gross breaches of netiquette, such as excerpting or reposting private email when permission to do so was not and would not be forthcoming, are frowned upon but not specifically enforced.
+This applies to users and developers alike.
+Gross breaches of netiquette, such as excerpting or reposting private email when permission to do so was not and would not be forthcoming, are frowned upon but not specifically enforced.
 * Advertising of non-FreeBSD related products or services is strictly prohibited and will result in an immediate ban if it is clear that the offender is advertising by spam.
 
 [[eresources-mailfiltering]]

--- a/documentation/content/en/books/handbook/eresources/_index.adoc
+++ b/documentation/content/en/books/handbook/eresources/_index.adoc
@@ -94,13 +94,11 @@ An open network for secure, decentralized communication.
 ////
 
 [[eresources-mail]]
-== Mailing Lists
+== FreeBSD Mailing Lists
 
-The mailing lists are the most direct way of addressing questions or opening a technical discussion to a concentrated FreeBSD audience.
-There are a wide variety of lists on a number of different FreeBSD topics.
-Sending questions to the most appropriate mailing list will invariably assure a faster and more accurate response.
+{mailing-lists-url} -- more than one hundred public lists, spanning a variety of topics.
 
-Technical list threads should remain technical.
+Choosing an appropriate list increases the likelihood of a rapid and accurate response.
 
 All users and developers of FreeBSD should subscribe to the {freebsd-announce}.
 
@@ -110,11 +108,14 @@ To test FreeBSD mailing list capabilities, aim for the {freebsd-test}.
 Please do not send test messages to any other list.
 ====
 
-When in doubt about what list to post a question to, see extref:{freebsd-questions-article}[How to get best results from the FreeBSD-questions mailing list].
+Posts to the public lists are archived in perpetuity.
+If privacy is a concern, consider using a disposable email address.
+
+If you are unsure about which list to address, see extref:{freebsd-questions-article}[How to get best results from the FreeBSD-questions mailing list].
 
 Before posting to any list, please:
 
-* learn about how to best use the mailing lists, such as how to help avoid frequently-repeated discussions, by reading the extref:{mailing-list-faq}[Mailing List Frequently Asked Questions] (FAQ) document
+* learn about how to best use the lists, such as how to help avoid frequently-repeated discussions, by reading the extref:{mailing-list-faq}[Mailing List Frequently Asked Questions] (FAQ) document
 * search the archives, to tell whether someone else has already posted what you intend to post.
 
 Archive search interfaces include: 
@@ -123,49 +124,47 @@ Archive search interfaces include:
 - https://www.freebsd.org/search/[] (DuckDuckGo)
 - https://freebsd.markmail.org/[] (MarkMail)
 
-Note that this also means that messages sent to FreeBSD mailing lists are archived in perpetuity.
-When protecting privacy is a concern, consider using a disposable secondary email address and posting only public information.
-
 FreeBSD-provided archives:
  
 * do not present links as links
 * do not present inline images
 * do not present HTML content of HTML messages.
 
+////
 [[eresources-summary]]
-The FreeBSD public mailing lists can be consulted link:{mailing-lists-url}[here].
 
+////
 [[eresources-subscribe]]
 === How to Subscribe or Unsubscribe
 
 At {mailing-lists-url}, click the name of a list to reveal its options.
 
-To post, after subscribing, send mail to `listname@FreeBSD.org`.
-The message will be redistributed to list members.
+To post, after subscribing, send email to `listname@FreeBSD.org`.
+The message will be distributed to list members.
 
 [[eresources-charters]]
-=== Lists Basic Rules
+=== Rules
 
-_All_ FreeBSD mailing lists have certain basic rules which must be adhered to by anyone using them.
-Failure to comply with these guidelines will result in two (2) written warnings from the FreeBSD Postmaster mailto:postmaster@FreeBSD.org[postmaster@FreeBSD.org], after which, on a third offense, the poster will removed from all FreeBSD mailing lists and filtered from further posting to them.
+All posters must adhere to these rules. 
+Failure to comply will result in two (2) written warnings from the FreeBSD Postmaster mailto:postmaster@FreeBSD.org[postmaster@FreeBSD.org], after which, on a third offense, the poster will removed from all FreeBSD mailing lists and filtered from further posting to them.
 
 We regret that such rules and measures are necessary at all, but today's Internet is a pretty harsh environment, it would seem, and many fail to appreciate just how fragile some of its mechanisms are.
 
 Rules of the road:
 
-* The topic of any posting should adhere to the basic description of the list it is posted to. If the list is about technical issues, the posting should contain technical discussion. Ongoing irrelevant chatter or flaming only detracts from the value of the mailing list for everyone on it and will not be tolerated. For free-form discussion on no particular topic, the {freebsd-chat} is freely available and should be used instead.
-* No posting should be made to more than 2 mailing lists, and only to 2 when a clear and obvious need to post to both lists exists. For most lists, there is already a great deal of subscriber overlap and except for the most esoteric mixes (say "-stable & -scsi"), there really is no reason to post to more than one list at a time. If a message is received with multiple mailing lists on the `Cc` line, trim the `Cc` line before replying. _The person who replies is still responsible for cross-posting, no matter who the originator might have been._
-* Personal attacks and profanity (in the context of an argument) are not allowed, and that includes users and developers alike. Gross breaches of netiquette, like excerpting or reposting private mail when permission to do so was not and would not be forthcoming, are frowned upon but not specifically enforced.
+* The topic of any post should adhere to the description of the list to which it is posted. If the list is for technical issues, the post should contain technical discussion. Irrelevant chatter or flaming detracts from the value of a list for and will not be tolerated. For non-technical discussion relating to the community, aim for the {freebsd-chat}.
+* No post should address more than two lists, and two _only_ if there is a clear and obvious need to address both. For most lists, there is a great deal of subscriber overlap, and except for the most esoteric mixes (say "-stable & -scsi"), there really is no reason to post to more than one. If you receive an email with multiple lists on the `Cc` line, trim this line before replying. No matter who the originator was, _the person who replies is responsible for cross-posting._
+* Personal attacks and profanity (in the context of an argument) are not allowed. This applies to users and developers alike. Gross breaches of netiquette, such as excerpting or reposting private email when permission to do so was not and would not be forthcoming, are frowned upon but not specifically enforced.
 * Advertising of non-FreeBSD related products or services is strictly prohibited and will result in an immediate ban if it is clear that the offender is advertising by spam.
 
 [[eresources-mailfiltering]]
-=== Filtering on the Mailing Lists
+=== Filtering
 
-The FreeBSD mailing lists are filtered in multiple ways to avoid the distribution of spam, viruses, and other unwanted emails.
-The filtering actions described in this section do not include all those used to protect the mailing lists.
+The lists are filtered in multiple ways to avoid spam, viruses, and other unwanted content.
+The filtering actions described in this section do not include all those used to protect the lists.
 
-Only certain types of attachments are allowed on the mailing lists.
-All attachments with a MIME content type not found in the list below will be stripped before an email is distributed on the mailing lists.
+Only certain types of attachments are allowed.
+All attachments with a MIME content type not listed below will be stripped before an email is distributed.
 
 * application/octet-stream
 * application/pdf
@@ -182,7 +181,8 @@ All attachments with a MIME content type not found in the list below will be str
 
 [NOTE]
 ====
-Some of the mailing lists might allow attachments of other MIME content types, but the above list should be applicable for most of the mailing lists.
+The stripping above applies to most lists.
+Few lists are more permissive.
 ====
 
 If a multi-part message includes text/plain and text/html parts:
@@ -197,16 +197,16 @@ If text/plain does not accompany text/html:
 [[eresources-news]]
 == Usenet Newsgroups
 
-In addition to two FreeBSD specific newsgroups, there are many others in which FreeBSD is discussed or are otherwise relevant to FreeBSD users.
+Alongside two FreeBSD-specific groups, other groups discuss FreeBSD or are otherwise relevant to users of FreeBSD.
 
-=== BSD Specific Newsgroups
+=== BSD-specific Groups
 
-* link:news:comp.unix.bsd.freebsd.announce[comp.unix.bsd.freebsd.announce]
-* link:news:comp.unix.bsd.freebsd.misc[comp.unix.bsd.freebsd.misc]
+* link:news:comp.unix.bsd.freebsd.announce[comp.unix.bsd.freebsd.announce] -- FreeBSD-specific
+* link:news:comp.unix.bsd.freebsd.misc[comp.unix.bsd.freebsd.misc] -- FreeBSD-specific
 * link:news:de.comp.os.unix.bsd[de.comp.os.unix.bsd] (German)
 * link:news:fr.comp.os.bsd[fr.comp.os.bsd] (French)
 
-=== Other UNIX(R) Newsgroups of Interest
+=== Other UNIX(R) Groups of Interest
 
 * link:news:comp.unix[comp.unix]
 * link:news:comp.unix.questions[comp.unix.questions]
@@ -216,6 +216,6 @@ In addition to two FreeBSD specific newsgroups, there are many others in which F
 * link:news:comp.unix.misc[comp.unix.misc]
 * link:news:comp.unix.bsd[comp.unix.bsd]
 
-=== X Window System
+=== The X Window System
 
 * link:news:comp.windows.x[comp.windows.x]


### PR DESCRIPTION
Affected: 

- [Appendix C. Resources on the Internet | FreeBSD Documentation Portal](https://docs.freebsd.org/en/books/handbook/eresources/#eresources-news)

Preview in GitHub: 

- <https://github.com/grahamperrin/freebsd-doc/blob/bug-264754/documentation/content/en/books/handbook/eresources/_index.adoc>

----

Hello, 2023. Remove the opening paragraph, which, many years ago, might have helped readers to understand why electronic media became more suitable than paper for FreeBSD Project enlightenment.

Be concise, not repetitive: 

- with 'Websites' as the subheading within the FreeBSD Handbook – and with 'Forums' and 'FreeBSD' within the name of The FreeBSD Forums – there's no need to describe The FreeBSD Forums as a web based discussion forum for FreeBSD

… and so on.

Expand, reorder and rewrite the list of websites.

Internet Relay Chat is a communication protocol that does not use HTTP or HTTPS; it's not a website. Make it separate from the websites section.

Below the separate section for Internet Relay Chat, add a hidden section in readiness for Matrix.

Refer to the Postmaster Team section of FreeBSD Project Administration and Management.

NNTP groups content reviewed. Delist some.

Reduce bullet point overload.

Make more use of normal paragraphs.

----

FreeBSD bug [264754 – FreeBSD Handbook: Appendix C: updates and corrections](https://bugs.freebsd.org/bugzilla/show_bug.cgi?id=264754)