### PR TITLE
status: 2023q2: OpenSSL 3: minor changes

### DIFF
--- a/website/content/en/status/report-2023-04-2023-06/openssl3.adoc
+++ b/website/content/en/status/report-2023-04-2023-06/openssl3.adoc
@@ -13,8 +13,8 @@ OpenSSL is a library for general-purpose cryptography and secure communication.
 It provides an open source implementation of the SSL and TLS network protocols, which are widely used in applications such as e-mail, instant messaging, Voice over IP (VoIP), or more prominently the global Web (aka HTTPS).
 Assuming that the Apache and nginx web servers use OpenSSL, their combined market share for web traffic exceeds 50%, cementing the leadership and critical importance of OpenSSL as part of the infrastructure of the Internet.
 
-Since its initial release in August 2016, the 1.1 branch of OpenSSL has been adopted by most Linux and BSD systems, while remaining supported by the upstream maintainers through a Long Term Support policy.
-However, official support is planned to end in the middle of September this year, and it became urgent and necessary to consider adopting its successor for Long Term Support, the 3.0 branch.
+Since its initial release in August 2016, the 1.1 branch of OpenSSL has been adopted by most Linux and BSD systems, while remaining supported by the upstream maintainers through an LTS (long term support) policy.
+However, official support is planned to end in the middle of September this year, and it became urgent and necessary to consider adopting its successor for LTS, the 3.0 branch.
 
 OpenSSL has largely outgrown its ancestor SSLeay, now shipping over half a million single lines of code (SLOC) split in over two thousand files.
 Perhaps as a consequence, its build system is relatively complex and normally requires Perl, which was removed from base more than twenty years ago for FreeBSD 5.0-RELEASE.

--- a/website/content/en/status/report-2023-04-2023-06/openssl3.adoc
+++ b/website/content/en/status/report-2023-04-2023-06/openssl3.adoc
@@ -10,21 +10,21 @@ Contact: Pierre Pronchery <pierre@freebsdfoundation.org>
 Pierre has been tasked with importing OpenSSL 3 into the base system.
 
 OpenSSL is a library for general-purpose cryptography and secure communication.
-It provides an Open Source implementation of the SSL and TLS network protocols, which are widely used in applications such as e-mail, instant messaging, Voice over IP (VoIP), or more prominently the global Web (aka HTTPS).
-Assuming that the Apache and nginx web servers use OpenSSL, their combined market share for web traffic exceeds 50%, cementing the leadership and critical importance of OpenSSL as part of Internet's infrastructure.
+It provides an open source implementation of the SSL and TLS network protocols, which are widely used in applications such as e-mail, instant messaging, Voice over IP (VoIP), or more prominently the global Web (aka HTTPS).
+Assuming that the Apache and nginx web servers use OpenSSL, their combined market share for web traffic exceeds 50%, cementing the leadership and critical importance of OpenSSL as part of the infrastructure of the Internet.
 
 Since its initial release in August 2016, the 1.1 branch of OpenSSL has been adopted by most Linux and BSD systems, while remaining supported by the upstream maintainers through a Long Term Support policy.
 However, official support is planned to end in the middle of September this year, and it became urgent and necessary to consider adopting its successor for Long Term Support, the 3.0 branch.
 
-OpenSSL has largely outgrown its ancestor SSLeay, now shipping over half a million single lines of code (SLOC) split in over 2.000 files.
-Perhaps as a consequence, its build system is relatively complex and normally requires Perl, which has been removed from FreeBSD's base system since 5.0-RELEASE.
-Thankfully however, it was possible to import and setup OpenSSL's 3.0.9 release the FreeBSD way, and it is now part of the base system as planned for FreeBSD's 14.0 release.
+OpenSSL has largely outgrown its ancestor SSLeay, now shipping over half a million single lines of code (SLOC) split in over two thousand files.
+Perhaps as a consequence, its build system is relatively complex and normally requires Perl, which was removed from base more than twenty years ago for FreeBSD 5.0-RELEASE.
+Thankfully however, it was possible to import and setup OpenSSL 3.0.9 the FreeBSD way, and it is now part of the base system as planned for FreeBSD 14.0-RELEASE.
 
-It is an understatement to mention that OpenSSL 3 is a new major release.
+To describe OpenSSL 3 as a major release is an understatement.
 First, its problematic licensing model has finally been solved, with a complete switch to the Apache License 2.0.
 Then, OpenSSL 3 introduces the concept of provider modules.
-While obsolete cryptographical algorithms have been isolated away into a "legacy" module, it is also possible to restrict the implementation to standards part of link:https://en.wikipedia.org/wiki/Federal_Information_Processing_Standards[FIPS] with the "fips" module.
-The latter can then benefit from a dedicated certification process, and be validated officially (like the 3.0.8 release when writing these lines).
+While obsolete cryptographical algorithms have been isolated to a _legacy_ module, it is also possible to restrict the implementation to the standards part of link:https://en.wikipedia.org/wiki/Federal_Information_Processing_Standards[FIPS] with the _fips_ module.
+The latter can then benefit from a dedicated certification process, and be validated officially (like the 3.0.8 release at the time of writing).
 
 Moreover, the updated library comes with a version bump, as applications using OpenSSL 1.1 need to be recompiled to use 3.0.
 Many API functions have been deprecated and replaced with newer, more generic alternatives, however it is still possible to explicitly request older APIs and have OpenSSL 3 expose them accordingly.


### PR DESCRIPTION
Precede 'Internet' with 'the'.

Precede 'standards part of FIPS' with 'the'.

Where FreeBSD 5.0-RELEASE is mentioned: to satisfy readers' curiosity, age it (loosely) – twenty years. 

(Exactly: 19th January 2003 <https://www.freebsd.org/releases/5.0R/announce/>.)

Other suggested changes, minor.

----

Fixes: eb2d1d5c67 Status/2023Q2/openssl3.adoc: Add report