### PR TITLE
status: 2023q2: KDE: grammar and other changes

### DIFF
--- a/website/content/en/status/report-2023-04-2023-06/kde.adoc
+++ b/website/content/en/status/report-2023-04-2023-06/kde.adoc
@@ -1,8 +1,8 @@
 === KDE on FreeBSD
 
 Links: +
-link:https://freebsd.kde.org/[KDE FreeBSD] URL: link:https://freebsd.kde.org/[] +
-link:https://community.kde.org/FreeBSD[KDE Community FreeBSD] URL:link:https://community.kde.org/FreeBSD[]
+link:https://freebsd.kde.org/[KDE/FreeBSD initiative] URL: link:https://freebsd.kde.org/[] +
+link:https://community.kde.org/FreeBSD[FreeBSD -- KDE Community Wiki] URL:link:https://community.kde.org/FreeBSD[]
 
 Contact: Adriaan de Groot <kde@FreeBSD.org>
 

--- a/website/content/en/status/report-2023-04-2023-06/kde.adoc
+++ b/website/content/en/status/report-2023-04-2023-06/kde.adoc
@@ -14,17 +14,23 @@ The notes below describe *mostly* ports for KDE, but also include items that are
 
 ==== Infrastructure
 
-* Qt5 ports had various updates:
-** package:devel/qt5-webengine[] was repaired when building with Clang 16.
-This is in preparation for the upcoming release of FreeBSD 14.
-** package:devel/qt5-qmake[] was repaired to deal with an edge case where installing qmake on an otherwise Qt-less system would cause weird errors.
-* Qt6 ports had various updates:
-** package:devel/qt6-tools[] was repaired when building with Clang 16. This is preparation for the upcoming release of FreeBSD 14.
-* The package:accessibility/at-spi2-core[] port -- essential for accessible technologies on the desktop -- was updated to release 2.48.0.
-* The package:accessibility/at-spi2-core[] port now has better support for non-X11 desktops. This is an improvement for Wayland-based systems. Thanks to Jan Beich for landing that.
-* The package:graphics/poppler[] which is a base for many PDF viewers was updated to 23.05.
-* The package::ports-mgmt/packagekit-qt[] port is a new addition to the tree to pave the way for graphical package managers on FreeBSD.
+Qt5 ports had various updates:
 
+* package:devel/qt5-webengine[] was repaired when building with Clang 16.
+This is in preparation for the upcoming release of FreeBSD 14.
+* package:devel/qt5-qmake[] was repaired to deal with an edge case where installing qmake on an otherwise Qt-less system would cause weird errors.
+
+Qt6 ports had various updates:
+
+* package:devel/qt6-tools[] was repaired when building with Clang 16. This is preparation for the upcoming release of FreeBSD 14.
+
+The package:accessibility/at-spi2-core[] port -- essential for accessible technologies on the desktop -- was updated to release 2.48.0.
+
+The package:accessibility/at-spi2-core[] port now has better support for non-X11 desktops. This is an improvement for Wayland-based systems. Thanks to Jan Beich for landing that.
+
+The package:graphics/poppler[] port -- a base for many PDF viewers -- was updated to 23.05.
+
+The package::ports-mgmt/packagekit-qt[] port is a new addition to the tree to pave the way for graphical package managers on FreeBSD.
 
 ==== KDE Stack
 
@@ -34,7 +40,6 @@ These (large) updates land shortly after their upstream release and are not list
 * KDE Frameworks updated to 5.105, .106 and .107.
 * KDE Gear updated to 23.04.0, then .1 and .2 with bugfixes.
 * KDE Plasma Desktop was updated to version 5.27.4, then .5 and .6 with bugfixes.
-
 
 ==== Related Ports
 

--- a/website/content/en/status/report-2023-04-2023-06/kde.adoc
+++ b/website/content/en/status/report-2023-04-2023-06/kde.adoc
@@ -2,7 +2,7 @@
 
 Links: +
 link:https://freebsd.kde.org/[KDE/FreeBSD initiative] URL: link:https://freebsd.kde.org/[] +
-link:https://community.kde.org/FreeBSD[FreeBSD -- KDE Community Wiki] URL:link:https://community.kde.org/FreeBSD[]
+link:https://community.kde.org/FreeBSD[FreeBSD -- KDE Community Wiki] URL: link:https://community.kde.org/FreeBSD[]
 
 Contact: Adriaan de Groot <kde@FreeBSD.org>
 


### PR DESCRIPTION
`URL:link:https://⋯` is not valid. Related: 

- #223

The phrase 'The graphics/poppler' should be followed by the word 'port'.

Whilst here: 

- make more use of normal paragraphs
- other minor changes.

----

Fixes: b2678db626 Status/2023Q2/kde.adoc: Add report