### PR TITLE
status: 2023q2: squashfs support for freebsd kernel

### DIFF
--- a/website/content/en/status/report-2023-04-2023-06/squashfs.adoc
+++ b/website/content/en/status/report-2023-04-2023-06/squashfs.adoc
@@ -1,0 +1,20 @@
+=== SquashFS port for FreeBSD kernel
+
+Links: +
+link:https://wiki.freebsd.org/SummerOfCode2023Projects/PortSquashFuseToTheFreeBSDKernel[wiki page] +
+link:https://github.com/Mashijams/freebsd-src/tree/gsoc/squashfs[source code]
+
+Contact: Raghav Sharma <raghav@FreeBSD.org>
+
+SquashFS is a read-only file system that lets you compress whole file systems or single directories very efficiently.
+Support for it has been built into the Linux kernel since 2009 and is very common in embedded Linux distributions.
+The goal of this project is to add SquashFS support for the FreeBSD kernel, with the aim of being able to boot FreeBSD from an in-memory SquashFS file system.
+
+Currently, the driver is compatible with the 13.2 FreeBSD release.
+The driver is able to correctly parse the SquashFS disk file with working mount(8) support.
+Linux SquashFS supports many compression options like zstd, lzo2, zlib, etc... based on the user's preference, and of course, our driver supports all those compressions as well.
+
+Planned future work includes adding directories, files, extended attributes, and symlinks read support.
+The project is still a work in progress under the mentorship from mailto:chuck@FreeBSD.org[Chuck Tuffli] and is expected to complete by the end of the Google Summer of Code program.
+
+Sponsor: The Google Summer of Code 2023 program

--- a/website/content/en/status/report-2023-04-2023-06/squashfs.adoc
+++ b/website/content/en/status/report-2023-04-2023-06/squashfs.adoc
@@ -1,8 +1,8 @@
 === SquashFS port for FreeBSD kernel
 
 Links: +
-link:https://wiki.freebsd.org/SummerOfCode2023Projects/PortSquashFuseToTheFreeBSDKernel[wiki page] +
-link:https://github.com/Mashijams/freebsd-src/tree/gsoc/squashfs[source code]
+link:https://wiki.freebsd.org/SummerOfCode2023Projects/PortSquashFuseToTheFreeBSDKernel[Wiki page] URL: link:https://wiki.freebsd.org/SummerOfCode2023Projects/PortSquashFuseToTheFreeBSDKernel[] +
+link:https://github.com/Mashijams/freebsd-src/tree/gsoc/squashfs[Source code] URL:  link:https://github.com/Mashijams/freebsd-src/tree/gsoc/squashfs[]
 
 Contact: Raghav Sharma <raghav@FreeBSD.org>
 
@@ -11,7 +11,7 @@ Support for it has been built into the Linux kernel since 2009 and is very commo
 The goal of this project is to add SquashFS support for the FreeBSD kernel, with the aim of being able to boot FreeBSD from an in-memory SquashFS file system.
 
 Currently, the driver is compatible with the 13.2 FreeBSD release.
-The driver is able to correctly parse the SquashFS disk file with working mount(8) support.
+The driver is able to correctly parse the SquashFS disk file with working man:mount[8] support.
 Linux SquashFS supports many compression options like zstd, lzo2, zlib, etc... based on the user's preference, and of course, our driver supports all those compressions as well.
 
 Planned future work includes adding directories, files, extended attributes, and symlinks read support.


### PR DESCRIPTION
This is a 2023Q2 status report for the SquashFS port to FreeBSD kernel GSoC project.