### PR TITLE
ZFS: fix a typo

### DIFF
--- a/documentation/content/en/books/handbook/zfs/_index.adoc
+++ b/documentation/content/en/books/handbook/zfs/_index.adoc
@@ -2065,7 +2065,7 @@ usr/home/joe        1.3G     31k    1.3G     0%    /usr/home/joe
 usr/home/joenew     1.3G     31k    1.3G     0%    /usr/home/joenew
 ....
 
-Creating a clone makes it an exact copy of the state the dataset as it was when taking the snapshot.
+Creating a clone makes it an exact copy of the state the dataset was in when taking the snapshot.
 Changing the clone independently from its originating dataset is possible now.
 The connection between the two is the snapshot.
 ZFS records this connection in the property `origin`.


### PR DESCRIPTION
Managing Clones

https://docs.freebsd.org/en/books/handbook/zfs/

'Creating a clone makes it an exact copy of the state the dataset as it was when taking the snapshot.'

– is fixed to 'the state the dataset was in'.