### PR TITLE
Update ifapi.adoc

### DIFF
--- a/website/content/en/status/report-2023-04-2023-06/ifapi.adoc
+++ b/website/content/en/status/report-2023-04-2023-06/ifapi.adoc
@@ -1,7 +1,7 @@
 === Network Interface API (IfAPI)
 
-Links: +
-link:https://wiki.freebsd.org/projects/ifnet[Original project page] URL: link:https://wiki.freebsd.org/projects/ifnet
+Link: +
+link:https://wiki.freebsd.org/projects/ifnet[Original project page] URL: link:https://wiki.freebsd.org/projects/ifnet[]
 
 Contact: Justin Hibbits <jhibbits@FreeBSD.org>
 


### PR DESCRIPTION
https://www.freebsd.org/status/report-2023-04-2023-06/#_network_interface_api_ifapi

- link: prefix is visible
- the result is not a link.

Fix breakage that would not have occurred without the contentious link: prefix