### PR TITLE
Update simd.adoc

### DIFF
--- a/website/content/en/status/report-2023-04-2023-06/simd.adoc
+++ b/website/content/en/status/report-2023-04-2023-06/simd.adoc
@@ -2,7 +2,7 @@
 
 Links: +
 link:https://reviews.freebsd.org/D40693[SIMD dispatch framework draft] URL: link:https://reviews.freebsd.org/D40693[] +
-link:http://fuz.su/~fuz/freebsd/2023-04-05_libc-proposal.txt[Project proposal] URL: link:http://fuz.su/~fuz/freebsd/2023-04-05_libc-proposal.txt
+link:http://fuz.su/~fuz/freebsd/2023-04-05_libc-proposal.txt[Project proposal] URL: link:http://fuz.su/~fuz/freebsd/2023-04-05_libc-proposal.txt[]
 
 Contact: Robert Clausecker <clausecker@FreeBSD.org>
 


### PR DESCRIPTION
https://www.freebsd.org/status/report-2023-04-2023-06/#_simd_enhancements_for_amd64

- link: prefix is visible
- the result is not a link

Fix breakage that would not have occurred without the contentious link: prefix