### PR TITLE
Update portmgr.adoc

### DIFF
--- a/website/content/en/status/report-2023-04-2023-06/portmgr.adoc
+++ b/website/content/en/status/report-2023-04-2023-06/portmgr.adoc
@@ -22,7 +22,7 @@ During this quarter, we welcomed back Tom Judge (tj@) and said goodbye to Steve 
 Steve was also on portmgr.
 As part of the portmgr lurker program, we welcomed Ronald Klop (ronald@), Renato Botelho (garga@), and Matthias Andree (mandree@).
 
-Portmgr has resumed work on introducing sub-packages into the Tree, but various things still needs to be fleshed out.
+Portmgr has resumed work on introducing sub-packages into the Tree, but various things still need to be fleshed out.
 
 On the software side, pkg was updated to 1.19.2, Firefox to 114.0.2, Chromium to 114.0.5735.198, and KDE Gear to 23.04.2.
 During this quarter, antoine@ ran 23 exp-runs to test package updates, bump CPU_MAXSIZE to 1024, fix armv7 failures for devel/cmake-core and add --auto-features=enabled to USES=meson

--- a/website/content/en/status/report-2023-04-2023-06/portmgr.adoc
+++ b/website/content/en/status/report-2023-04-2023-06/portmgr.adoc
@@ -11,11 +11,11 @@ Contact: René Ladan <portmgr-secretary@FreeBSD.org> +
 Contact: FreeBSD Ports Management Team <portmgr@FreeBSD.org>
 
 The Ports Management Team is responsible for overseeing the overall direction of the Ports Tree, building packages, and personnel matters.
-Below is what happened in the last quarter.
+Below is what happened in this quarter.
 
 Currently there are just over 34,400 ports in the Ports Tree.
 There are currently 3,019 open ports PRs of which 746 are unassigned.
-The last quarter saw 10,439 commits on the `main` branch by 151 committers and 745 commits on the `2023Q2` branch by 55 committers.
+This quarter saw 10,439 commits on the `main` branch by 151 committers and 745 commits on the `2023Q2` branch by 55 committers.
 Compared to the previous quarter, this means a slight increase in the number of ports, a tiny decrease in the number of open PRs, and a fair increase in the number of ports commits.
 
 During this quarter, we welcomed back Tom Judge (tj@) and said goodbye to Steve Wills (swills@).
@@ -25,5 +25,5 @@ As part of the portmgr lurker program, we welcomed Ronald Klop (ronald@), Renato
 Portmgr has resumed work on introducing sub-packages into the Tree, but various things still needs to be fleshed out.
 
 On the software side, pkg was updated to 1.19.2, Firefox to 114.0.2, Chromium to 114.0.5735.198, and KDE Gear to 23.04.2.
-During the last quarter, antoine@ ran 23 exp-runs to test package updates, bump CPU_MAXSIZE to 1024, fix armv7 failures for devel/cmake-core and add --auto-features=enabled to USES=meson
+During this quarter, antoine@ ran 23 exp-runs to test package updates, bump CPU_MAXSIZE to 1024, fix armv7 failures for devel/cmake-core and add --auto-features=enabled to USES=meson
 Lastly, the Ports Tree was updated to support LLVM 16 and OpenSSL 3 in FreeBSD-CURRENT.


### PR DESCRIPTION
Preamble https://www.freebsd.org/status/report-2023-04-2023-06/#preamble put _the last quarter_ in context. It was: 

- quarter one.

https://www.freebsd.org/status/report-2023-04-2023-06/#_ports_collection should be consistent. If the quarter (two) to which the report relates is to be described, it should not be described as last quarter. 

Either be consistent (this PR as is), or remove the superfluous phrases. It all falls under the heading of: 

# FreeBSD Status Report Second Quarter 2023 | The FreeBSD Project 