### PR TITLE
Update _index.adoc

### DIFF
--- a/website/content/en/status/report-2023-04-2023-06/_index.adoc
+++ b/website/content/en/status/report-2023-04-2023-06/_index.adoc
@@ -29,6 +29,8 @@ toc::[]
 
 {FreeBSD-Team-Reports-desc}
 
+'''
+
 include::{reports-path}/core.adoc[]
 
 '''
@@ -104,6 +106,8 @@ include::{reports-path}/nvmf.adoc[]
 
 {kernel-desc}
 
+'''
+
 include::{reports-path}/boot-performance.adoc[]
 
 '''
@@ -141,6 +145,8 @@ include::{reports-path}/epoch-netgraph.adoc[]
 
 {architectures-desc}
 
+'''
+
 include::{reports-path}/simd.adoc[]
 
 '''
@@ -153,6 +159,8 @@ include::{reports-path}/mfsbsd.adoc[]
 == Cloud
 
 {cloud-desc}
+
+'''
 
 include::{reports-path}/cloud-init.adoc[]
 
@@ -175,6 +183,8 @@ include::{reports-path}/ec2.adoc[]
 
 {documentation-desc}
 
+'''
+
 include::{reports-path}/doceng.adoc[]
 
 '''
@@ -183,6 +193,8 @@ include::{reports-path}/doceng.adoc[]
 == Ports
 
 {ports-desc}
+
+'''
 
 include::{reports-path}/kde.adoc[]
 
@@ -208,6 +220,8 @@ include::{reports-path}/wazuh.adoc[]
 == Third Party Projects
 
 {third-Party-Projects-desc}
+
+'''
 
 include::{reports-path}/pkgbase.live.adoc[]
 


### PR DESCRIPTION
Consistent use of dividing lines. 

The line that's already under <https://www.freebsd.org/status/report-2023-04-2023-06/#projects> looks good to me. 