### PR TITLE
Update pf.adoc

### DIFF
--- a/website/content/en/status/report-2023-04-2023-06/pf.adoc
+++ b/website/content/en/status/report-2023-04-2023-06/pf.adoc
@@ -40,6 +40,6 @@ Naman finished the work started by Luiz Amaral.
 There is work in progress to support SCTP in pf.
 That support includes filtering on port numbers, state tracking, pfsync failover and returning ABORT chunks for rejected connections.
 
-Sponsor: InnoGames GmbH
-Sponsor: Orange Business Services
+Sponsor: InnoGames GmbH +
+Sponsor: Orange Business Services +
 Sponsor: The FreeBSD Foundation

--- a/website/content/en/status/report-2023-04-2023-06/pf.adoc
+++ b/website/content/en/status/report-2023-04-2023-06/pf.adoc
@@ -1,4 +1,4 @@
-=== pf Improvements
+=== Pf Improvements
 
 Links: +
 link:https://reviews.freebsd.org/D40911[D40911] URL: link:https://reviews.freebsd.org/D40911[] +

--- a/website/content/en/status/report-2023-04-2023-06/pf.adoc
+++ b/website/content/en/status/report-2023-04-2023-06/pf.adoc
@@ -1,4 +1,4 @@
-=== Pf Improvements
+=== pf Improvements
 
 Links: +
 link:https://reviews.freebsd.org/D40911[D40911] URL: link:https://reviews.freebsd.org/D40911[] +


### PR DESCRIPTION
https://www.freebsd.org/status/report-2023-04-2023-06/#_pf_improvements

~~Subheadings that begin 'pfsync' are true to lowercase.~~ 

~~Be true for the primary subheading that begins 'pf'.~~

Fix the lines for the three sponsors (there should be three lines, not a single line for all sponsors). 