### PR TITLE
Committer's Guide: Fix a typo

### DIFF
--- a/documentation/content/en/articles/committers-guide/_index.adoc
+++ b/documentation/content/en/articles/committers-guide/_index.adoc
@@ -2851,7 +2851,7 @@ Once your question is answered, if no one pointed you to documentation that spel
 == Bugzilla
 
 The FreeBSD Project utilizes Bugzilla for tracking bugs and change requests.
-Be sure that if you commit a fix or suggestion found in the PR database to close it.
+Be sure that, if you commit a fix or suggestion found in the PR database, close it.
 It is also considered nice if you take time to close any PRs associated with your commits, if appropriate.
 
 Committers with non-``FreeBSD.org`` Bugzilla accounts can have the old account merged with the `FreeBSD.org` account by following these steps:


### PR DESCRIPTION
Bugzilla

https://docs.freebsd.org/en/articles/committers-guide/#bugzilla

'Be sure that if you commit a fix or suggestion found in the PR database to close it.'

-- is fixed to 'Be sure that, if you commit a fix or suggestion found in the PR database, close it.'