### PR TITLE
Writing style: additions, improvements

### DIFF
--- a/documentation/content/en/books/fdp-primer/writing-style/_index.adoc
+++ b/documentation/content/en/books/fdp-primer/writing-style/_index.adoc
@@ -198,7 +198,7 @@ There are two conventions.
 
 This generalization includes monospaced representation of monospaced texts that do _not_ follow the two spaces convention.
 
-Where a variable-width font will be used: the per-line convention, above, will usually negate the need to think about spacing. 
+Where a variable-width font will be used: the link:{one-sentence-per-line}[per-line convention] will usually negate the need to think about spacing. 
 
 If a multi-sentence list item does use a space between sentences (with the possibility of strictly replacing the space with a line break): 
 

--- a/documentation/content/en/books/fdp-primer/writing-style/_index.adoc
+++ b/documentation/content/en/books/fdp-primer/writing-style/_index.adoc
@@ -187,6 +187,32 @@ All human beings are born free and equal in dignity and rights.
 They are endowed with reason and conscience and should act towards one another in a spirit of brotherhood.
 ....
 
+[[sentence-spacing]]
+=== Spaces between sentences
+
+There are two conventions.
+
+*Generally*: 
+
+* one space. 
+
+This generalization includes monospaced representation of monospaced texts that do _not_ follow the two spaces convention.
+
+Where a variable-width font will be used: the per-line convention, above, will usually negate the need to think about spacing. 
+
+If a multi-sentence list item does use a space between sentences (with the possibility of strictly replacing the space with a line break): 
+
+* consider edition, to have no more than one sentence per point
+** do not assume that nesting of points is the solution
+** instead, an adjacent bullet point might be promoted to a simple paragraph.
+
+*Exceptionally*: 
+
+* two spaces in errata notices
+* two spaces in security advisories
+* two spaces in manual pages (in the `src` tree, for example)
+* two spaces in other files that will normally be viewed with a monospaced font.
+
 [[writing-style-acronyms]]
 === Acronyms
 

--- a/documentation/content/en/books/fdp-primer/writing-style/_index.adoc
+++ b/documentation/content/en/books/fdp-primer/writing-style/_index.adoc
@@ -352,7 +352,7 @@ This rule proposes better wording.
 
 . FreeBSD.Hyphens: Often adverbs ending with 'ly' are added with a hyphen which is wrong.
 
-. FreeBSD.Spacing: Often double spaces are hard to catch with the naked eye and this is addressed here.
+. FreeBSD.Spacing: Between a pair of sentences, it may be incorrect to have two spaces (see link:{sentence-spacing}[spacing between sentences]). 
 
 . FreeBSD.SuperfluousOptArgInLinks: Suggest to empty square brackets in `link:` macros when the displayed text coincides with the URL.
 

--- a/documentation/content/en/books/fdp-primer/writing-style/_index.adoc
+++ b/documentation/content/en/books/fdp-primer/writing-style/_index.adoc
@@ -154,11 +154,16 @@ Wrong: ... in the filename [.filename]#/etc/rc.local#...
 +
 Right: ... in [.filename]#/etc/rc.local#...
 +
-Manual page references (the second example uses `man:[]` with the man:csh[1] entity):
+Manual page references:
 +
 Wrong: See `man csh` for more information.
 +
 Right: See man:csh[1].
+
+[TIP]
+====
+`man:csh[1]` -- `man:` for the FreeBSD-defined _ManPageMacro_, `csh` names a page and `[1]` specifies the section of the manual from which the named page is taken.
+====
 
 For more information about writing style, see http://www.bartleby.com/141/[Elements of Style] by William Strunk.
 

--- a/documentation/content/en/books/fdp-primer/writing-style/_index.adoc
+++ b/documentation/content/en/books/fdp-primer/writing-style/_index.adoc
@@ -216,7 +216,7 @@ If a multi-sentence list item does use a space between sentences (with the possi
 [[writing-style-acronyms]]
 === Acronyms
 
-Acronyms should be defined the first time they appear in a document, as in: "Network Time Protocol (NTP)".
+Acronyms should be defined the first time they appear in a document, as in: "Network Time Protocol (`NTP`)".
 After the acronym has been defined, use the acronym alone unless it makes more sense contextually to use the whole term.
 Acronyms are usually defined only once per chapter or per document.
 

--- a/documentation/content/en/books/fdp-primer/writing-style/_index.adoc
+++ b/documentation/content/en/books/fdp-primer/writing-style/_index.adoc
@@ -210,7 +210,7 @@ If a multi-sentence list item does use a space between sentences (with the possi
 
 * two spaces in errata notices
 * two spaces in security advisories
-* two spaces in manual pages (in the `src` tree, for example)
+* two spaces in link:../manual-pages/[manual pages]
 * two spaces in other files that will normally be viewed with a monospaced font.
 
 [[writing-style-acronyms]]

--- a/documentation/content/en/books/fdp-primer/writing-style/_index.adoc
+++ b/documentation/content/en/books/fdp-primer/writing-style/_index.adoc
@@ -204,7 +204,7 @@ If a multi-sentence list item does use a space between sentences (with the possi
 
 * consider edition, to have no more than one sentence per point
 ** do not assume that nesting of points is the solution
-** instead, an adjacent bullet point might be promoted to a simple paragraph.
+*** as an alternive to nesting, consider de-nesting nearby text -- for example, adjacent bullet points might be promoted to simple paragraphs.
 
 *Exceptionally*: 
 

--- a/documentation/content/en/books/fdp-primer/writing-style/_index.adoc
+++ b/documentation/content/en/books/fdp-primer/writing-style/_index.adoc
@@ -168,7 +168,7 @@ For more information about writing style, see http://www.bartleby.com/141/[Eleme
 To keep the source for the documentation consistent when many different people are editing it, please follow these style conventions.
 
 [[one-sentence-per-line]]
-== One sentence per line
+=== One sentence per line
 
 Use Semantic Line Breaks in the documentation, a technique called "one sentence per line".
 The idea of this technique is to help the users to write and read documentation.
@@ -188,7 +188,7 @@ They are endowed with reason and conscience and should act towards one another i
 ....
 
 [[writing-style-acronyms]]
-== Acronyms
+=== Acronyms
 
 Acronyms should be defined the first time they appear in a document, as in: "Network Time Protocol (NTP)".
 After the acronym has been defined, use the acronym alone unless it makes more sense contextually to use the whole term.


### PR DESCRIPTION
https://docs.freebsd.org/en/books/fdp-primer/writing-style/

The two existing conventions should not be headed at the same level as the heading that pleads for writers to follow the two.

Add the conventions that apply to spacing between sentences.

Mark up an acronym, as it should be marked.

Demonstrate the macro:page[section] approach to linking to a manual page.

Attention to the listing for the FreeBSD-defined FreeBSD.Spacing rule for Vale.