### PR TITLE
Fix broken link in porters-handbook

### DIFF
--- a/documentation/content/en/books/porters-handbook/upgrading/_index.adoc
+++ b/documentation/content/en/books/porters-handbook/upgrading/_index.adoc
@@ -51,7 +51,7 @@ When a port is not the most recent version available from the authors, update th
 The port might have already been updated to the new version.
 
 When working with more than a few ports, it will probably be easier to use Git to keep the whole ports collection up-to-date,
-as described in the extref:{handbook}[Handbook, ports-using].
+as described in the extref:{handbook}ports[Using the Ports Collection, ports-using].
 This will have the added benefit of tracking all the port's dependencies.
 
 The next step is to see if there is an update already pending.


### PR DESCRIPTION
Currently the `ports-using` macro is rendered as https://docs.freebsd.org/en/books/handbook#ports-using, which doesn't look right.

This commit changes the rendered link to https://docs.freebsd.org/en/books/handbook/ports#ports-using.