### PR TITLE
Status: 2023q3: desktop convenience: changes

### DIFF
--- a/website/content/en/status/report-2023-07-2023-09/desktop-convenience.adoc
+++ b/website/content/en/status/report-2023-07-2023-09/desktop-convenience.adoc
@@ -9,17 +9,17 @@ link:https://github.com/outpaddling/freebsd-update-notify[Popup notification for
 Contact: Jason Bacon <jwb@FreeBSD.org>
 
 The package:sysutils/desktop-installer[] port, available for over a decade now, quickly configures a bare FreeBSD system with any desktop environment or window manager.
-However, the FreeBSD base and ports collection has been missing some common features that end users have come to expect from a desktop OS.
+However, the FreeBSD base and ports collection has been missing some common features that end users expect from a desktop OS.
 
 The desktop-installer battery monitor script has been enhanced to display popup notifications at various levels of charge/discharge.
 
-The new port, package:deskutils/qmediamanager[], in conjunction with package:sysutils/devd-mount[] and package:sysutils/npmount[], mounts inserted media upon notification from devd, and displays a popup window offering the user options to show filesystem information, open a file manager, reformat, copy a disk image to the device, or unmount.
+package:deskutils/qmediamanager[], in conjunction with package:sysutils/devd-mount[] and package:sysutils/npmount[], mounts inserted media upon notification from devd, and displays a popup window offering the user options to show filesystem information, open a file manager, reformat, copy a disk image to the device, or unmount.
 It provides a convenient and secure way to work with external media such as USB sticks.
 
-The package:sysutils/freebsd-update-notify[] port displays a popup when new base updates are available, or when a configurable time limit has elapsed.
+A fourth new port -- package:deskutils/freebsd-update-notify[] -- displays a popup when new base updates are available, or when a configurable time limit has elapsed.
 If the user chooses to proceed with updates, the entire system is updated (packages, ports, and base) with auto-update-system (part of package:sysutils/auto-admin[]).
 
 These new tools bring the FreeBSD desktop experience a step closer to the convenience of the most popular desktop operating systems.
 
-These tools are effectively prototypes, stable and reliable, but in need of review.
-Feedback from users regarding default behavior and configuration options would be appreciated.
+The tools are effectively prototypes, stable and reliable, but in need of review.
+Feedback from users regarding default behavior and configuration options will be appreciated.

--- a/website/content/en/status/report-2023-07-2023-09/desktop-convenience.adoc
+++ b/website/content/en/status/report-2023-07-2023-09/desktop-convenience.adoc
@@ -17,7 +17,7 @@ package:deskutils/qmediamanager[], in conjunction with package:sysutils/devd-mou
 It provides a convenient and secure way to work with external media such as USB sticks.
 
 A fourth new port -- package:deskutils/freebsd-update-notify[] -- displays a popup when new base updates are available, or when a configurable time limit has elapsed.
-If the user chooses to proceed with updates, the entire system is updated (packages, ports, and base) with auto-update-system (part of package:sysutils/auto-admin[]).
+If the user chooses to proceed with updates, the entire system is updated (packages, ports, and base) with man:auto-update-system[1] (a feature of package:sysutils/auto-admin[]).
 
 These new tools bring the FreeBSD desktop experience a step closer to the convenience of the most popular desktop operating systems.
 


### PR DESCRIPTION
One correction. 

A few suggested changes, some of which should make clear that there are four new ports. The four, in order of appearance within the report: 

- <https://www.freshports.org/deskutils/qmediamanager/>
- <https://www.freshports.org/sysutils/devd-mount/>
- <https://www.freshports.org/sysutils/npmount/>
- <https://www.freshports.org/deskutils/freebsd-update-notify/>.

----

As this relates to a [status report](https://github.com/freebsd/freebsd-doc/pulls?q=is%3Apr+label%3A%22status+report%22), please treat it as an exception to the rule that excludes my PRs from this repository. Thank you.