### PR TITLE
Update _index.adoc Change geli algo refs to match current offerings

### DIFF
--- a/documentation/content/en/books/handbook/disks/_index.adoc
+++ b/documentation/content/en/books/handbook/disks/_index.adoc
@@ -2171,7 +2171,7 @@ The size of the blocks data is broken into before it is encrypted.
 Larger sector sizes increase performance at the cost of higher storage overhead.
 The recommended size is 4096 bytes.
 
-This example configures an encrypted swap partition using the Blowfish algorithm with a key length of 128 bits and a sectorsize of 4 kilobytes:
+This example configures an encrypted swap partition using the AES-XTS algorithm with a key length of 128 bits and a sectorsize of 4 kilobytes:
 
 [.programlisting]
 ....

--- a/documentation/content/en/books/handbook/disks/_index.adoc
+++ b/documentation/content/en/books/handbook/disks/_index.adoc
@@ -1976,7 +1976,7 @@ This control utility adds some features and uses a different scheme for doing cr
 It provides the following features:
 
 * Utilizes the man:crypto[9] framework and automatically uses cryptographic hardware when it is available.
-* Supports multiple cryptographic algorithms such as AES-XTS,  AES-CBC, and Camellia-CBCAES.
+* Supports multiple cryptographic algorithms such as AES-XTS, AES-CBC, and Camellia-CBCAES.
 * Allows the root partition to be encrypted. The passphrase used to access the encrypted root partition will be requested during system boot.
 * Allows the use of two independent keys.
 * It is fast as it performs simple sector-to-sector encryption.

--- a/documentation/content/en/books/handbook/disks/_index.adoc
+++ b/documentation/content/en/books/handbook/disks/_index.adoc
@@ -1976,7 +1976,7 @@ This control utility adds some features and uses a different scheme for doing cr
 It provides the following features:
 
 * Utilizes the man:crypto[9] framework and automatically uses cryptographic hardware when it is available.
-* Supports multiple cryptographic algorithms such as AES, Blowfish, and 3DES.
+* Supports multiple cryptographic algorithms such as AES-XTS,  AES-CBC, and Camellia-CBCAES.
 * Allows the root partition to be encrypted. The passphrase used to access the encrypted root partition will be requested during system boot.
 * Allows the use of two independent keys.
 * It is fast as it performs simple sector-to-sector encryption.

--- a/documentation/content/en/books/handbook/disks/_index.adoc
+++ b/documentation/content/en/books/handbook/disks/_index.adoc
@@ -2176,7 +2176,7 @@ This example configures an encrypted swap partition using the Blowfish algorithm
 [.programlisting]
 ....
 # Device		Mountpoint	FStype	Options				Dump	Pass#
-/dev/ada0s1b.eli	none		swap	sw,ealgo=blowfish,keylen=128,sectorsize=4096	0	0
+/dev/ada0s1b.eli	none		swap	sw,ealgo=AES-XTS,keylen=128,sectorsize=4096	0	0
 ....
 
 === Encrypted Swap Verification


### PR DESCRIPTION
Current example of blowfish is no longer an option and geli(8) says AES-XTS is the default.