### PR TITLE
Status: 2023q3: Valgrind: correction, changes

### DIFF
--- a/website/content/en/status/report-2023-07-2023-09/valgrind.adoc
+++ b/website/content/en/status/report-2023-07-2023-09/valgrind.adoc
@@ -20,5 +20,5 @@ As usual there are numerous small bugfixes.
 Specific to FreeBSD there is now support for FreeBSD 15.
 Two extra `_umtx_op` operations are now supported, `UMTX_OP_GET_MIN_TIMEOUT` and `UMTX_OP_SET_MIN_TIMEOUT`.
 There is a fix for the use of sysctl kern proc pathname with the guest pid or -1, which previously returned the path of the Valgrind host.
-The sysctl will now return the name of the guest.
+The sysctl will now return the path of the guest.
 Support for the `close_range` system call has been added.

--- a/website/content/en/status/report-2023-07-2023-09/valgrind.adoc
+++ b/website/content/en/status/report-2023-07-2023-09/valgrind.adoc
@@ -6,7 +6,7 @@ link:https://www.valgrind.org/docs/manual/dist.news.html[Valgrind News] URL: lin
 
 Contact: Paul Floyd <pjfloyd@wanadoo.fr>
 
-The package:devel/valgrind-devel[] is in the process of being updated.
+package:devel/valgrind-devel[] is in the process of being updated.
 This contains most of what will be in the official release of Valgrind 3.22 due out in October.
 
 `memcheck` has been enhanced with some more checks.
@@ -19,5 +19,6 @@ As usual there are numerous small bugfixes.
 
 Specific to FreeBSD there is now support for FreeBSD 15.
 Two extra `_umtx_op` operations are now supported, `UMTX_OP_GET_MIN_TIMEOUT` and `UMTX_OP_SET_MIN_TIMEOUT`.
-There is a fix for the use of sysctl kern proc pathname with the guest pid or -1 which previously returned the path of the Valgrind host. The sysctl will now return the name of the guest.
+There is a fix for the use of sysctl kern proc pathname with the guest pid or -1, which previously returned the path of the Valgrind host.
+The sysctl will now return the name of the guest.
 Support for the `close_range` system call has been added.


### PR DESCRIPTION
Grammar: 'devel/valgrind-devel' is not followed by the word 'port', so do not precede by the word 'The'.

Other suggested changes, minor.