### PR TITLE
Status/2023Q3/openssl3.adoc: Add report

### DIFF
--- a/website/content/en/status/report-2023-07-2023-09/openssl3.adoc
+++ b/website/content/en/status/report-2023-07-2023-09/openssl3.adoc
@@ -1,0 +1,25 @@
+=== OpenSSL 3 in base - improved
+
+Links: +
+link:https://www.openssl.org/source/[OpenSSL Downloads] URL: link:https://www.openssl.org/source/[]
+
+Contact: Pierre Pronchery <pierre@freebsdfoundation.org>
+
+This is a follow-up to the link:https://www.freebsd.org/status/report-2023-04-2023-06/[previous quarterly report] on the link:https://www.freebsd.org/status/report-2023-04-2023-06/#_openssl_3_in_base[integration of OpenSSL 3 into the base system].
+
+The most obvious update since the previous report is certainly the 3.0.10 and then 3.0.11 releases, fixing CVE issues with low to medium severity (link:https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2023-2975[CVE-2023-2975], link:https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2023-3446[CVE-2023-3446], link:https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2023-3817[CVE-2023-3817], link:https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2023-4807[CVE-2023-4807]).
+
+However this is not the only change, and this quarter some issues specific to the integration were fixed, most of which were found while building ports with OpenSSL 3 in the base system.
+This included:
+
+* Linking the engines and the legacy provider with the libcrypto.so shared object, for proper visibility of symbols, and for which a link:https://cgit.freebsd.org/src/commit/Makefile.inc1?id=1a18383a52bc373e316d224cef1298debf6f7e25[hack was required in the build system].
+* Correcting the list of source files for the FIPS provider.
+* Ensuring backward compatibility for the deprecated 0.9.8 API, which was notably helpful for the PAM authentication module from link:https://www.freshports.org/security/pam_ssh_agent_auth/[security/pam_ssh_agent_auth], based on OpenSSH's link:https://man.freebsd.org/cgi/man.cgi?ssh-agent(1)[ssh-agent] authentication mechanism.
+
+The kernel was also affected, as the former assembly-optimized algorithms provided by OpenSSL's 1.1.1 series were link:https://cgit.freebsd.org/src/commit/sys/crypto/openssl?id=c0855eaa3ee9614804b6bd6a255aa9f71e095f43[replaced by their newer equivalents] from OpenSSL 3.
+Last but not least there is exciting work in progress for the aarch64 platform, with support for the BTI and pointer authentication security mitigations link:https://reviews.freebsd.org/D41940[is being reviewed].
+
+Finally, unlike reported last time, it seems it will not be possible to ship the FIPS provider with a functional setup out of the box.
+This will be documented instead.
+
+Sponsor: The FreeBSD Foundation


### PR DESCRIPTION
This is another humble attempt at documenting the changes made to the integration of OpenSSL 3 into FreeBSD's base system, since the last quarter.