### PR TITLE
Fix typo in VNET Jail configuration example

### DIFF
--- a/documentation/content/en/books/handbook/jails/_index.adoc
+++ b/documentation/content/en/books/handbook/jails/_index.adoc
@@ -730,7 +730,7 @@ vnet {
   exec.prestart += "ifconfig ${bridge} addm ${epair}a up";
   exec.start    += "ifconfig ${epair}b ${ip} up";
   exec.start    += "route add default ${gateway}";
-  exec.poststop = "ifconfig ${$bridge} deletem ${epair}a";
+  exec.poststop = "ifconfig ${bridge} deletem ${epair}a";
   exec.poststop += "ifconfig ${epair}a destroy";
 }
 ....


### PR DESCRIPTION
I found this typo which caught me off guard with a confusing error when trying to create a VNET Jail for the first time.

I thought I would spend a few minutes to make a quick fix to send upstream. 👍