### PR TITLE
Status: 2023q3: Core: corrections, changes

### DIFF
--- a/website/content/en/status/report-2023-07-2023-09/core.adoc
+++ b/website/content/en/status/report-2023-07-2023-09/core.adoc
@@ -24,9 +24,9 @@ The proposal was approved by the Ports Management Team and will take effect at t
 
 ==== Deprecation of 32-bit platforms for FreeBSD 15
 
-Work is underway to mark support for 32-bit platforms as "deprecated" for FreeBSD 15.
+Work is underway to mark support for 32-bit platforms as "deprecated".
 
-==== Matrix IM
+==== Matrix
 
 The testing of the Matrix instance and the Element-web client is still in progress.
 
@@ -34,8 +34,8 @@ The beta is planned to be released after EuroBSDCon in September.
 
 ==== Improve Commit Bit Expiration Policy
 
-The Core Team will clarify how to update the PGP key once a developer has become Alumni.
+The Core Team will clarify how to update the PGP key once a developer has become alumna or alumnus.
 
 == EuroBSDCon
 
-Core Team members met with the FreeBSD Foundation in Coimbra during EuroBSDcon to discuss the direction of the project in Coimbra.
+Core Team members met with the FreeBSD Foundation in Coimbra during EuroBSDcon to discuss the direction of the Project.

--- a/website/content/en/status/report-2023-07-2023-09/core.adoc
+++ b/website/content/en/status/report-2023-07-2023-09/core.adoc
@@ -28,7 +28,7 @@ Work is underway to mark support for 32-bit platforms as "deprecated".
 
 ==== Matrix
 
-The testing of the Matrix instance and the Element-web client is still in progress.
+The testing of the Matrix instance and the Element web client is still in progress.
 
 The beta is planned to be released after EuroBSDCon in September.
 

--- a/website/content/en/status/report-2023-07-2023-09/core.adoc
+++ b/website/content/en/status/report-2023-07-2023-09/core.adoc
@@ -36,6 +36,6 @@ The beta is planned to be released after EuroBSDCon in September.
 
 The Core Team will clarify how to update the PGP key once a developer has become alumna or alumnus.
 
-== EuroBSDCon
+=== EuroBSDCon
 
 Core Team members met with the FreeBSD Foundation in Coimbra during EuroBSDcon to discuss the direction of the Project.


### PR DESCRIPTION
Heading levels.

Grammar: a person (singular) can be alumna or alumnus, but not alumni (plural).

Project (not Project in Coimbra).

Uppercase P for Project (the FreeBSD Project).

Reduce repetition.

If Matrix is to be described in a single word, do not use the word 'IM'.  It is not simply text-based instant messaging.  

https://matrix.org/about/