### PR TITLE
Status: 2023: OpenSSL 3, base: markup, changes

### DIFF
--- a/website/content/en/status/report-2023-07-2023-09/openssl3.adoc
+++ b/website/content/en/status/report-2023-07-2023-09/openssl3.adoc
@@ -1,4 +1,4 @@
-=== OpenSSL 3 in base - improved
+=== OpenSSL 3 in base -- improved
 
 Links: +
 link:https://www.openssl.org/source/[OpenSSL Downloads] URL: link:https://www.openssl.org/source/[]
@@ -7,11 +7,11 @@ Contact: Pierre Pronchery <pierre@freebsdfoundation.org>
 
 This is a follow-up to the link:https://www.freebsd.org/status/report-2023-04-2023-06/[previous quarterly report] on the link:https://www.freebsd.org/status/report-2023-04-2023-06/#_openssl_3_in_base[integration of OpenSSL 3 into the base system].
 
-The most obvious update since the previous report is certainly the 3.0.10 and then 3.0.11 releases, fixing CVE issues with low to medium severity (link:https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2023-2975[CVE-2023-2975], link:https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2023-3446[CVE-2023-3446], link:https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2023-3817[CVE-2023-3817], link:https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2023-4807[CVE-2023-4807]).
+The most obvious updates since the previous report are certainly the 3.0.10 and then 3.0.11 releases, fixing CVE issues with low to medium severity (link:https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2023-2975[CVE-2023-2975], link:https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2023-3446[CVE-2023-3446], link:https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2023-3817[CVE-2023-3817], link:https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2023-4807[CVE-2023-4807]).
 
-However this is not the only change, and this quarter some issues specific to the integration were fixed, most of which were found while building ports with OpenSSL 3 in the base system.
+However these are not the only changes, and this quarter some issues specific to the integration were fixed, most of which were found while building ports with OpenSSL 3 in the base system.
 
-This included:
+Fixes included:
 
 * Linking the engines and the legacy provider with the libcrypto.so shared object, for proper visibility of symbols, and for which a link:https://cgit.freebsd.org/src/commit/Makefile.inc1?id=1a18383a52bc373e316d224cef1298debf6f7e25[hack was required in the build system].
 * Correcting the list of source files for the FIPS provider.


### PR DESCRIPTION
AsciiDoc: ' -- ' instead of ' - '.

Two updates are not a single update.