### PR TITLE
Status: 2023q3: SIMD: correction, specificity

### DIFF
--- a/website/content/en/status/report-2023-07-2023-09/simd.adoc
+++ b/website/content/en/status/report-2023-07-2023-09/simd.adoc
@@ -1,8 +1,8 @@
 === SIMD enhancements for amd64
 
 Links: +
-link:http://fuz.su/~fuz/freebsd/2023-04-05_libc-proposal.txt[Project proposal] URL: link:http://fuz.su/~fuz/freebsd/2023-04-05_libc-proposal.txt[]
-link:https://man.freebsd.org/cgi/man.cgi?query=simd&manpath=FreeBSD+15.0-CURRENT[simd(7)] URL: link:https://man.freebsd.org/cgi/man.cgi?query=simd&manpath=FreeBSD+15.0-CURRENT[]
+link:http://fuz.su/~fuz/freebsd/2023-04-05_libc-proposal.txt[Project proposal] URL: link:http://fuz.su/~fuz/freebsd/2023-04-05_libc-proposal.txt[] +
+link:https://man.freebsd.org/cgi/man.cgi?query=simd&sektion=7&manpath=FreeBSD+15.0-CURRENT[simd(7)] URL: link:https://man.freebsd.org/cgi/man.cgi?query=simd&sektion=7&manpath=FreeBSD+15.0-CURRENT[]
 
 Contact: Robert Clausecker <fuz@FreeBSD.org>
 

--- a/website/content/en/status/report-2023-07-2023-09/simd.adoc
+++ b/website/content/en/status/report-2023-07-2023-09/simd.adoc
@@ -12,7 +12,7 @@ The goal of this project is to provide SIMD-enhanced versions of common libc fun
 For each function optimised, up to four implementations will be provided:
 
  * a *scalar* implementation optimised for amd64, but without any SIMD usage,
- * a *baseline* implementation using SSE and SSE2 or alternatively an *x86-64-v2* implementation using all SSE extensions up to SSE4.2,
+ * either a *baseline* implementation using SSE and SSE2, or an *x86-64-v2* implementation using all SSE extensions up to SSE4.2,
  * an *x86-64-v3* implementation using AVX and AVX2, and
  * an *x86-64-v4* implementation using AVX-512F/BW/CD/DQ.
 


### PR DESCRIPTION
Markup: a hard line break between the first and second links.

Manual page: link to the specified section (7).

Use 'either …, or …' within the second of four list items.