### PR TITLE
Status: 2023q3: PortOptsCLI: corrections, changes

### DIFF
--- a/website/content/en/status/report-2023-07-2023-09/portoptscli.adoc
+++ b/website/content/en/status/report-2023-07-2023-09/portoptscli.adoc
@@ -1,4 +1,4 @@
-=== PortOptsCLI - Accessibility Ports Collection
+=== PortOptsCLI -- Ports Collection Accessibility
 
 Link: +
 link:https://gitlab.com/alfix/portoptscli[Project repository] URL: link:https://gitlab.com/alfix/portoptscli[]
@@ -8,15 +8,15 @@ Contact: FreeBSD Accessibility mailing list <freebsd-accessibility@freebsd.org>
 
 FreeBSD provides the Ports Collection to give users and administrators a simple way to install applications.
 It is possible to configure a port before the building and installation.
-The command 'make config' uses package:ports-mgmt/dialog4ports[] and package:ports-mgmt/portconfig[] to set up a port interactively via a Text User Interface.
+The command `make config` uses package:ports-mgmt/dialog4ports[] and package:ports-mgmt/portconfig[] to set up a port interactively via a text user interface (TUI).
 
-Unfortunately screen readers perform poorly with TUI; it is a well-known accessibility problem.
+Unfortunately, screen readers perform poorly with a TUI; it is a well-known accessibility problem.
 FreeBSD provides tens of thousands of ports; port configuration is a key feature, but it is inaccessible to users with vision impairment.
 
-PortOptsCLI (Port Options CLI) is a new utility for setting the port options via a Command Line Interface.
-Properly PortOptsCLI provides commands to navigate the configuration lists (checklists and/or radiolists) and set up their items interactively.
+PortOptsCLI (Port Options CLI) is a new utility for setting port options via a command line interface.
+Properly, PortOptsCLI provides commands to navigate configuration dialogues (checklists and/or radio buttons) and set up their items interactively.
 It is also suitable for a speech synthesizer; currently it is tested with package:accessibility/orca[].
-PortOptsCLI can be installed via the package:SECTION/portoptscli[] package or the package:ports-mgmt/portoptscli[] port.
+PortOptsCLI can be installed via the package:ports-mgmt/portoptscli[] port or package.
 
 Tips and new ideas are welcome.
 If possible, send reports to the FreeBSD Accessibility mailing list, to share and to track discussions in a public place.


### PR DESCRIPTION
SECTION/portoptscli is not a valid reference to a port.

Markup: ' -- ' instead of ' - ', and \`…\` for a command.

Grammar: 'Ports Collection Accessibility' instead of 'Accessibility Ports Collection'.

Whilst here: other suggested changes, minor.