### PR TITLE
Status: 2023q3: lldb-kmod: correction

### DIFF
--- a/website/content/en/status/report-2023-07-2023-09/lldb-kmod.adoc
+++ b/website/content/en/status/report-2023-07-2023-09/lldb-kmod.adoc
@@ -3,7 +3,7 @@
 Links: +
 link:https://wiki.freebsd.org/SummerOfCode2023Projects/LLDBKernelModuleImprovement[GSoC Wiki Project] URL: link:https://wiki.freebsd.org/SummerOfCode2023Projects/LLDBKernelModuleImprovement[] +
 link:https://github.com/aokblast/freebsd-src/tree/lldb_dynamicloader_freebsd_kernel[Project Codebase] URL: link:https://github.com/aokblast/freebsd-src/tree/lldb_dynamicloader_freebsd_kernel[] +
-link:https://github.com/llvm/llvm-project/pull/67106[LLVM PullRequest] URL: link:https://github.com/llvm/llvm-project/pull/67106#discussion_r1337558115[]
+link:https://github.com/llvm/llvm-project/pull/67106[LLVM PullRequest] URL: link:https://github.com/llvm/llvm-project/pull/67106[]
 
 Contact: Sheng-Yi Hong <aokblast@FreeBSD.org>
 


### PR DESCRIPTION
The URL link:https: in the URL: part of the second link: line differs from the URL link:https: in the first part.