### PR TITLE
Status: 2023q3: portmgr: fixes, other changes

### DIFF
--- a/website/content/en/status/report-2023-07-2023-09/portmgr.adoc
+++ b/website/content/en/status/report-2023-07-2023-09/portmgr.adoc
@@ -15,18 +15,20 @@ Below is what happened this quarter.
 
 According to INDEX, there are currently 34,600 ports in the Ports Collection.
 There are currently 3,000 open ports PRs of which some 730 are unassigned.
-This quarter saw 11,454 commits by 130 committers on the main branch and 828 commits by 37 committers on the 2023Q3 branch.
-Compared to last quarter, this means a slight decrease in the number of unassigned PRs, a 10% increase in the number of commits on the main branch but also fewer backports to the quarterly branch.
-The number of ports also grew a bit.
+There were 11,454 commits by 130 committers on the main branch, and 828 commits by 37 committers on the 2023Q3 branch.
+Compared to the previous quarter, this means a slight decrease in the number of unassigned PRs, a 10% increase in the number of commits on the main branch, but also fewer backports to the quarterly branch.
+The number of ports also grew slightly.
 
-During Q3 we welcomed Joel Bodenmann (jbo@) as a new ports committer, granted a ports commit bit to mizhka@ who was already a src committer, and took the commit bits of knu@ and uqs@ in for safe-keeping after a year of inactivity.
+We welcomed Joel Bodenmann (jbo@) as a new ports committer, granted a ports commit bit to mizhka@ who was already a src committer, and took the commit bits of knu@ and uqs@ in for safe-keeping after a year of inactivity.
 
-Portgmr discussed and worked on the following things during Q3:
+portgmr@ discussed and worked on:
 
-* Some progress has been made on sub-packages and a lightning talk was given by pizzamig@ at EuroBSDCon
-* Overhauling some parts of the ports tree (`LIB_DEPENDS`, `PREFIX`, `MANPREFIX`, `MANPATH`).
+* Progress on sub-packages 
+** a lightning talk was given by pizzamig@ at EuroBSDCon
+* Overhauling some parts of the ports tree
+** `LIB_DEPENDS`, `PREFIX`, `MANPREFIX`, `MANPATH`.
 
-Support for FreeBSD 13.1 was removed from the ports tree as it reached its end-of-life on August 1st.
+Support for FreeBSD 13.1 was removed from the ports tree, as it reached its end-of-life on August 1st.
 
 ==== Infrastructure
 

--- a/website/content/en/status/report-2023-07-2023-09/portmgr.adoc
+++ b/website/content/en/status/report-2023-07-2023-09/portmgr.adoc
@@ -4,7 +4,7 @@ Links: +
 link:https://www.FreeBSD.org/ports/[About FreeBSD Ports] URL:link:https://www.FreeBSD.org/ports/[] +
 link:https://docs.freebsd.org/en/articles/contributing/#ports-contributing[Contributing to Ports] URL: link:https://docs.freebsd.org/en/articles/contributing/#ports-contributing[] +
 link:https://www.freebsd.org/portmgr/[Ports Management Team] URL: link:https://www.freebsd.org/portmgr/[] +
-link:http://ftp.freebsd.org/pub/FreeBSD/ports/ports/[Ports Tarball] URL: link:http://ftp.freebsd.org/pub/FreeBSD/ports/ports/[]
+link:https://download.freebsd.org/ftp/ports/ports/[Ports Tarball] URL: link:https://download.freebsd.org/ftp/ports/ports/[]
 
 Contact: René Ladan <portmgr-secretary@FreeBSD.org> +
 Contact: FreeBSD Ports Management Team <portmgr@FreeBSD.org>

--- a/website/content/en/status/report-2023-07-2023-09/portmgr.adoc
+++ b/website/content/en/status/report-2023-07-2023-09/portmgr.adoc
@@ -13,7 +13,7 @@ Contact: FreeBSD Ports Management Team <portmgr@FreeBSD.org>
 The Ports Management Team is responsible for overseeing the overall direction of the Ports Tree, building packages, and personnel matters.
 Below is what happened this quarter.
 
-* According to INDEX, there are currently 34,600 ports in the Ports Collection.
+According to INDEX, there are currently 34,600 ports in the Ports Collection.
 There are currently 3,000 open ports PRs of which some 730 are unassigned.
 This quarter saw 11,454 commits by 130 committers on the main branch and 828 commits by 37 committers on the 2023Q3 branch.
 Compared to last quarter, this means a slight decrease in the number of unassigned PRs, a 10% increase in the number of commits on the main branch but also fewer backports to the quarterly branch.
@@ -22,21 +22,25 @@ The number of ports also grew a bit.
 During Q3 we welcomed Joel Bodenmann (jbo@) as a new ports committer, granted a ports commit bit to mizhka@ who was already a src committer, and took the commit bits of knu@ and uqs@ in for safe-keeping after a year of inactivity.
 
 Portgmr discussed and worked on the following things during Q3:
+
 * Some progress has been made on sub-packages and a lightning talk was given by pizzamig@ at EuroBSDCon
-* Overhauling some parts of the ports tree (LIB_DEPENDS, PREFIX, MANPREFIX, MANPATH)
+* Overhauling some parts of the ports tree (`LIB_DEPENDS`, `PREFIX`, `MANPREFIX`, `MANPATH`).
 
 Support for FreeBSD 13.1 was removed from the ports tree as it reached its end-of-life on August 1st.
 
-The following happened on the infrastructure side:
-* USES for ebur128 and guile were added
+==== Infrastructure
+
+* `USES` for `ebur128` and `guile` were added
 * Default versions for Mono, Perl, and PostgreSQL were updated to respectively 5.20, 5.34, and 15
-* Default versions for ebur128, guile, and pycryptography were added at respectively "rust", 2.2, and "rust"
-* Updates to major ports that happened were:
-  * pkg to 1.20.7
-  * chromium to 117.0.5938.132
-  * Firefox to 118.0.1
-  * KDE to 5.27.8
-  * Rust to 1.72.0
-  * Wine to 8.0.2
+* Default versions for `ebur128`, `guile`, and `pycryptography` were added at respectively "rust", 2.2, and "rust".
+
+==== Updates to major ports
+
+* pkg to 1.20.7
+* chromium to 117.0.5938.132
+* Firefox to 118.0.1
+* KDE to 5.27.8
+* Rust to 1.72.0
+* Wine to 8.0.2.
 
 During this quarter, pgkmgr@ ran 18 exp-runs to test various ports upgrades, updates to default versions of ports, and changes to pycryptography.

--- a/website/content/en/status/report-2023-07-2023-09/portmgr.adoc
+++ b/website/content/en/status/report-2023-07-2023-09/portmgr.adoc
@@ -3,7 +3,6 @@
 Links: +
 link:https://www.FreeBSD.org/ports/[About FreeBSD Ports] URL:link:https://www.FreeBSD.org/ports/[] +
 link:https://docs.freebsd.org/en/articles/contributing/#ports-contributing[Contributing to Ports] URL: link:https://docs.freebsd.org/en/articles/contributing/#ports-contributing[] +
-link:http://portsmon.freebsd.org/[FreeBSD Ports Monitoring] URL: link:http://portsmon.freebsd.org/[] +
 link:https://www.freebsd.org/portmgr/[Ports Management Team] URL: link:https://www.freebsd.org/portmgr/[] +
 link:http://ftp.freebsd.org/pub/FreeBSD/ports/ports/[Ports Tarball] URL: link:http://ftp.freebsd.org/pub/FreeBSD/ports/ports/[]
 

--- a/website/content/en/status/report-2023-07-2023-09/portmgr.adoc
+++ b/website/content/en/status/report-2023-07-2023-09/portmgr.adoc
@@ -11,15 +11,15 @@ Contact: René Ladan <portmgr-secretary@FreeBSD.org> +
 Contact: FreeBSD Ports Management Team <portmgr@FreeBSD.org>
 
 The Ports Management Team is responsible for overseeing the overall direction of the Ports Tree, building packages, and personnel matters.
-Below is what happened in the last quarter.
+Below is what happened this quarter.
 
 * According to INDEX, there are currently 34,600 ports in the Ports Collection.
 There are currently 3,000 open ports PRs of which some 730 are unassigned.
-The last quarter saw 11,454 commits by 130 committers on the main branch and 828 commits by 37 committers on the 2023Q3 branch.
-Compared to last quarter, this means a slight decrease in the number of unassigned PRs, a 10% increase in the number of commits on the main branch but also less backports to the quarterly branch.
+This quarter saw 11,454 commits by 130 committers on the main branch and 828 commits by 37 committers on the 2023Q3 branch.
+Compared to last quarter, this means a slight decrease in the number of unassigned PRs, a 10% increase in the number of commits on the main branch but also fewer backports to the quarterly branch.
 The number of ports also grew a bit.
 
-During Q3 we welcomed Joel Bodemmann (jbo@) as a new ports committer, granted a ports commit bit to mizhka@ who was already a src committer, and took the commit bits of knu@ and uqs@ in for safe-keeping after a year of inactivity.
+During Q3 we welcomed Joel Bodenmann (jbo@) as a new ports committer, granted a ports commit bit to mizhka@ who was already a src committer, and took the commit bits of knu@ and uqs@ in for safe-keeping after a year of inactivity.
 
 Portgmr discussed and worked on the following things during Q3:
 * Some progress has been made on sub-packages and a lightning talk was given by pizzamig@ at EuroBSDCon
@@ -39,4 +39,4 @@ The following happened on the infrastructure side:
   * Rust to 1.72.0
   * Wine to 8.0.2
 
-During the last quarter, pgkmgr@ ran 18 exp-runs to test various ports upgrades, updates to default versions of ports, and changes to pycryptography.
+During this quarter, pgkmgr@ ran 18 exp-runs to test various ports upgrades, updates to default versions of ports, and changes to pycryptography.

--- a/website/content/en/status/report-2023-07-2023-09/portmgr.adoc
+++ b/website/content/en/status/report-2023-07-2023-09/portmgr.adoc
@@ -20,10 +20,22 @@ The number of ports also grew slightly.
 
 We welcomed Joel Bodenmann (jbo@) as a new ports committer, granted a ports commit bit to mizhka@ who was already a src committer, and took in the commit bits of knu@ and uqs@ for safe-keeping after a year of inactivity.
 
-portgmr@ discussed and worked on the following things during Q3: * Some progress has been made on sub-packages and a lightning talk was given by pizzamig@ at EuroBSDCon * Overhauling some parts of the ports tree (`LIB_DEPENDS`, `PREFIX`, `MANPREFIX`, `MANPATH`)
+portgmr@ discussed and worked on the following things during Q3:
+* Some progress has been made on sub-packages and a lightning talk was given by pizzamig@ at EuroBSDCon
+* Overhauling some parts of the ports tree (LIB_DEPENDS, PREFIX, MANPREFIX, MANPATH)
 
-Support for FreeBSD 13.1 was removed from the ports tree, as it reached its end-of-life on August 1st.
+Support for FreeBSD 13.1 was removed from the ports tree as it reached its end-of-life on August 1st.
 
-The following happened on the infrastructure side: * `USES` for `ebur128` and `guile` were added * Default versions for Mono, Perl, and PostgreSQL were updated to respectively 5.20, 5.34, and 15 * Default versions for `ebur128`, `guile`, and `pycryptography` were added at respectively "rust", 2.2, and "rust" * Updates to major ports that happened were: * pkg to 1.20.7 * chromium to 117.0.5938.132 * Firefox to 118.0.1 * KDE to 5.27.8 * Rust to 1.72.0 * Wine to 8.0.2
+The following happened on the infrastructure side:
+* `USES` for `ebur128` and `guile` were added
+* Default versions for Mono, Perl, and PostgreSQL were updated to respectively 5.20, 5.34, and 15
+* Default versions for `ebur128`, `guile`, and `pycryptography` were added at respectively "rust", 2.2, and "rust"
+* Updates to major ports that happened were:
+  * pkg to 1.20.7
+  * chromium to 117.0.5938.132
+  * Firefox to 118.0.1
+  * KDE to 5.27.8
+  * Rust to 1.72.0
+  * Wine to 8.0.2
 
 During this quarter, pgkmgr@ ran 18 exp-runs to test various ports upgrades, updates to default versions of ports, and changes to pycryptography.

--- a/website/content/en/status/report-2023-07-2023-09/portmgr.adoc
+++ b/website/content/en/status/report-2023-07-2023-09/portmgr.adoc
@@ -12,7 +12,7 @@ Contact: FreeBSD Ports Management Team <portmgr@FreeBSD.org>
 The Ports Management Team is responsible for overseeing the overall direction of the Ports Tree, building packages, and personnel matters.
 Below is what happened this quarter.
 
-According to INDEX, there are currently 34,600 ports in the Ports Collection.
+* According to INDEX, there are currently 34,600 ports in the Ports Collection.
 There are currently 3,000 open ports PRs of which some 730 are unassigned.
 There were 11,454 commits by 130 committers on the main branch, and 828 commits by 37 committers on the 2023Q3 branch.
 Compared to the previous quarter, this means a slight decrease in the number of unassigned PRs, a 10% increase in the number of commits on the main branch, but also fewer backports to the quarterly branch.
@@ -20,30 +20,10 @@ The number of ports also grew slightly.
 
 We welcomed Joel Bodenmann (jbo@) as a new ports committer, granted a ports commit bit to mizhka@ who was already a src committer, and took in the commit bits of knu@ and uqs@ for safe-keeping after a year of inactivity.
 
-portgmr@ discussed and worked on:
-
-* Progress on sub-packages 
-** a lightning talk was given by pizzamig@ at EuroBSDCon
-* Overhauling some parts of the ports tree
-** `LIB_DEPENDS`, `PREFIX`, `MANPREFIX`, `MANPATH`.
+portgmr@ discussed and worked on the following things during Q3: * Some progress has been made on sub-packages and a lightning talk was given by pizzamig@ at EuroBSDCon * Overhauling some parts of the ports tree (`LIB_DEPENDS`, `PREFIX`, `MANPREFIX`, `MANPATH`)
 
 Support for FreeBSD 13.1 was removed from the ports tree, as it reached its end-of-life on August 1st.
 
-==== Infrastructure
+The following happened on the infrastructure side: * `USES` for `ebur128` and `guile` were added * Default versions for Mono, Perl, and PostgreSQL were updated to respectively 5.20, 5.34, and 15 * Default versions for `ebur128`, `guile`, and `pycryptography` were added at respectively "rust", 2.2, and "rust" * Updates to major ports that happened were: * pkg to 1.20.7 * chromium to 117.0.5938.132 * Firefox to 118.0.1 * KDE to 5.27.8 * Rust to 1.72.0 * Wine to 8.0.2
 
-* `USES` for `ebur128` and `guile` were added
-* Default versions for Mono, Perl, and PostgreSQL were updated to respectively 5.20, 5.34, and 15
-* Default versions for `ebur128`, `guile`, and `pycryptography` were added at respectively "rust", 2.2, and "rust".
-
-==== Updates to major ports
-
-* pkg to 1.20.7
-* chromium to 117.0.5938.132
-* Firefox to 118.0.1
-* KDE to 5.27.8
-* Rust to 1.72.0
-* Wine to 8.0.2.
-
-==== pgkmgr
-
-pgkmgr@ ran 18 exp-runs to test various ports upgrades, updates to default versions of ports, and changes to pycryptography.
+During this quarter, pgkmgr@ ran 18 exp-runs to test various ports upgrades, updates to default versions of ports, and changes to pycryptography.

--- a/website/content/en/status/report-2023-07-2023-09/portmgr.adoc
+++ b/website/content/en/status/report-2023-07-2023-09/portmgr.adoc
@@ -18,7 +18,7 @@ There were 11,454 commits by 130 committers on the main branch, and 828 commits 
 Compared to the previous quarter, this means a slight decrease in the number of unassigned PRs, a 10% increase in the number of commits on the main branch, but also fewer backports to the quarterly branch.
 The number of ports also grew slightly.
 
-We welcomed Joel Bodenmann (jbo@) as a new ports committer, granted a ports commit bit to mizhka@ who was already a src committer, and took the commit bits of knu@ and uqs@ in for safe-keeping after a year of inactivity.
+We welcomed Joel Bodenmann (jbo@) as a new ports committer, granted a ports commit bit to mizhka@ who was already a src committer, and took in the commit bits of knu@ and uqs@ for safe-keeping after a year of inactivity.
 
 portgmr@ discussed and worked on:
 

--- a/website/content/en/status/report-2023-07-2023-09/portmgr.adoc
+++ b/website/content/en/status/report-2023-07-2023-09/portmgr.adoc
@@ -43,4 +43,6 @@ Support for FreeBSD 13.1 was removed from the ports tree as it reached its end-o
 * Rust to 1.72.0
 * Wine to 8.0.2.
 
-During this quarter, pgkmgr@ ran 18 exp-runs to test various ports upgrades, updates to default versions of ports, and changes to pycryptography.
+==== pgkmgr
+
+pgkmgr@ ran 18 exp-runs to test various ports upgrades, updates to default versions of ports, and changes to pycryptography.


### PR DESCRIPTION
Correctly spell Joel's surname.

Remove FreeBSD Ports Monitoring. 

Alter the URL for the tarball, based on the redirect.

About FreeBSD Ports no longer exists. Seek `portmgr@` advice, then alter the URL.

The collated report will be for Q3 as if it was written during (not after) the events of Q3, so 'this quarter' is Q3.

Consistent use of 'this' for Q3 allows the comparison with 'last quarter' to make sense.  (Logically: you can not compare last quarter with last quarter.)

Fix, or add, markup for list items (bullet points).

Consider use of subheadings.

Other suggested changes.