### PR TITLE
Fix typo in "thin jail with nullfs guide"

### DIFF
--- a/documentation/content/en/books/handbook/jails/_index.adoc
+++ b/documentation/content/en/books/handbook/jails/_index.adoc
@@ -625,14 +625,14 @@ thinjail {
 
   # HOSTNAME/PATH
   host.hostname = "${name}";
-  path = "/usr/local/jails/containers/${name}";
+  path = "/usr/local/jails/${name}-nullfs-base";
 
   # NETWORK
   ip4.addr = 192.168.1.153;
   interface = em0;
 
   # MOUNT
-  mount.fstab = "/usr/local/jails/thinjail-nullfs-base.fstab";
+  mount.fstab = "/usr/local/jails/${name}-nullfs-base.fstab";
 }
 ....
 


### PR DESCRIPTION
Previous statement resulted in errors regarding missing directories.

Error:

```
# service jail start thinjail
Starting jails: cannot start jail  "thinjail":
jail: thinjail: mount.devfs: /usr/local/jails/containers/thinjail/dev: No such file or directory
```