### PR TITLE
network: update ifconfig wlan create

### DIFF
--- a/documentation/content/en/books/handbook/network/_index.adoc
+++ b/documentation/content/en/books/handbook/network/_index.adoc
@@ -619,7 +619,7 @@ To find out what wireless network cards are in the system check the section <<co
 
 [source,shell]
 ....
-# ifconfig wlan0 create wlandevice iwm0
+# ifconfig wlan0 create wlandev iwm0
 ....
 
 To make the change persist across reboots execute the following command:


### PR DESCRIPTION
Update the example ifconfig create command to use the correct parent device name parameter (wlandev instead of wlandevice).