### PR TITLE
network: use sysrc to set ifconfig_wlan0

### DIFF
--- a/documentation/content/en/books/handbook/network/_index.adoc
+++ b/documentation/content/en/books/handbook/network/_index.adoc
@@ -721,7 +721,7 @@ To use a dynamic address it will be necessary to execute the following command:
 
 [source,shell]
 ....
-# ifconfig_wlan0="WPA DHCP"
+# sysrc ifconfig_wlan0="WPA DHCP"
 ....
 
 Then restart the network executing the following command:


### PR DESCRIPTION
Correct the example setting ifconfig_wlan0 in rc.conf to use sysrc.