### PR TITLE
handbook: fix typo for WINE

### DIFF
--- a/documentation/content/en/books/handbook/wine/_index.adoc
+++ b/documentation/content/en/books/handbook/wine/_index.adoc
@@ -59,7 +59,7 @@ It will also translate any responses as needed into what the Windows(R) software
 So in some ways, it _emulates_ a Windows(R) environment, in that it provides many of the resources Windows(R) applications are expecting.
 
 However, it is not an emulator in the traditional sense.
-Many of these solutions operate by constructing an entire other computer using software processes in place of hardware.
+Many of these solutions operate by constructing an entirely separate computer using software processes in place of hardware.
 Virtualization (such as that provided by the package:emulators/qemu[] port) operates in this way.
 One of the benefits of this approach is the ability to install a full version of the OS in question to the emulator.
 It means that the environment will not look any different to applications than a real machine, and chances are good that everything will work on it.
@@ -77,10 +77,10 @@ It can always serve as the first option which, if successful, offers a good expe
 This chapter will describe:
 
 * How to install WINE on a FreeBSD system.
-* How WINE operates, and how it is different from other alternatives like virtualizaton.
+* How WINE operates, and how it is different from other alternatives like virtualization.
 * How to fine-tune WINE to the specific needs of some applications.
 * How to install GUI helpers for WINE.
-* Common tips and solutions for on FreeBSD.
+* Common tips and solutions for using WINE on FreeBSD.
 * Considerations for WINE on FreeBSD in terms of the multi-user environment.
 
 Before reading this chapter, it will be useful to:
@@ -126,7 +126,7 @@ Therefore, WINE's utilities are designed by default to launch graphical programs
 However, there are three methods available to run these so-called Console User Interface (CUI) programs:
 
 * The _Bare Streams_ approach will display the output directly to standard output.
-* The _wineconsole_ utility can be used with either the _user_ or _curses_ backed to utilize some of the enhancements the WINE system provides for CUI applications.
+* The _wineconsole_ utility can be used with either the _user_ or _curses_ backend to utilize some of the enhancements the WINE system provides for CUI applications.
 
 These approaches are described in greater detail on the https://wiki.winehq.org/Wine_User%27s_Guide#Text_mode_programs_.28CUI:_Console_User_Interface.29[WINE Wiki].
 
@@ -174,7 +174,7 @@ For FreeBSD users, some alternatives to using WINE are as follows:
 
 * Dual-Booting: A straightforward option is to run desired Windows(R) applications natively on that OS. This of course means exiting FreeBSD in order to boot Windows(R), so this method is not feasible if access to programs in both systems is required simultaneously.
 * Virtual Machines: Virtual Machines (VMs), as mentioned earlier in this chapter, are software processes that emulate full sets of hardware, on which additional operating systems (including Windows(R)) can be installed and run. Modern tools make VMs easy to create and manage, but this method comes at a cost. A good portion of the host systems resources must be allocated to each VM, and those resources cannot be reclaimed by the host as long as the VM is running. A few examples of VM managers include the open source solutions qemu, bhyve, and VirtualBox. See the chapter on <<virtualization,Virtualization>> for more detail.
-* Remote Access: Like many other UNIX(R)-like systems, FreeBSD can run a variety of applications enabling users to remotely access Windows(R) computers and use their programs or data. In addtion to clients such as xrdp that connect to the standard Windows(R) Remote Desktop Protocol, other open source standards such as vnc can also be used (provided a compatible server is present on the other side).
+* Remote Access: Like many other UNIX(R)-like systems, FreeBSD can run a variety of applications enabling users to remotely access Windows(R) computers and use their programs or data. In addition to clients such as xrdp that connect to the standard Windows(R) Remote Desktop Protocol, other open source standards such as vnc can also be used (provided a compatible server is present on the other side).
 
 [[installing-wine-on-freebsd]]
 == Installing WINE on FreeBSD
@@ -570,7 +570,7 @@ To install Suyimazu's binary package, issue the following command:
 ....
 
 Suyimazu is available in the FreeBSD Ports system.
-However, than the _emulators_ section of Ports or binary packages, look for it in the _games_ section.
+However, instead of looking in the _emulators_ section of Ports or binary packages, look for it in the _games_ section.
 
 [source,shell]
 ....
@@ -682,7 +682,7 @@ There are two strategies to minimize the impact of multiple WINE users in the sy
 === Installing Applications to a Common Drive
 
 As shown in the section on WINE Configuration, WINE provides the ability to attach additional drives to a given prefix.
-In this way, applications can be installed to a common location, while each user will still have an prefix where individual settings may be kept (depending on the program).
+In this way, applications can be installed to a common location, while each user will still have a prefix where individual settings may be kept (depending on the program).
 This is a good setup if there are relatively few applications to be shared between users, and they are programs that require few custom tweaks changes to the prefix in order to function.
 
 The steps to make install applications in this way are as follows:


### PR DESCRIPTION
1. `... an entire other computer ...` -> `... an entirely separate computer ...`
2. `virtualizaton` -> `virtualization`
3. `... for on FreeBSD` -> `... for using WINE on FreeBSD`
4. `backed` -> `backend`
5. `addtion` -> `addition`
6. `However, than the _emulators_ section...` -> `However, instead of looking in the _emulators_ section ...`
7. `... have an prefix ...` -> `... have a prefix ...`
This is from the Advanced UNIX Programming Course (Fall’23) at NTHU.