### PR TITLE
handbook: fix typo for linuxemu

### DIFF
--- a/documentation/content/en/books/handbook/linuxemu/_index.adoc
+++ b/documentation/content/en/books/handbook/linuxemu/_index.adoc
@@ -261,7 +261,7 @@ The output should be similar to the following:
 Linux 3.17.0 x86_64
 ....
 
-Once inside the chroot, the system behaves as in a normal Ubuntu installation
+Once inside the chroot, the system behaves as in a normal Ubuntu installation.
 While systemd doesn't work, the man:service[8] command works as usual.
 
 [TIP]


### PR DESCRIPTION
There's a missing period here.
This is from the Advanced UNIX Programming Course (Fall’23) at NTHU.