### PR TITLE
freebsd-src-lsp/_index.adoc: write "keys" instead of "key"

### DIFF
--- a/documentation/content/en/articles/freebsd-src-lsp/_index.adoc
+++ b/documentation/content/en/articles/freebsd-src-lsp/_index.adoc
@@ -278,7 +278,7 @@ In the top-level directory of the FreeBSD src tree, to generate compilation data
 ....
 
 The `--append` flag tells `bear` to read an existing compilation database if it is present, and append the results to the database.
-Entries with duplicated command key are merged.
+Entries with duplicated command keys are merged.
 The generated compilation database by default is saved in the current working directory as [.filename]#compile_commands.json#.
 
 [[final]]


### PR DESCRIPTION
It should be
>  Entries with duplicated command key**s** are merged.

Webpage: https://docs.freebsd.org/en/articles/freebsd-src-lsp/#_usage_2