### PR TITLE
handbook: fix typo for Network Servers

### DIFF
--- a/documentation/content/en/books/handbook/network-servers/_index.adoc
+++ b/documentation/content/en/books/handbook/network-servers/_index.adoc
@@ -1039,7 +1039,7 @@ When adding a new machine, login restrictions must be defined for all netgroups.
 When a new user is added, the account must be added to one or more netgroups.
 If the NIS setup is planned carefully, only one central configuration file needs modification to grant or deny access to machines.
 
-The first step is the initialization of the NIS`netgroup` map.
+The first step is the initialization of the NIS `netgroup` map.
 In FreeBSD, this map is not created by default.
 On the NIS master server, use an editor to create a map named [.filename]#/var/yp/netgroup#.
 


### PR DESCRIPTION
There's a missing space, which causes the markdown to not display correctly.
This is from the Advanced UNIX Programming Course (Fall’23) at NTHU.