### PR TITLE
fix typo in committers guide

### DIFF
--- a/documentation/content/en/articles/committers-guide/_index.adoc
+++ b/documentation/content/en/articles/committers-guide/_index.adoc
@@ -672,7 +672,7 @@ For example, to encrypt for the subkey `DEADBEEF`, use `DEADBEEF!`.
 
 Commit signatures can be verified by running either `git verify-commit <commit hash>`, or `git log --show-signature`.
 
-Tag signatures can be verified with `git verity-tag <tag name>`, or `git tag -v <tag name>`.
+Tag signatures can be verified with `git verify-tag <tag name>`, or `git tag -v <tag name>`.
 
 ////
 Commented out for now until we decide what to do.


### PR DESCRIPTION
verity-tag -> verify-tag

see also: https://bugs.freebsd.org/bugzilla/show_bug.cgi?id=275935