### PR TITLE
arch-handbook/driverbasics: use tabs to indent the example code

### DIFF
--- a/documentation/content/en/books/arch-handbook/driverbasics/_index.adoc
+++ b/documentation/content/en/books/arch-handbook/driverbasics/_index.adoc
@@ -90,28 +90,28 @@ Skeleton Layout of a kernel module
 static int
 skel_loader(struct module *m, int what, void *arg)
 {
-  int err = 0;
+	int err = 0;
 
-  switch (what) {
-  case MOD_LOAD:                /* kldload */
-    uprintf("Skeleton KLD loaded.\n");
-    break;
-  case MOD_UNLOAD:
-    uprintf("Skeleton KLD unloaded.\n");
-    break;
-  default:
-    err = EOPNOTSUPP;
-    break;
-  }
-  return(err);
+	switch (what) {
+	case MOD_LOAD:                /* kldload */
+		uprintf("Skeleton KLD loaded.\n");
+		break;
+	case MOD_UNLOAD:
+		uprintf("Skeleton KLD unloaded.\n");
+		break;
+	default:
+		err = EOPNOTSUPP;
+		break;
+	}
+	return(err);
 }
 
 /* Declare this module to the rest of the kernel */
 
 static moduledata_t skel_mod = {
-  "skel",
-  skel_loader,
-  NULL
+	"skel",
+	skel_loader,
+	NULL
 };
 
 DECLARE_MODULE(skeleton, skel_mod, SI_SUB_KLD, SI_ORDER_ANY);


### PR DESCRIPTION
In the "Writing FreeBSD Device Drivers" page, the first example uses 2 characters (spaces) to indent the code. Since FreeBSD uses tabs (8 characters) to indent and as the second example also follows this, it's better to just use tabs here as well.

Link: https://docs.freebsd.org/en/books/arch-handbook/driverbasics/
Diff: https://github.com/mystuffs/freebsd-doc-fork/commit/eaf08bae727ea46737b87a938e513036dfe42a7c.diff