### PR TITLE
arch-handbook/boot: add a space between the next word and the previous stop

### DIFF
--- a/documentation/content/en/books/arch-handbook/boot/_index.adoc
+++ b/documentation/content/en/books/arch-handbook/boot/_index.adoc
@@ -50,7 +50,8 @@ endif::[]
 [[boot-synopsis]]
 == Synopsis
 
-This chapter is an overview of the boot and system initialization processes, starting from the BIOS (firmware) POST, to the first user process creation.
+This chapter is an overview of the boot and system initialization processes,
+starting from the BIOS (firmware) POST, to the first user process creation.
 Since the initial steps of system startup are very architecture dependent, the IA-32 architecture is used as an example.
 But the AMD64 and ARM64 architectures are much more important and compelling examples and should be explained in the near future according to the topic of this document.
 
@@ -146,16 +147,19 @@ FreeBSD clang version 11.0.1 (git@github.com:llvm/llvm-project.git llvmorg-11.0.
 == The BIOS
 
 When the computer powers on, the processor's registers are set to some predefined values.
-One of the registers is the _instruction pointer_ register, and its value after a power on is well defined: it is a 32-bit value of `0xfffffff0`.
+One of the registers is the _instruction pointer_ register,
+and its value after a power on is well defined: it is a 32-bit value of `0xfffffff0`.
 The instruction pointer register (also known as the Program Counter) points to code to be executed by the processor.
 Another important register is the `cr0` 32-bit control register, and its value just after a reboot is `0`.
-One of ``cr0``'s bits, the PE (Protection Enabled) bit, indicates whether the processor is running in 32-bit protected mode or 16-bit real mode.
+One of ``cr0``'s bits, the PE (Protection Enabled) bit,
+indicates whether the processor is running in 32-bit protected mode or 16-bit real mode.
 Since this bit is cleared at boot time, the processor boots in 16-bit real mode.
 Real mode means, among other things, that linear and physical addresses are identical.
 The reason for the processor not to start immediately in 32-bit protected mode is backwards compatibility.
 In particular, the boot process relies on the services provided by the BIOS, and the BIOS itself works in legacy, 16-bit code.
 
-The value of `0xfffffff0` is slightly less than 4 GB, so unless the machine has 4 GB of physical memory, it cannot point to a valid memory address.
+The value of `0xfffffff0` is slightly less than 4 GB,
+so unless the machine has 4 GB of physical memory, it cannot point to a valid memory address.
 The computer's hardware translates this address so that it points to a BIOS memory block.
 
 The BIOS (Basic Input Output System) is a chip on the motherboard that has a relatively small amount of read-only memory (ROM).
@@ -163,7 +167,8 @@ This memory contains various low-level routines that are specific to the hardwar
 The processor will first jump to the address 0xfffffff0, which really resides in the BIOS's memory.
 Usually this address contains a jump instruction to the BIOS's POST routines.
 
-The POST (Power On Self Test) is a set of routines including the memory check, system bus check, and other low-level initialization so the CPU can set up the computer properly.
+The POST (Power On Self Test) is a set of routines including the memory check, system bus check,
+and other low-level initialization so the CPU can set up the computer properly.
 The important step of this stage is determining the boot device.
 Modern BIOS implementations permit the selection of a boot device, allowing booting from a floppy, CD-ROM, hard disk, or other devices.
 
@@ -215,17 +220,20 @@ This program uses low-level "tricks" like taking advantage of the side effects o
 Care must also be taken when handling the partition table, which is embedded in the MBR itself.
 For these reasons, be very careful when modifying [.filename]#boot0.S#.
 
-Note that the [.filename]#boot0.S# source file is assembled "as is": instructions are translated one by one to binary, with no additional information (no ELF file format, for example).
+Note that the [.filename]#boot0.S# source file is assembled "as is": instructions are translated one by one to binary,
+with no additional information (no ELF file format, for example).
 This kind of low-level control is achieved at link time through special control flags passed to the linker.
 For example, the text section of the program is set to be located at address `0x600`.
 In practice this means that [.filename]#boot0# must be loaded to memory address `0x600` in order to function properly.
 
-It is worth looking at the [.filename]#Makefile# for [.filename]#boot0# ([.filename]#stand/i386/boot0/Makefile#), as it defines some of the run-time behavior of [.filename]#boot0#.
+It is worth looking at the [.filename]#Makefile# for [.filename]#boot0# ([.filename]#stand/i386/boot0/Makefile#),
+as it defines some of the run-time behavior of [.filename]#boot0#.
 For instance, if a terminal connected to the serial port (COM1) is used for I/O, the macro `SIO` must be defined (`-DSIO`).
 `-DPXE` enables boot through PXE by pressing kbd:[F6].
 Additionally, the program defines a set of _flags_ that allow further modification of its behavior.
 All of this is illustrated in the [.filename]#Makefile#.
-For example, look at the linker directives which command the linker to start the text section at address `0x600`, and to build the output file "as is" (strip out any file formatting):
+For example, look at the linker directives which command the linker to start the text section at address `0x600`,
+and to build the output file "as is" (strip out any file formatting):
 
 [.programlisting]
 ....
@@ -265,7 +273,7 @@ The next block is responsible for the relocation and subsequent jump to the relo
 
 [.programlisting]
 ....
-      movw %sp,%si	# Source
+      movw %sp,%si		# Source
       movw $start,%di		# Destination
       movw $0x100,%cx		# Word count
       rep			# Relocate
@@ -279,11 +287,15 @@ The next block is responsible for the relocation and subsequent jump to the relo
 ....
 
 .[.filename]#stand/i386/boot0/boot0.S# [[boot-boot0-relocation]]
-As [.filename]#boot0# is loaded by the BIOS to address `0x7C00`, it copies itself to address `0x600` and then transfers control there (recall that it was linked to execute at address `0x600`).
+As [.filename]#boot0# is loaded by the BIOS to address `0x7C00`,
+it copies itself to address `0x600` and then transfers control there (recall that it was linked to execute at address `0x600`).
 The source address, `0x7c00`, is copied to register `%si`.
 The destination address, `0x600`, to register `%di`.
 The number of words to copy, `256` (the program's size = 512 bytes), is copied to register `%cx`.
-Next, the `rep` instruction repeats the instruction that follows, that is, `movsw`, the number of times dictated by the `%cx` register.The `movsw` instruction copies the word pointed to by `%si` to the address pointed to by `%di`.
+Next, the `rep` instruction repeats the instruction that follows, that is, `movsw`,
+the number of times dictated by the `%cx` register.
+
+The `movsw` instruction copies the word pointed to by `%si` to the address pointed to by `%di`.
 This is repeated another 255 times.
 On each repetition, both the source and destination registers, `%si` and `%di`, are incremented by one.
 Thus, upon completion of the 256-word (512-byte) copy, `%di` has the value `0x600`+`512`= `0x800`, and `%si` has the value `0x7c00`+`512`= `0x7e00`; we have thus completed the code _relocation_.
@@ -296,7 +308,8 @@ Now, `stosw` is executed 8 times.
 This instruction copies a `0` value to the address pointed to by the destination register (`%di`, which is `0x800`), and increments it.
 This is repeated another 7 times, so `%di` ends up with value `0x810`.
 Effectively, this clears the address range `0x800`-`0x80f`.
-This range is used as a (fake) partition table for writing the MBR back to disk. Finally, the sector field for the CHS addressing of this fake partition is given the value 1 and a jump is made to the main function from the relocated code.
+This range is used as a (fake) partition table for writing the MBR back to disk.
+Finally, the sector field for the CHS addressing of this fake partition is given the value 1 and a jump is made to the main function from the relocated code.
 Note that until this jump to the relocated code, any reference to an absolute address was avoided.
 
 The following code block tests whether the drive number provided by the BIOS should be used, or the one stored in [.filename]#boot0#.

--- a/documentation/content/en/books/arch-handbook/boot/_index.adoc
+++ b/documentation/content/en/books/arch-handbook/boot/_index.adoc
@@ -163,8 +163,7 @@ This memory contains various low-level routines that are specific to the hardwar
 The processor will first jump to the address 0xfffffff0, which really resides in the BIOS's memory.
 Usually this address contains a jump instruction to the BIOS's POST routines.
 
-The POST (Power On Self Test) is a set of routines including the memory check, system bus check,
-and other low-level initialization so the CPU can set up the computer properly.
+The POST (Power On Self Test) is a set of routines including the memory check, system bus check, and other low-level initialization so the CPU can set up the computer properly.
 The important step of this stage is determining the boot device.
 Modern BIOS implementations permit the selection of a boot device, allowing booting from a floppy, CD-ROM, hard disk, or other devices.
 
@@ -216,20 +215,17 @@ This program uses low-level "tricks" like taking advantage of the side effects o
 Care must also be taken when handling the partition table, which is embedded in the MBR itself.
 For these reasons, be very careful when modifying [.filename]#boot0.S#.
 
-Note that the [.filename]#boot0.S# source file is assembled "as is": instructions are translated one by one to binary,
-with no additional information (no ELF file format, for example).
+Note that the [.filename]#boot0.S# source file is assembled "as is": instructions are translated one by one to binary, with no additional information (no ELF file format, for example).
 This kind of low-level control is achieved at link time through special control flags passed to the linker.
 For example, the text section of the program is set to be located at address `0x600`.
 In practice this means that [.filename]#boot0# must be loaded to memory address `0x600` in order to function properly.
 
-It is worth looking at the [.filename]#Makefile# for [.filename]#boot0# ([.filename]#stand/i386/boot0/Makefile#),
-as it defines some of the run-time behavior of [.filename]#boot0#.
+It is worth looking at the [.filename]#Makefile# for [.filename]#boot0# ([.filename]#stand/i386/boot0/Makefile#), as it defines some of the run-time behavior of [.filename]#boot0#.
 For instance, if a terminal connected to the serial port (COM1) is used for I/O, the macro `SIO` must be defined (`-DSIO`).
 `-DPXE` enables boot through PXE by pressing kbd:[F6].
 Additionally, the program defines a set of _flags_ that allow further modification of its behavior.
 All of this is illustrated in the [.filename]#Makefile#.
-For example, look at the linker directives which command the linker to start the text section at address `0x600`,
-and to build the output file "as is" (strip out any file formatting):
+For example, look at the linker directives which command the linker to start the text section at address `0x600`, and to build the output file "as is" (strip out any file formatting):
 
 [.programlisting]
 ....
@@ -269,7 +265,7 @@ The next block is responsible for the relocation and subsequent jump to the relo
 
 [.programlisting]
 ....
-      movw %sp,%si              # Source
+      movw %sp,%si     # Source
       movw $start,%di		# Destination
       movw $0x100,%cx		# Word count
       rep			# Relocate
@@ -287,8 +283,7 @@ As [.filename]#boot0# is loaded by the BIOS to address `0x7C00`, it copies itsel
 The source address, `0x7c00`, is copied to register `%si`.
 The destination address, `0x600`, to register `%di`.
 The number of words to copy, `256` (the program's size = 512 bytes), is copied to register `%cx`.
-Next, the `rep` instruction repeats the instruction that follows, that is, `movsw`,
-the number of times dictated by the `%cx` register.
+Next, the `rep` instruction repeats the instruction that follows, that is, `movsw`, the number of times dictated by the `%cx` register.
 The `movsw` instruction copies the word pointed to by `%si` to the address pointed to by `%di`.
 This is repeated another 255 times.
 On each repetition, both the source and destination registers, `%si` and `%di`, are incremented by one.

--- a/documentation/content/en/books/arch-handbook/boot/_index.adoc
+++ b/documentation/content/en/books/arch-handbook/boot/_index.adoc
@@ -296,7 +296,7 @@ Now, `stosw` is executed 8 times.
 This instruction copies a `0` value to the address pointed to by the destination register (`%di`, which is `0x800`), and increments it.
 This is repeated another 7 times, so `%di` ends up with value `0x810`.
 Effectively, this clears the address range `0x800`-`0x80f`.
-This range is used as a (fake) partition table for writing the MBR back to disk.Finally, the sector field for the CHS addressing of this fake partition is given the value 1 and a jump is made to the main function from the relocated code.
+This range is used as a (fake) partition table for writing the MBR back to disk. Finally, the sector field for the CHS addressing of this fake partition is given the value 1 and a jump is made to the main function from the relocated code.
 Note that until this jump to the relocated code, any reference to an absolute address was avoided.
 
 The following code block tests whether the drive number provided by the BIOS should be used, or the one stored in [.filename]#boot0#.

--- a/documentation/content/en/books/arch-handbook/boot/_index.adoc
+++ b/documentation/content/en/books/arch-handbook/boot/_index.adoc
@@ -50,8 +50,7 @@ endif::[]
 [[boot-synopsis]]
 == Synopsis
 
-This chapter is an overview of the boot and system initialization processes,
-starting from the BIOS (firmware) POST, to the first user process creation.
+This chapter is an overview of the boot and system initialization processes, starting from the BIOS (firmware) POST, to the first user process creation.
 Since the initial steps of system startup are very architecture dependent, the IA-32 architecture is used as an example.
 But the AMD64 and ARM64 architectures are much more important and compelling examples and should be explained in the near future according to the topic of this document.
 
@@ -147,19 +146,16 @@ FreeBSD clang version 11.0.1 (git@github.com:llvm/llvm-project.git llvmorg-11.0.
 == The BIOS
 
 When the computer powers on, the processor's registers are set to some predefined values.
-One of the registers is the _instruction pointer_ register,
-and its value after a power on is well defined: it is a 32-bit value of `0xfffffff0`.
+One of the registers is the _instruction pointer_ register, and its value after a power on is well defined: it is a 32-bit value of `0xfffffff0`.
 The instruction pointer register (also known as the Program Counter) points to code to be executed by the processor.
 Another important register is the `cr0` 32-bit control register, and its value just after a reboot is `0`.
-One of ``cr0``'s bits, the PE (Protection Enabled) bit,
-indicates whether the processor is running in 32-bit protected mode or 16-bit real mode.
+One of ``cr0``'s bits, the PE (Protection Enabled) bit, indicates whether the processor is running in 32-bit protected mode or 16-bit real mode.
 Since this bit is cleared at boot time, the processor boots in 16-bit real mode.
 Real mode means, among other things, that linear and physical addresses are identical.
 The reason for the processor not to start immediately in 32-bit protected mode is backwards compatibility.
 In particular, the boot process relies on the services provided by the BIOS, and the BIOS itself works in legacy, 16-bit code.
 
-The value of `0xfffffff0` is slightly less than 4 GB,
-so unless the machine has 4 GB of physical memory, it cannot point to a valid memory address.
+The value of `0xfffffff0` is slightly less than 4 GB, so unless the machine has 4 GB of physical memory, it cannot point to a valid memory address.
 The computer's hardware translates this address so that it points to a BIOS memory block.
 
 The BIOS (Basic Input Output System) is a chip on the motherboard that has a relatively small amount of read-only memory (ROM).
@@ -273,7 +269,7 @@ The next block is responsible for the relocation and subsequent jump to the relo
 
 [.programlisting]
 ....
-      movw %sp,%si		# Source
+      movw %sp,%si              # Source
       movw $start,%di		# Destination
       movw $0x100,%cx		# Word count
       rep			# Relocate
@@ -287,14 +283,12 @@ The next block is responsible for the relocation and subsequent jump to the relo
 ....
 
 .[.filename]#stand/i386/boot0/boot0.S# [[boot-boot0-relocation]]
-As [.filename]#boot0# is loaded by the BIOS to address `0x7C00`,
-it copies itself to address `0x600` and then transfers control there (recall that it was linked to execute at address `0x600`).
+As [.filename]#boot0# is loaded by the BIOS to address `0x7C00`, it copies itself to address `0x600` and then transfers control there (recall that it was linked to execute at address `0x600`).
 The source address, `0x7c00`, is copied to register `%si`.
 The destination address, `0x600`, to register `%di`.
 The number of words to copy, `256` (the program's size = 512 bytes), is copied to register `%cx`.
 Next, the `rep` instruction repeats the instruction that follows, that is, `movsw`,
 the number of times dictated by the `%cx` register.
-
 The `movsw` instruction copies the word pointed to by `%si` to the address pointed to by `%di`.
 This is repeated another 255 times.
 On each repetition, both the source and destination registers, `%si` and `%di`, are incremented by one.


### PR DESCRIPTION
Currently, it's
> This range is used as a (fake) partition table for writing the MBR back to disk.Finally, the sector field 

It should be
> This range is used as a (fake) partition table for writing the MBR back to disk. Finally, the sector field

(Add a space) 