### PR TITLE
handbook: fix cpufreq man link

### DIFF
--- a/documentation/content/en/books/handbook/config/_index.adoc
+++ b/documentation/content/en/books/handbook/config/_index.adoc
@@ -1252,7 +1252,7 @@ In this example the brightness is decreased by 10%:
 CPU is the most consuming part of the system.
 Knowing how to improve CPU efficiency is a fundamental part of our system in order to save energy.
 
-In order to make proper use of the machine's resources in a correct way, FreeBSD supports technologies such as Intel Turbo Boost, AMD Turbo Core, Intel Speed Shift among others through the use of man:powerd[8] and cpufreq[4].
+In order to make proper use of the machine's resources in a correct way, FreeBSD supports technologies such as Intel Turbo Boost, AMD Turbo Core, Intel Speed Shift among others through the use of man:powerd[8] and man:cpufreq[4].
 
 The first step will be to obtain the CPU information by executing the following command:
 

--- a/documentation/content/en/books/handbook/config/_index.po
+++ b/documentation/content/en/books/handbook/config/_index.po
@@ -2674,7 +2674,7 @@ msgid ""
 "In order to make proper use of the machine's resources in a correct way, "
 "FreeBSD supports technologies such as Intel Turbo Boost, AMD Turbo Core, "
 "Intel Speed Shift among others through the use of man:powerd[8] and "
-"cpufreq[4]."
+"man:cpufreq[4]."
 msgstr ""
 
 #. type: Plain text


### PR DESCRIPTION
`man:` prefix is missing for `cpufreq`.