### PR TITLE
dev-handbook/tools: fix Emacs reference URL and some grammar

### DIFF
--- a/documentation/content/en/books/developers-handbook/tools/_index.adoc
+++ b/documentation/content/en/books/developers-handbook/tools/_index.adoc
@@ -434,7 +434,7 @@ free(foo);
 
 Making one of these mistakes will not always lead to an error, but they are always bad practice.
 Some systems and compilers are more tolerant than others,
-which is why programs that ran well on one system can crash when you try them on an another.
+which is why programs that run well on one system can crash when you try them on another.
 
 ==== Sometimes when I get a core dump it says bus error. It says in my UNIX(R) book that this means a hardware problem, but the computer still seems to be working. Is this true?
 
@@ -1248,7 +1248,7 @@ Instead of using a proprietary macro language for configuration, Emacs uses a ve
 Working with Emacs Lisp can be quite helpful if you want to go on and learn something like Common Lisp.
 Emacs Lisp has many features of Common Lisp, although it is considerably smaller (and thus easier to master).
 
-The best way to learn Emacs Lisp is to download the link:ftp://ftp.gnu.org/old-gnu/emacs/elisp-manual-19-2.4.tar.gz[Emacs Tutorial]
+The best way to learn Emacs Lisp is to read the online link:https://www.gnu.org/software/emacs/manual/elisp.html[Emacs Reference] manual.
 
 However, there is no need to actually know any Lisp to get started with configuring Emacs,
 as I have included a sample [.filename]#.emacs#, which should be enough to get you started.


### PR DESCRIPTION
1. Currently the given link of Emacs tutorial is broken and outdated. Emacs 19 was released way before and the FTP server is also unavailable. As these links get out of date rather quickly, use the online reference URL instead.

2. Fix grammar, use present tense (to match "can") and remove "an". (e.g. ran -> run, an another -> another)