### PR TITLE
dev-handbook/x86: remove line numbers from the example

### DIFF
--- a/documentation/content/en/books/developers-handbook/x86/_index.adoc
+++ b/documentation/content/en/books/developers-handbook/x86/_index.adoc
@@ -541,22 +541,22 @@ We are now ready for our first program, the mandatory Hello, World!
 
 [.programlisting]
 ....
-1:	%include	'system.inc'
- 2:
- 3:	section	.data
- 4:	hello	db	'Hello, World!', 0Ah
- 5:	hbytes	equ	$-hello
- 6:
- 7:	section	.text
- 8:	global	_start
- 9:	_start:
-10:	push	dword hbytes
-11:	push	dword hello
-12:	push	dword stdout
-13:	sys.write
-14:
-15:	push	dword 0
-16:	sys.exit
+	%include	'system.inc'
+
+	section	.data
+	hello	db	'Hello, World!', 0Ah
+	hbytes	equ	$-hello
+
+	section	.text
+	global	_start
+_start:
+	push	dword hbytes
+	push	dword hello
+	push	dword stdout
+	sys.write
+
+	push	dword 0
+	sys.exit
 ....
 
 Here is what it does: Line 1 includes the defines, the macros, and the code from [.filename]#system.inc#.


### PR DESCRIPTION
These line numbers seem to be mistakenly copied from the editor. Since the user is (likely) going to copy-and-paste the example, we should remove these line numbers.