### PR TITLE
doc: Fix path details for nullfs in thin jails

### DIFF
--- a/documentation/content/en/books/handbook/jails/_index.adoc
+++ b/documentation/content/en/books/handbook/jails/_index.adoc
@@ -578,7 +578,7 @@ The next step is to create the symlinks to the `skeleton` by executing the follo
 # ln -s skeleton/etc etc
 # ln -s skeleton/home home
 # ln -s skeleton/root root
-# ln -s skeleton/usr/local usr/local
+# ln -s ../skeleton/usr/local usr/local
 # ln -s skeleton/tmp tmp
 # ln -s skeleton/var var
 ....
@@ -625,7 +625,7 @@ thinjail {
 
   # HOSTNAME/PATH
   host.hostname = "${name}";
-  path = "/usr/local/jails/containers/${name}";
+  path = "/usr/local/jails/thinjail-nullfs-base";
 
   # NETWORK
   ip4.addr = 192.168.1.153;


### PR DESCRIPTION
After following all the instructions about thin jails with nullfs, I found I needed to make these two changes in order for it to work properly. I think these are errors in the handbook.