### PR TITLE
Added a clarification about jail configuration

### DIFF
--- a/documentation/content/en/books/handbook/jails/_index.adoc
+++ b/documentation/content/en/books/handbook/jails/_index.adoc
@@ -250,9 +250,6 @@ There are two ways to configure jails.
 The first one is to add an entry for each jail to the file [.filename]#/etc/jail.conf#.
 The other option is to create a file for each jail in the directory [.filename]#/etc/jail.conf.d/#.
 
-There is no right or wrong option.
-Each administrator must choose the one that best suits their needs.
-
 In case a host system has few jails, an entry for each jail can be added in the file [.filename]#/etc/jail.conf#.
 If the host system has many jails, it is good idea to have one configuration file for each jail in the [.filename]#/etc/jail.conf.d/# directory.
 

--- a/documentation/content/en/books/handbook/jails/_index.adoc
+++ b/documentation/content/en/books/handbook/jails/_index.adoc
@@ -256,6 +256,15 @@ Each administrator must choose the one that best suits their needs.
 In case a host system has few jails, an entry for each jail can be added in the file [.filename]#/etc/jail.conf#.
 If the host system has many jails, it is good idea to have one configuration file for each jail in the [.filename]#/etc/jail.conf.d/# directory.
 
+The files you put in the [.filename]#/etc/jail.conf.d/# directory must have `.conf` as their extension.
+
+If you enabled jails in [.filename]#/etc/rc.conf# you should put the following into [.filename]#/etc/jail.conf#:
+
+[.programmlisting]
+....
+.include "/etc/jail.conf.d/*.conf";
+....
+
 A typical jail entry would look like this:
 
 [.programlisting]

--- a/documentation/content/en/books/handbook/jails/_index.adoc
+++ b/documentation/content/en/books/handbook/jails/_index.adoc
@@ -251,7 +251,7 @@ The first one is to add an entry for each jail to the file [.filename]#/etc/jail
 The other option is to create a file for each jail in the directory [.filename]#/etc/jail.conf.d/#.
 
 In case a host system has few jails, an entry for each jail can be added in the file [.filename]#/etc/jail.conf#.
-If the host system has many jails, it is good idea to have one configuration file for each jail in the [.filename]#/etc/jail.conf.d/# directory.
+If the host system has many jails, it is a good idea to have one configuration file for each jail in the [.filename]#/etc/jail.conf.d/# directory.
 
 The files you put in the [.filename]#/etc/jail.conf.d/# directory must have `.conf` as their extension.
 

--- a/documentation/content/en/books/handbook/jails/_index.adoc
+++ b/documentation/content/en/books/handbook/jails/_index.adoc
@@ -253,9 +253,7 @@ The other option is to create a file for each jail in the directory [.filename]#
 In case a host system has few jails, an entry for each jail can be added in the file [.filename]#/etc/jail.conf#.
 If the host system has many jails, it is a good idea to have one configuration file for each jail in the [.filename]#/etc/jail.conf.d/# directory.
 
-The files you put in the [.filename]#/etc/jail.conf.d/# directory must have `.conf` as their extension.
-
-If you enabled jails in [.filename]#/etc/rc.conf# you should put the following into [.filename]#/etc/jail.conf#:
+The files in [.filename]#/etc/jail.conf.d/# must have `.conf` as their extension and have to be included in [.filename]#/etc/jail.conf#:
 
 [.programmlisting]
 ....


### PR DESCRIPTION
- Files in /etc/jail.conf.d must have a .conf extension in order for the tools to pick them up.
- Autostart of jails requires the /etc/jail.conf file.