### PR TITLE
status: 2023q4: portmgr: corrections

### DIFF
--- a/website/content/en/status/report-2023-10-2023-12/portmgr.adoc
+++ b/website/content/en/status/report-2023-10-2023-12/portmgr.adoc
@@ -21,6 +21,7 @@ The number of ports also fell a bit (down from 34,600).
 
 In Q4 there were around 9424 commits to main.
 The most active committers where:
+
         sunpoet   2946
         yuri       861
         bofh       793

--- a/website/content/en/status/report-2023-10-2023-12/portmgr.adoc
+++ b/website/content/en/status/report-2023-10-2023-12/portmgr.adoc
@@ -2,9 +2,8 @@
 
 Links: +
 link:https://www.FreeBSD.org/ports/[About FreeBSD Ports] URL: link:https://www.FreeBSD.org/ports/[] +
-link:https://docs.freebsd.org/en/articles/contributing/#ports-contributing[Contributing
-to Ports] URL: link:https://docs.freebsd.org/en/articles/contributing/#ports-contributing[]
-+
+link:https://docs.freebsd.org/en/articles/contributing/#ports-contributing[Contributing to Ports] URL: link:https://docs.freebsd.org/en/articles/contributing/#ports-contributing[]
+
 link:https://www.freebsd.org/portmgr/[Ports Management Team] URL: link:https://www.freebsd.org/portmgr/[] +
 link:http://ftp.freebsd.org/pub/FreeBSD/ports/ports/[Ports Tarball] URL: link:http://ftp.freebsd.org/pub/FreeBSD/ports/ports/[]
 

--- a/website/content/en/status/report-2023-10-2023-12/portmgr.adoc
+++ b/website/content/en/status/report-2023-10-2023-12/portmgr.adoc
@@ -11,16 +11,16 @@ Contact: Tobias C. Berner <portmgr-secretary@FreeBSD.org> +
 Contact: FreeBSD Ports Management Team <portmgr@FreeBSD.org>
 
 The Ports Management Team is responsible for overseeing the overall direction of the Ports Tree, building packages, and personnel matters.
-Below is what happened in the last quarter.
+Below is what happened in the quarter.
 
 * According to INDEX, there are currently 31,942 ports in the Ports Collection.
 There are currently ~3,100 open ports PRs.
-The last quarter saw 9,424 commits by 157 committers on the main branch and 781 commits by 71 committers on the 2023Q4 branch.
+The quarter saw 9,424 commits by 157 committers on the main branch and 781 commits by 71 committers on the 2023Q4 branch.
 Compared to last quarter, this means a hefty decrease in the number of commits on the main branch (down from 11,454) and slightly fewer backports to the quarterly branch (down from 828).
 The number of ports also fell a bit (down from 34,600).
 
 In Q4 there were around 9424 commits to main.
-The most active committers where:
+The most active committers were:
 
         sunpoet   2946
         yuri       861
@@ -47,8 +47,6 @@ The following happened on the infrastructure side:
 
 * Packages for 14.0-RELEASE were built
 * Poudriere was updated to release-3.4
-
-Support for FreeBSD 12.x was removed.
 
 The no-longer maintained package:www/qt5-webkit[] was removed.
 

--- a/website/content/en/status/report-2023-10-2023-12/portmgr.adoc
+++ b/website/content/en/status/report-2023-10-2023-12/portmgr.adoc
@@ -44,23 +44,30 @@ Similar to when flavors were introduced, new subpackages will require an approva
 With subpackages it is possible to create multiple packages from a single build of a port.
 
 The following happened on the infrastructure side:
+
 * Packages for 14.0-RELEASE were built
 * Poudriere was updated to release-3.4
 
-* Support for FreeBSD 12.x was removed.
-* The no-longer maintained package:www/qt5-webkit[] was removed.
-* postgresql11, php80, mysql57, percona57, ghostscript9 were removed.
-* The following default versions changed:
-    * perl                    to 5.36
-    * ghostcript              to 10
-    * corosync                to 3
-* Updates to major ports that happened were:
-    * package:ports-mgmt/pkg[]          to 1.20.9
-    * package:ports-mgmt/poudriere[]    to 3.4.0 (subpackage support)
-    * KDE-bits                to plasma-5.27.10, frameworks-5.112, gear-23.08.4, and beta-2
-    * package:www/chromium[]            to 120.0.6099.129
-    * package:www/firefox[]             to 121.0 (rc1)
-    * package:lang/rust[]               to 1.74.1
-    * ... and many more ...
+Support for FreeBSD 12.x was removed.
+
+The no-longer maintained package:www/qt5-webkit[] was removed.
+
+postgresql11, php80, mysql57, percona57, ghostscript9 were removed.
+
+The following default versions changed:
+
+* perl                    to 5.36
+* ghostcript              to 10
+* corosync                to 3
+
+Updates to major ports that happened were:
+
+* package:ports-mgmt/pkg[]          to 1.20.9
+* package:ports-mgmt/poudriere[]    to 3.4.0 (subpackage support)
+* KDE-bits                to plasma-5.27.10, frameworks-5.112, gear-23.08.4, and beta-2
+* package:www/chromium[]            to 120.0.6099.129
+* package:www/firefox[]             to 121.0 (rc1)
+* package:lang/rust[]               to 1.74.1
+* ... and many more ...
 
 During the last quarter, pkgmgr@ ran 26 exp-runs to test various ports upgrades, updates to default versions of ports, subpackage support and base system changes.


### PR DESCRIPTION
```text
Rendered '+ ' at the beginning of a line was the result of superfluous
+ markup in isolation on the preceding line.

Remove a superfluous line ending from the sentence that preceded the +.

Do not describe the quarter of the report as the last quarter (doing so
makes nonsense of comparing the last quarter with the last quarter).

Typo: were (not where).

Add a line, for a simple table to appear where a table was intended.

Add a line, to create a list where a list was intended.

Fix subsequent list items.

Deduplicate the statements about removal of support for FreeBSD 12.x.
```