### PR TITLE
Change wlandevice -> wlandev.

### DIFF
--- a/documentation/content/en/books/handbook/network/_index.adoc
+++ b/documentation/content/en/books/handbook/network/_index.adoc
@@ -619,7 +619,7 @@ To find out what wireless network cards are in the system check the section <<co
 
 [source,shell]
 ....
-# ifconfig wlan0 create wlandevice iwm0
+# ifconfig wlan0 create wlandev iwm0
 ....
 
 To make the change persist across reboots execute the following command:

--- a/documentation/content/en/books/handbook/network/_index.po
+++ b/documentation/content/en/books/handbook/network/_index.po
@@ -1346,7 +1346,7 @@ msgstr ""
 #. type: delimited block . 4
 #: documentation/content/en/books/handbook/network/_index.adoc:623
 #, no-wrap
-msgid "# ifconfig wlan0 create wlandevice iwm0\n"
+msgid "# ifconfig wlan0 create wlandev iwm0\n"
 msgstr ""
 
 #. type: delimited block . 4


### PR DESCRIPTION
As of `14.0`, `wlandev` appears to be the right parameter, not `wlandevice`:

https://man.freebsd.org/cgi/man.cgi?ifconfig

I configured my wifi card correctly following the instructions on the page using `wlandev`.