### PR TITLE
status: 2023q4: GNOME: corrections

### DIFF
--- a/website/content/en/status/report-2023-10-2023-12/gnome-contributions.adoc
+++ b/website/content/en/status/report-2023-10-2023-12/gnome-contributions.adoc
@@ -4,7 +4,7 @@ Links: +
 link:https://www.gnome.org/[GNOME] URL: link:https://www.gnome.org/[] +
 link:https://codeberg.org/olivierd/freebsd-ports-gnome[Development repository] URL: link:https://codeberg.org/olivierd/freebsd-ports-gnome[]
 
-Contact: FreeBSD GNOME Team <gnome@FreeBSD.org>
+Contact: FreeBSD GNOME Team <gnome@FreeBSD.org> +
 Contact: Olivier Duchateau <duchateau.olivier@gmail.com>
 
 GNOME is a full desktop environment which is mainly based on GLib, GTK3/GTK4, and libadwaita.
@@ -43,5 +43,5 @@ Tests and patches are welcomed, especially for WebKitGTK.
 Next months I plan to work on:
 
 * Allowing selecting a session in display manager (gdm), it is regression with our patches.
-* Fixing sharing network (VNC, SSH) panel in package:sysutils[gnome-control-center] and backport for link:https://bugs.freebsd.org/bugzilla/show_bug.cgi?id=275900[bug #275900].
+* Fixing sharing network (VNC, SSH) panel in package:sysutils/gnome-control-center[] and backport for link:https://bugs.freebsd.org/bugzilla/show_bug.cgi?id=275900[bug #275900].
 * Continuing to update applications and libraries for GNOME 45.


### PR DESCRIPTION
Add a missing line break.

Correct the link for sysutils/gnome-control-center.