### PR TITLE
13.3R/readme: corrections, changes

### DIFF
--- a/website/content/en/releases/13.3R/readme.adoc
+++ b/website/content/en/releases/13.3R/readme.adoc
@@ -123,7 +123,7 @@ Other Project-maintained books and articles are more specialized -- covering a w
 
 For offline documentation in HTML and PDF formats: you can install a language-specific package such as package:misc/freebsd-doc-en[] (_-en_ for English), or multi-language package:misc/freebsd-doc-all[]. Alternatively, use a copy of the [.filename]`doc` repo to build and install from source code.
 
-A listing of other books and documents about FreeBSD can be found in the link:{handbook}#bibliography[bibliography] of the FreeBSD Handbook. Because of FreeBSD's strong UNIX(R) heritage, many other articles and books written for UNIX(R) systems are applicable as well, some of which are also listed in the bibliography.
+A listing of other books and documents about FreeBSD can be found in the link:{handbook}bibliography[bibliography] of the FreeBSD Handbook. Because of FreeBSD's strong UNIX(R) heritage, many other articles and books written for UNIX(R) systems are applicable as well, some of which are also listed in the bibliography.
 
 [[acknowledgements]]
 == Acknowledgments


### PR DESCRIPTION
```text
Fix the link to the FreeBSD Handbook bibliography. 

Sentence markup.
…
```

Affects: 

https://www.freebsd.org/releases/13.3R/readme/