### PR TITLE
13.3R/relnotes: corrections

### DIFF
--- a/website/content/en/releases/13.3R/relnotes.adoc
+++ b/website/content/en/releases/13.3R/relnotes.adoc
@@ -213,7 +213,7 @@ gitref:0fb0306a89ad[repository=src]
 
 A problem with the `graid` implementation of Promise RAID1 created with 4 or more disks has been fixed.
 The array worked only until reboot.
-gitref:94ceefc2f2f5[repository=src]
+gitref:394ceefc2f2f[repository=src]
 
 The man:iwlwifi[4] driver for Intel wireless interfaces has been updated, supporting chipsets up to B200.
 (Sponsored by The FreeBSD Foundation)

--- a/website/content/en/releases/13.3R/relnotes.adoc
+++ b/website/content/en/releases/13.3R/relnotes.adoc
@@ -198,7 +198,7 @@ This section covers changes to kernel configurations, system tuning, and system 
 === General Kernel Changes
 
 The man:intro[9] introduction to the kernel programming interfaces has been completely rewritten.
-gitref:5a0c410787b8[repository=src] gitref:221a6bc397ad[repository=src] gitref:2cd20d9bc807[repository=src] (Sponsored by The FreeBSD Foundation)
+gitref:5a0c410787b8[repository=src] (Sponsored by The FreeBSD Foundation)
 
 [[drivers]]
 == Devices and Drivers


### PR DESCRIPTION
```text
Two of the three references for OpenSSH were duplicated in the
paragraph for intro(9).

Correct the reference for
graid: MFC: unbreak Promise RAID1 with 4+ providers.
```