### PR TITLE
Fix typo in handbook/wayland

### DIFF
--- a/documentation/content/en/books/handbook/wayland/_index.adoc
+++ b/documentation/content/en/books/handbook/wayland/_index.adoc
@@ -206,7 +206,7 @@ One final thing to note is the <super> key.
 Most of the configuration mentions this key, and it is the traditional `Windows` key on the keyboard.
 Most keyboards have this super key available; however, it should be remapped within this configuration file if it is not available.
 For example, to lock the screen, press and hold the super key, the kbd:[shift] key, and press the kbd:[escape] key.
-nless the mappings have changed, this will execute the swaylock application.
+Unless the mappings have changed, this will execute the swaylock application.
 The default configuration for `swaylock` will show a grey screen; however, the application is highly customizable and well documented.
 In addition, since the swaylock-effects is the version that was installed, there are several options available such as the blur effect, which can be seen using the following command:
 


### PR DESCRIPTION
Change 'nless' to 'Unless'