### PR TITLE
fix package URLs, and highlight the elisp code

### DIFF
--- a/documentation/content/en/books/fdp-primer/editor-config/_index.adoc
+++ b/documentation/content/en/books/fdp-primer/editor-config/_index.adoc
@@ -52,7 +52,7 @@ Adjusting your text editor configuration can make working on document files quic
 [[editor-config-vim]]
 == Vim
 
-Install from package:editors/vim[], or package:editors/vim-console[], then follow the configuration instructions in <<editor-config-vim-config>>.
+Install from package:editors/vim[], then follow the configuration instructions in <<editor-config-vim-config>>.
 More advanced users can use a proper linter like link:https://github.com/dense-analysis/ale[Ale] which can also act as a Vim link:https://langserver.org/[Language Server Protocol] client.
 
 [[editor-config-vim-use]]
@@ -238,6 +238,7 @@ Again, add these lines to Emacs's initialization file to make the changes perman
 
 To apply settings specific to the FreeBSD documentation project, create [.filename]#.dir-locals.el# in the root directory of the documentation repository and add these lines to the file:
 
+[source,emacs-lisp]
 ....
 ;;; Directory Local Variables
 ;;; For more information see (info "(emacs) Directory Variables")
@@ -254,7 +255,7 @@ To apply settings specific to the FreeBSD documentation project, create [.filena
 [[editor-config-nano]]
 == nano
 
-Install from package:editors/nano[] or package:editors/nano-devel[].
+Install from package:editors/nano[].
 
 [[editor-config-nano-config]]
 === Configuration


### PR DESCRIPTION
1. There seem to be no package called vim-console or nano-devel in the ports tree, rather it's now just called vim or nano (depending on which one a user will install).

2. Highlight the emacs lisp syntax.