### PR TITLE
handbook/wine: add Mizuma's source code URL, and small typos

### DIFF
--- a/documentation/content/en/books/handbook/wine/_index.adoc
+++ b/documentation/content/en/books/handbook/wine/_index.adoc
@@ -52,7 +52,7 @@ endif::[]
 == Synopsis
 
 https://www.winehq.org/[WINE], which stands for Wine Is Not an Emulator, is technically a software translation layer.
-It enables to install and run some software written for Windows(R) on FreeBSD (and other) systems.
+It enables to install and run software written for Windows(R) on FreeBSD (and other) systems.
 
 It operates by intercepting system calls, or requests from the software to the operating system, and translating them from Windows(R) calls to calls that FreeBSD understands.
 It will also translate any responses as needed into what the Windows(R) software is expecting.
@@ -483,7 +483,7 @@ The below sections include a selection of the most popular.
 === Winetricks
 
 The `winetricks` tool is a cross-platform, general purpose helper program for WINE.
-It is not developed by the WINE project proper, but rather maintained on https://github.com/Winetricks/winetricks[Github] by a group of contributors.
+It is not developed by the WINE project proper, but rather maintained on https://github.com/Winetricks/winetricks[GitHub] by a group of contributors.
 It contains some automated "recipes" for getting common applications to work on WINE, both by optimizing the settings as well as acquiring some DLL libraries automatically.
 
 [[installing-winetricks]]
@@ -556,7 +556,7 @@ image::winetricks-uninstall-3.png[]
 [[homura]]
 === Mizutamari
 
-Mizutamari is an application similar to `winetricks`, although it was inspired by the https://lutris.net/[Lutris] gaming system for Linux.
+https://codeberg.org/Alexander88207/Mizutamari[Mizutamari] is an application similar to `winetricks`, although it was inspired by the https://lutris.net/[Lutris] gaming system for Linux.
 But while it is focused on games, there are also non-gaming applications available for install through Mizutamari.
 
 [[installing-homura]]
@@ -890,5 +890,5 @@ There are plenty of places FreeBSD users discuss issues related to WINE that can
 There are a number of resources focused on other operating systems that may be useful for FreeBSD users:
 
 * https://wiki.winehq.org/[The WINE Wiki] has a wealth of information on using WINE, much of which is applicable across many of WINE's supported operating systems.
-* Similarly, the documentation available from other OS projects can also be of good value. https://wiki.archlinux.org/index.php/wine[The WINE page] on the Arch Linux Wiki is a particularly good example, although some of the "Third-party applications" (i.e., "companion applications") are obviously not available on FreeBSD.
+* Similarly, the documentation available from other OS projects can also be of good value. https://wiki.archlinux.org/title/wine[The WINE page] on the Arch Linux Wiki is a particularly good example, although some of the "Third-party applications" (i.e., "companion applications") are obviously not available on FreeBSD.
 * Finally, Codeweavers (a developer of a commercial version of WINE) is an active upstream contributor. Oftentimes answers to questions in https://www.codeweavers.com/support/forums[their support forum] can be of aid in troubleshooting problems with the open source version of WINE.


### PR DESCRIPTION
1. It's particularly interesting to know what games/apps are currently "supported" through Mizuma, so it's a good idea to link the source code URL (winetricks source code URL is also already mentioned.)
2. Remove the word "some" from the synopsis. It's ambiguous to know the meaning of "some" here, whereas Wine is intended (and does support) a wide range of Windows applications out of the box.
3. Use the word GitHub instead Github (ignorable).
4. Also edit the Arch Wiki URL (it redirects to that new URL from the previous one) (forgot to mention in the commit).