### PR TITLE
fix jexec example

### DIFF
--- a/documentation/content/en/books/handbook/jails/_index.adoc
+++ b/documentation/content/en/books/handbook/jails/_index.adoc
@@ -988,7 +988,7 @@ For example, to stop a service that is running inside a jail, the command will b
 
 [source,shell]
 ....
-# jexec -l jailname service stop nginx
+# jexec -l jailname service nginx stop
 ....
 
 [[jail-upgrading]]


### PR DESCRIPTION
Correct the usage of `service` in the jexec example.