### PR TITLE
Handbook 9.5.2: Google Meet does work on Firefox on my Fx 14.0p6

### DIFF
--- a/documentation/content/en/books/handbook/multimedia/_index.adoc
+++ b/documentation/content/en/books/handbook/multimedia/_index.adoc
@@ -579,7 +579,7 @@ FreeBSD currently supports the following tools used to carry out videoconference
 | link:https://teams.live.com[]
 
 | Google Meet
-| Does not work
+| Works
 | Works
 | link:https://meet.google.com/[]
 


### PR DESCRIPTION
I was actually not able to get it working on chromium, but I only installed chromium to attempt to use Google Meet based on this info.

EDIT: This is my first time trying to touch the handbook, please forgive and correct nits.