### PR TITLE
Status/2024Q1/_index.adoc: Sort reports

### DIFF
--- a/website/content/en/status/report-2024-01-2024-03/_index.adoc
+++ b/website/content/en/status/report-2024-01-2024-03/_index.adoc
@@ -1,0 +1,151 @@
+---
+title: "FreeBSD Status Report First Quarter 2024"
+sidenav: about
+---
+
+= Introduction
+:doctype: article
+:toc: macro
+:toclevels: 2
+:icons: font
+:!sectnums:
+:source-highlighter: rouge
+:experimental:
+:reports-path: content/en/status/report-2024-01-2024-03
+
+include::content/en/status/categories-desc.adoc[]
+
+include::{reports-path}/intro.adoc[]
+
+'''
+
+toc::[]
+
+'''
+
+[[FreeBSD-Team-Reports]]
+== FreeBSD Team Reports
+
+{FreeBSD-Team-Reports-desc}
+
+include::{reports-path}/core.adoc[]
+
+'''
+
+include::{reports-path}/freebsd-foundation.adoc[]
+
+'''
+
+include::{reports-path}/releng.adoc[]
+
+'''
+
+include::{reports-path}/clusteradm.adoc[]
+
+'''
+
+include::{reports-path}/ci.adoc[]
+
+'''
+
+include::{reports-path}/portmgr.adoc[]
+
+'''
+
+[[projects]]
+== Projects
+
+{projects-desc}
+
+include::{reports-path}/audio.adoc[]
+
+'''
+
+include::{reports-path}/bhyve.adoc[]
+
+'''
+
+include::{reports-path}/bsdinstall.adoc[]
+
+'''
+
+[[userland]]
+== Userland
+
+{userland-desc}
+
+include::{reports-path}/libsys.adoc[]
+
+'''
+
+include::{reports-path}/packagekit.adoc[]
+
+'''
+
+[[kernel]]
+== Kernel
+
+{kernel-desc}
+
+include::{reports-path}/wireless.adoc[]
+
+'''
+
+[[architectures]]
+== Architectures
+
+{architectures-desc}
+
+include::{reports-path}/ten64-whle-honeycomb.adoc[]
+
+'''
+
+[[cloud]]
+== Cloud
+
+{cloud-desc}
+
+include::{reports-path}/azure.adoc[]
+
+'''
+
+include::{reports-path}/cloud-init.adoc[]
+
+'''
+
+include::{reports-path}/openstack.adoc[]
+
+'''
+
+[[documentation]]
+== Documentation
+
+{documentation-desc}
+
+include::{reports-path}/doceng.adoc[]
+
+'''
+
+[[ports]]
+== Ports
+
+{ports-desc}
+
+include::{reports-path}/freshports.adoc[]
+
+'''
+
+include::{reports-path}/gcc.adoc[]
+
+'''
+
+include::{reports-path}/valgrind.adoc[]
+
+'''
+
+[[third-Party-Projects]]
+== Third Party Projects
+
+{third-Party-Projects-desc}
+
+include::{reports-path}/pot.adoc[]


### PR DESCRIPTION
I have restored some good old status tools in a special branch of my own freebsd-doc fork. They were not suitable for the official freebsd-doc repo, but they are still very useful and efficient (at least for my own workflow). There you might find easier to judge the reports sorting: https://github.com/lsalvadore/freebsd-doc/commit/06d367d9297038bb15885d74b43d22fa32b5fd5f .