### PR TITLE
14.1R: reveal the release notes

### DIFF
--- a/website/content/en/releases/14.1R/_index.adoc
+++ b/website/content/en/releases/14.1R/_index.adoc
@@ -24,7 +24,7 @@ can be found at these pages:
 //link:signatures[FreeBSD {localRel}-RELEASE signed checksum files] +
 //link:installation[FreeBSD {localRel}-RELEASE installation information] +
 //link:hardware[FreeBSD {localRel}-RELEASE hardware information] +
-//link:relnotes[FreeBSD {localRel}-RELEASE release notes] +
+link:relnotes[FreeBSD {localRel}-RELEASE release notes] +
 //link:errata[FreeBSD {localRel}-RELEASE errata] +
 //link:readme[FreeBSD {localRel}-RELEASE readme] +
 link:schedule[FreeBSD {localRel}-RELEASE schedule] +


### PR DESCRIPTION
```text
https://mail-archive.freebsd.org/cgi/mid.cgi?20240512153850.B0D01257D9
discloses the link to release notes.

Disclose at the main page.
```