### PR TITLE
Fix thinjail instructions on UFS

### DIFF
--- a/documentation/content/en/books/handbook/jails/_index.adoc
+++ b/documentation/content/en/books/handbook/jails/_index.adoc
@@ -597,11 +597,10 @@ In case of using OpenZFS, OpenZFS snapshots can be used to easily create as many
 # zfs clone zroot/jails/templates/13.2-RELEASE-skeleton@base zroot/jails/containers/thinjail
 ....
 
-In case of using UFS the man:cp[1] program can be used by executing the following commands:
+In case of using UFS the man:cp[1] program can be used by executing the following command:
 
 [source,shell]
 ....
-# mkdir /usr/local/jails/containers/thinjail
 # cp -R /usr/local/jails/templates/13.2-RELEASE-skeleton /usr/local/jails/containers/thinjail
 ....
 


### PR DESCRIPTION
### Description 

The zfs instructions say to clone a snapshot from the skeleton to the new thinjail. But the UFS instructions say to _make_ the thinjail directory first and then copy the skeleton into it. This will cause your new jail to be inside of `/usr/local/jails/containers/thinjail/13.2-RELEASE-skeleton` instead of just `/usr/local/jails/containers/thinjail`.