### PR TITLE
Fix wording to reflect commands without DHCP

### DIFF
--- a/documentation/content/en/books/handbook/network/_index.adoc
+++ b/documentation/content/en/books/handbook/network/_index.adoc
@@ -495,7 +495,7 @@ To assign a default router, specify its address executing the following command:
 If the network has a DHCP server, it is very easy to configure the network interface to use DHCP.
 man:dhclient[8] will provide automatically the IP, the netmask and the default router.
 
-To make the interface work with DHCP execute the following command:
+To make the interface work without DHCP, execute the following commands:
 
 [source,shell]
 ....


### PR DESCRIPTION
The `sysrc` commands would be enabled when an interface configures its address via SLAAC, not DHCP. Hence, the instruction is incorrect.