### PR TITLE
releng: 14.1 (correction) and suggested changes

### DIFF
--- a/website/content/en/releng/_index.adoc
+++ b/website/content/en/releng/_index.adoc
@@ -13,7 +13,7 @@ About the FreeBSD release engineering (RE) process.
 * <<schedule,Upcoming Release Schedule>>
 * <<freeze,Code Freeze Status>>
 * link:../releng/charter/[Charter for the Release Engineering Team]
-* <<docs,Release Engineering Documentation>>
+* <<docs,Documentation>>
 * <<team,Teams>>
 * <<old,Old Releases>>
 
@@ -74,10 +74,12 @@ Commits to any branch listed as "frozen" must first be reviewed and approved by 
 Historic `src` branches corresponding to FreeBSD 10.x and earlier are not represented above.
 
 [[docs]]
-== Release Engineering Documentation
+== Documentation
 
-* link:{freebsd-releng}[FreeBSD Release Engineering] +
-This document details the approach used by the FreeBSD release engineering team to make production-quality releases of the FreeBSD Operating System. It describes the tools available for those interested in producing customized FreeBSD releases for corporate rollouts or commercial productization.
+link:{freebsd-releng}[FreeBSD Release Engineering] describes: 
+
+- the Primary Release Engineering Team's methods
+- tools to customize releases.
 
 [[team]]
 == Teams

--- a/website/content/en/releng/_index.adoc
+++ b/website/content/en/releng/_index.adoc
@@ -45,7 +45,7 @@ Commits to any branch listed as "frozen" must first be reviewed and approved by 
 [cols="1,1,2,4",options="header",]
 |===
 |`src`&nbsp;tree&nbsp;branch |Status |Contact |Notes
-|`main` |Open |committers |Active development branch for 15.0-CURRENT.
+|`main` |Open |committers |Development branch for 15.0-CURRENT.
 |`stable/14` |Open |committers |Development branch for FreeBSD 14-STABLE.
 |`releng/14.1` |Frozen |re@FreeBSD.org |FreeBSD 14.1 supported errata fix branch.
 |`releng/14.0` |Frozen |security-officer@FreeBSD.org |FreeBSD 14.0 supported errata fix branch.

--- a/website/content/en/releng/_index.adoc
+++ b/website/content/en/releng/_index.adoc
@@ -44,7 +44,7 @@ Commits to any branch listed as "frozen" must first be reviewed and approved by 
 [.tblbasic]
 [cols="1,1,2,4",options="header",]
 |===
-|`src` tree branch |Status |Contact |Notes
+|`src`&nbsp;tree&nbsp;branch |Status |Contact |Notes
 |`main` |Open |committers |Active development branch for 15.0-CURRENT.
 |`stable/14` |Open |committers |Development branch for FreeBSD 14-STABLE.
 |`releng/14.1` |Frozen |re@FreeBSD.org |FreeBSD 14.1 supported errata fix branch.

--- a/website/content/en/releng/_index.adoc
+++ b/website/content/en/releng/_index.adoc
@@ -45,7 +45,7 @@ Commits to any branch listed as "frozen" must first be reviewed and approved by 
 [cols="1,1,2,4",options="header",]
 |===
 |`src`&nbsp;tree&nbsp;branch |Status |Contact |Notes
-|`main` |Open |committers |Development branch for 15.0-CURRENT.
+|`main` |Open |committers |Development branch for FreeBSD 15.0-CURRENT.
 |`stable/14` |Open |committers |Development branch for FreeBSD 14-STABLE.
 |`releng/14.1` |Frozen |re@FreeBSD.org |FreeBSD 14.1 supported errata fix branch.
 |`releng/14.0` |Frozen |security-officer@FreeBSD.org |FreeBSD 14.0 supported errata fix branch.

--- a/website/content/en/releng/_index.adoc
+++ b/website/content/en/releng/_index.adoc
@@ -8,13 +8,13 @@ include::shared/en/urls.adoc[]
 
 = Release Engineering Information
 
-This page contains documentation about the FreeBSD release engineering process.
+About the FreeBSD release engineering (RE) process.
 
 * <<schedule,Upcoming Release Schedule>>
 * <<freeze,Code Freeze Status>>
 * link:../releng/charter/[Charter for the Release Engineering Team]
 * <<docs,Release Engineering Documentation>>
-* <<team,Current Release Engineering Team>>
+* <<team,Teams>>
 * <<old,Old Releases>>
 
 ////
@@ -80,9 +80,9 @@ Historic `src` branches corresponding to FreeBSD 10.x and earlier are not repres
 This document details the approach used by the FreeBSD release engineering team to make production-quality releases of the FreeBSD Operating System. It describes the tools available for those interested in producing customized FreeBSD releases for corporate rollouts or commercial productization.
 
 [[team]]
-== Release Engineering Team
+== Teams
 
-The primary release engineering team is responsible for approving link:{handbook}glossary/#mfc-glossary[MFC] requests during code freezes, setting release schedules, and all of the other responsibilities laid out in our link:../releng/charter/[charter].
+The Primary Release Engineering Team is responsible for approving link:{handbook}glossary/#mfc-glossary[MFC] requests during code freezes, setting release schedules, and all of the other responsibilities laid out in its link:../releng/charter/[charter].
 
 *Primary RE Team (re@FreeBSD.org)* : {re-members} form the primary release engineering decision-making group.
 

--- a/website/content/en/releng/_index.adoc
+++ b/website/content/en/releng/_index.adoc
@@ -37,7 +37,7 @@ As of 2024-06-04, the next release has not yet been announced.
 |===
 ////
 [[freeze]]
-== Code-Freeze Status
+== Code Freeze Status
 
 Commits to any branch listed as "frozen" must first be reviewed and approved by the relevant contact party. 
 

--- a/website/content/en/releng/_index.adoc
+++ b/website/content/en/releng/_index.adoc
@@ -39,12 +39,12 @@ As of 2024-06-04, the next release has not yet been announced.
 [[freeze]]
 == Code-Freeze Status
 
-This table lists the code freeze status for major branches of the `src/` repository of the FreeBSD Git repositories. Commits to any branch listed as "frozen" must first be reviewed and approved by the relevant contact party. The status of other repositories such as `ports/` and `doc/` is also provided below.
+Commits to any branch listed as "frozen" must first be reviewed and approved by the relevant contact party. 
 
 [.tblbasic]
 [cols="1,1,2,4",options="header",]
 |===
-|Branch |Status |Contact |Notes
+|`src` tree branch |Status |Contact |Notes
 |`main` |Open |committers |Active development branch for 15.0-CURRENT.
 |`stable/14` |Open |committers |Development branch for FreeBSD 14-STABLE.
 |`releng/14.1` |Frozen |re@FreeBSD.org |FreeBSD 14.1 supported errata fix branch.
@@ -66,12 +66,12 @@ This table lists the code freeze status for major branches of the `src/` reposit
 |`releng/11.2` |Frozen |security-officer@FreeBSD.org |FreeBSD 11.2 errata fix branch (not officially supported).
 |`releng/11.1` |Frozen |security-officer@FreeBSD.org |FreeBSD 11.1 errata fix branch (not officially supported).
 |`releng/11.0` |Frozen |security-officer@FreeBSD.org |FreeBSD 11.0 errata fix branch (not officially supported).
-|*Repository* |*Status* |*Contact* |*Notes*
+|*Tree* |*Status* |*Contact* |*Notes*
 |`ports/` |Open |portmgr@FreeBSD.org |FreeBSD Ports Collection.
 |`doc/` |Open |freebsd-doc@FreeBSD.org |ASCIIDoc-based documentation set.
 |===
 
-(Branches corresponding to FreeBSD 10.x and earlier are of historical interest only, and are omitted from the table above.)
+Historic `src` branches corresponding to FreeBSD 10.x and earlier are not represented above.
 
 [[docs]]
 == Release Engineering Documentation

--- a/website/content/en/releng/_index.adoc
+++ b/website/content/en/releng/_index.adoc
@@ -47,7 +47,7 @@ This table lists the code freeze status for major branches of the `src/` reposit
 |Branch |Status |Contact |Notes
 |`main` |Open |committers |Active development branch for 15.0-CURRENT.
 |`stable/14` |Open |committers |Development branch for FreeBSD 14-STABLE.
-|`releng/14.1` |Frozen |re@FreeBSD.org |FreeBSD 14.0 supported errata fix branch.
+|`releng/14.1` |Frozen |re@FreeBSD.org |FreeBSD 14.1 supported errata fix branch.
 |`releng/14.0` |Frozen |security-officer@FreeBSD.org |FreeBSD 14.0 supported errata fix branch.
 |`stable/13` |Open |committers |Development branch for FreeBSD 13-STABLE.
 |`releng/13.3` |Frozen |security-officer@FreeBSD.org |FreeBSD 13.3 supported errata fix branch.

--- a/website/content/en/releng/_index.adoc
+++ b/website/content/en/releng/_index.adoc
@@ -93,6 +93,6 @@ The third party packages in the Ports Collection are managed by the pkgmgr@ team
 [[old]]
 == Old Releases
 
-The FreeBSD Project does not maintain a complete archive of old release ISO images, but many of them are available at ftp://ftp-archive.FreeBSD.org/pub/FreeBSD-Archive/old-releases/.
+The FreeBSD Project does not maintain a complete archive of old release ISO images, but many of them are available at http://ftp-archive.freebsd.org/pub/FreeBSD-Archive/old-releases/[].
 
 Older releases that are no longer present on any FTP mirror might still be available from CD-ROM vendors.

--- a/website/content/en/releng/_index.adoc
+++ b/website/content/en/releng/_index.adoc
@@ -93,6 +93,6 @@ The third party packages in the Ports Collection are managed by the pkgmgr@ team
 [[old]]
 == Old Releases
 
-The FreeBSD Project does not maintain a complete archive of old release ISO images, but many of them are available at http://ftp-archive.freebsd.org/pub/FreeBSD-Archive/old-releases/[].
+The archive at http://ftp-archive.freebsd.org/pub/FreeBSD-Archive/old-releases/[] includes many ISO images.
 
-Older releases that are no longer present on any FTP mirror might still be available from CD-ROM vendors.
+The FreeBSD Project does not maintain a complete archive. Older releases that are no longer online may be available from CD-ROM vendors.

--- a/website/content/en/releng/_index.adoc
+++ b/website/content/en/releng/_index.adoc
@@ -65,8 +65,8 @@ As of 2024-06-04, the next release has not yet been announced.
 |`releng/11.1` |Frozen |security-officer@FreeBSD.org |FreeBSD 11.1 errata fix branch (not officially supported).
 |`releng/11.0` |Frozen |security-officer@FreeBSD.org |FreeBSD 11.0 errata fix branch (not officially supported).
 |*Tree* |*Status* |*Contact* |*Notes*
+|`doc/` |Open |freebsd-doc@FreeBSD.org |AsciiDoc-based documentation set.
 |`ports/` |Open |portmgr@FreeBSD.org |FreeBSD Ports Collection.
-|`doc/` |Open |freebsd-doc@FreeBSD.org |ASCIIDoc-based documentation set.
 |===
 
 Commits to frozen branches require prior approval.

--- a/website/content/en/releng/_index.adoc
+++ b/website/content/en/releng/_index.adoc
@@ -39,8 +39,6 @@ As of 2024-06-04, the next release has not yet been announced.
 [[freeze]]
 == Code Freeze Status
 
-Commits to any branch listed as "frozen" must first be reviewed and approved by the relevant contact party. 
-
 [.tblbasic]
 [cols="1,1,2,4",options="header",]
 |===
@@ -71,7 +69,9 @@ Commits to any branch listed as "frozen" must first be reviewed and approved by 
 |`doc/` |Open |freebsd-doc@FreeBSD.org |ASCIIDoc-based documentation set.
 |===
 
-Historic `src` branches corresponding to FreeBSD 10.x and earlier are not represented above.
+Commits to frozen branches require prior approval.
+
+Historic branches for FreeBSD 10.x and earlier are not represented above.
 
 [[docs]]
 == Documentation


### PR DESCRIPTION
```text
14.1 for the releng/14.1 line of the table.

AsciiDoc, not ASCIIDoc.

HTTP instead of FTP for the archive URL.

Rationalise subheadings, reduce verbosity, other minor changes.
```