### PR TITLE
fix(280150): 'Edit this page' link is broken in FreeBSD handbook

### DIFF
--- a/documentation/themes/beastie/layouts/articles/list.html
+++ b/documentation/themes/beastie/layouts/articles/list.html
@@ -47,9 +47,10 @@
           {{ $docType := index $pathSections 1 }}
           {{ $docName := index $pathSections 2 }}
           {{ $pdfFilename := printf "%s_%s.pdf" $docName $docLang }}
+          {{ $adocFileName := printf "%s.adoc" $.Page.File }}
           {{ $pdfUrl := printf "%s%s/%s/%s/%s" $.Site.Params.downloadBaseUrl $docLang $docType $docName $pdfFilename }}
           <li><i class="fa fa-file-pdf-o" aria-hidden="true" title="{{ i18n "download-pdf" }}"></i><a href="{{ $pdfUrl }}">{{ i18n "download-pdf" }}</a></li>
-          {{ $editUrl := printf "%s%s/%s" $.Site.Params.editBaseUrl $.Site.Home.Language .Page.File }}
+          {{ $editUrl := printf "%s%s/%s/%s/%s" $.Site.Params.editBaseUrl $docLang $docType $docName $adocFileName }}
           <li><i class="fa fa-pencil-square-o" aria-hidden="true" title="{{ i18n "edit-page" }}"></i><a href="{{ $editUrl }}" target="_blank">{{ i18n "edit-page" }}</a></li>
         </ul>
       </div>

--- a/documentation/themes/beastie/layouts/books/list.html
+++ b/documentation/themes/beastie/layouts/books/list.html
@@ -133,11 +133,19 @@
           {{ $docLang := $.Site.Home.Language.Lang }}
           {{ $docType := index $pathSections 1 }}
           {{ $docName := index $pathSections 2 }}
+          {{ $sectionName := index $pathSections 3 }}
           {{ $pdfFilename := printf "%s_%s.pdf" $docName $docLang }}
+          {{ $adocFileName := printf "%s.adoc" $.Page.File }}
           {{ $pdfUrl := printf "%s%s/%s/%s/%s" $.Site.Params.downloadBaseUrl $docLang $docType $docName $pdfFilename }}
           <li><i class="fa fa-file-pdf-o" aria-hidden="true" title="{{ i18n "download-pdf" }}"></i><a href="{{ $pdfUrl }}">{{ i18n "download-pdf" }}</a></li>
-          {{ $editUrl := printf "%s%s/%s" $.Site.Params.editBaseUrl $.Site.Home.Language .Page.File }}
-          <li><i class="fa fa-pencil-square-o" aria-hidden="true" title="{{ i18n "edit-page" }}"></i><a href="{{ $editUrl }}" target="_blank">{{ i18n "edit-page" }}</a></li>
+          {{ if $sectionName }}
+            {{ $editUrl := printf "%s%s/%s/%s/%s/%s" $.Site.Params.editBaseUrl $docLang $docType $docName $sectionName $adocFileName }}
+            <li><i class="fa fa-pencil-square-o" aria-hidden="true" title="{{ i18n "edit-page" }}"></i><a href="{{ $editUrl }}" target="_blank">{{ i18n "edit-page" }}</a></li>
+          {{ else }}
+            {{ $editUrl := printf "%s%s/%s/%s/%s" $.Site.Params.editBaseUrl $docLang $docType $docName $adocFileName }}
+            <li><i class="fa fa-pencil-square-o" aria-hidden="true" title="{{ i18n "edit-page" }}"></i><a href="{{ $editUrl }}" target="_blank">{{ i18n "edit-page" }}</a></li>
+          {{ end }}
+          
         </ul>
       </div>
     </div>

--- a/documentation/themes/beastie/layouts/books/single.html
+++ b/documentation/themes/beastie/layouts/books/single.html
@@ -134,9 +134,10 @@
           {{ $docType := index $pathSections 1 }}
           {{ $docName := index $pathSections 2 }}
           {{ $pdfFilename := printf "%s_%s.pdf" $docName $docLang }}
+          {{ $adocFileName := printf "%s.adoc" $.Page.File }}
           {{ $pdfUrl := printf "%s%s/%s/%s/%s" $.Site.Params.downloadBaseUrl $docLang $docType $docName $pdfFilename }}
           <li><i class="fa fa-file-pdf-o" aria-hidden="true" title="{{ i18n "download-pdf" }}"></i><a href="{{ $pdfUrl }}">{{ i18n "download-pdf" }}</a></li>
-          {{ $editUrl := printf "%s%s/%s" $.Site.Params.editBaseUrl $.Site.Home.Language .Page.File }}
+          {{ $editUrl := printf "%s%s/%s/%s/%s" $.Site.Params.editBaseUrl $docLang $docType $docName $adocFileName }}
           <li><i class="fa fa-pencil-square-o" aria-hidden="true" title="{{ i18n "edit-page" }}"></i><a href="{{ $editUrl }}" target="_blank">{{ i18n "edit-page" }}</a></li>
         </ul>
       </div>


### PR DESCRIPTION
I noticed that the links to the edit page are broken and saw the following bug reported: https://bugs.freebsd.org/bugzilla/show_bug.cgi?id=280150

This change fixes the creation of the edit URL to point to the correct file. 

The `IF` in the list template for the book was introduced because the load of the main page from the menu is loaded with the list template, but this main page doesn't present any specific section in the pathSections, which I named `sectionName`.

Hope it helps. :)