### PR TITLE
modify shasum check command

### DIFF
--- a/documentation/content/en/books/handbook/bsdinstall/_index.adoc
+++ b/documentation/content/en/books/handbook/bsdinstall/_index.adoc
@@ -183,12 +183,12 @@ Note that you need to compare the calculated _checksum_ against the correct file
 FreeBSD provides man:sha256[1] and man:sha512[1] that can be used for calculating the _checksum_.
 Other operating systems have similar programs.
 
-Verifying the _checksum_ in FreeBSD can be done automatically using man:sha256sum[1] (and man:sha512sum[1]) by executing:
+Verifying the _checksum_ in FreeBSD can be done automatically using man:sha256sum[1] or man:sha512sum[1] by executing:
 
 [source,shell]
 ....
-% sha256sum -c CHECKSUM.SHA256-FreeBSD-13.1-RELEASE-amd64 FreeBSD-13.1-RELEASE-amd64-dvd1.iso
-FreeBSD-13.1-RELEASE-amd64-dvd1.iso: OK
+% sha512sum -c CHECKSUM.SHA512-FreeBSD-14.1-RELEASE-amd64 --ignore-missing
+FreeBSD-14.1-RELEASE-amd64-memstick.img: OK
 ....
 
 The checksums must match exactly.

--- a/documentation/content/en/books/handbook/bsdinstall/_index.po
+++ b/documentation/content/en/books/handbook/bsdinstall/_index.po
@@ -426,15 +426,15 @@ msgstr ""
 #: documentation/content/en/books/handbook/bsdinstall/_index.adoc:180
 msgid ""
 "Verifying the _checksum_ in FreeBSD can be done automatically using man:"
-"sha256sum[1] (and man:sha512sum[1]) by executing:"
+"sha256sum[1] or man:sha512sum[1] by executing:"
 msgstr ""
 
 #. type: delimited block . 4
 #: documentation/content/en/books/handbook/bsdinstall/_index.adoc:185
 #, no-wrap
 msgid ""
-"% sha256sum -c CHECKSUM.SHA256-FreeBSD-13.1-RELEASE-amd64 FreeBSD-13.1-RELEASE-amd64-dvd1.iso\n"
-"FreeBSD-13.1-RELEASE-amd64-dvd1.iso: OK\n"
+"% sha512sum -c CHECKSUM.SHA512-FreeBSD-14.1-RELEASE-amd64 --ignore-missing\n"
+"FreeBSD-14.1-RELEASE-amd64-memstick.img: OK\n"
 msgstr ""
 
 #. type: Plain text


### PR DESCRIPTION
by default, sha256sum and sha512sum will look for any file mentioned in the CHECKSUM file, which is all of them:
```
$ wc -l < CHECKSUM.SHA512-FreeBSD-14.1-RELEASE-amd64 10
```
with the current command, this will lead to 9 failures and 1 OK. the fact that you specify the filename to be checked does not seem to mean that is the *only* file that is checked.

for this reason, I suggest that the filename to be checked is removed, and replaced with the flag --ignore-missing which is present in both commands on both BSD and Linux.

this flag means that all files mentioned will be checked, just like before, but output will only be returned for successful checks. example:
```
$ sha512sum -c CHECKSUM.SHA512-FreeBSD-14.1-RELEASE-amd64 --ignore-missing
FreeBSD-14.1-RELEASE-amd64-memstick.img: OK
```
this assumes that the img file is in the same directory, but this was already assumed in the previous version.