### PR TITLE
handbook/security: fix incorrect command example

### DIFF
--- a/documentation/content/en/books/handbook/security/_index.adoc
+++ b/documentation/content/en/books/handbook/security/_index.adoc
@@ -180,7 +180,7 @@ The following command can be run to check which hash mechanism is currently bein
 
 [source,shell]
 ....
-# grep user /etc/master.passwd
+# grep passwd_format /etc/login.conf
 ....
 
 The output should be similar to the following:


### PR DESCRIPTION
This section indicates to check which password hash is used, one should `grep user /etc/master.passwd`, but then the output of `grep passwd_format /etc/login.conf` is shown.