### PR TITLE
Update Chapter 2: Section 2.5.3 zh-tw translation to the latest version

### DIFF
--- a/documentation/content/zh-tw/books/handbook/bsdinstall/_index.adoc
+++ b/documentation/content/zh-tw/books/handbook/bsdinstall/_index.adoc
@@ -392,8 +392,9 @@ image::bsdinstall-config-components.png[]
 
 決定要安裝的元件主要會根據系統的用途以及可用的磁碟空間容量。FreeBSD 核心 (Kernel) 及 Userland 統稱為 _基礎系統 (Base system)_，是必須安裝的部份。依據系統的架構，部份元件可能不會顯示：
 
-* `doc` - 額外的說明文件，大部份是經年累月的產物，會安裝到 [.filename]#/usr/shared/doc#。由 FreeBSD 文件計劃所提供的說明文件可在之後安裝，依照 crossref:cutting-edge[updating-upgrading-documentation,更新文件集] 中的指示操作。
-* `games` - 數個傳統 BSD 遊戲，包含 fortune, rot13 以及其他。
+* `base-dbg` - 啟用除錯符號的基本工具，例如 cat 和 ls 等。
+* `kernel-dbg` -  啟用除錯符號的核心和模組。
+* `lib32-dbg` - 在 64-bit 版本的 FreeBSD 上運行 32-bit 應用程式的相容性程式庫，啟用了除錯符號。
 * `lib32` - 在 64-bit 版本的 FreeBSD 供執行 32-bit 應用程式使用的相容性程式庫。
 * `ports` - FreeBSD Port 套件集是一套可自動下載、編譯安裝第三方軟體套件的集合，crossref:ports[ports,安裝應用程式：套件與 Port] 中會討論到如何使用 Port 套件集。
 +
@@ -404,6 +405,7 @@ image::bsdinstall-config-components.png[]
 ====
 
 * `src` - 完整的 FreeBSD 原始碼，包含核心 (Kernel) 與 Userland。雖然大多數的應用程式並不需要，但它可以編譯裝置驅動程式、核心模組或部份來自 Port 套件集的應用程式，它同時也用來做為開發 FreeBSD 本身所使用。完整的原始碼樹需要 1 GB 的磁碟空間，重新編譯整個 FreeBSD 系統需要額外再 5 GB 的空間。
+* `test` - FreeBSD 測試套件。
 
 [[bsdinstall-netinstall]]
 === 從網路安裝


### PR DESCRIPTION
This commit updates the translation of Figure 8 and the accompanying text in Chapter 2.5.3 to the latest English version. The following changes were made:

1. Updated translation of the components selection:
   - The English version has been updated with new components such as `base-dbg`, `kernel-dbg`, `lib32-dbg`, and `tests`, which were not present in the previous Traditional Chinese version. These components are now translated and included.

2. Removed outdated descriptions:
   - The original Traditional Chinese version mentioned `doc` and `games` components, which are no longer listed in the latest English version. These outdated components have been removed to match the English text.
