### PR TITLE
sockets(examples): remove unused register keyword, replace bzero with memset

### DIFF
--- a/documentation/content/en/books/developers-handbook/sockets/_index.adoc
+++ b/documentation/content/en/books/developers-handbook/sockets/_index.adoc
@@ -562,8 +562,7 @@ We now know enough to write a very simple client, one that will get current time
 #include <unistd.h>
 
 int main() {
-  register int s;
-  register int bytes;
+  int s, bytes;
   struct sockaddr_in sa;
   char buffer[BUFSIZ+1];
 
@@ -572,7 +571,7 @@ int main() {
     return 1;
   }
 
-  bzero(&sa, sizeof sa);
+  memset(&sa, '\0', sizeof(sa));
 
   sa.sin_family = AF_INET;
   sa.sin_port = htons(13);
@@ -718,8 +717,8 @@ The child calls `listen`, then starts an endless loop, which accepts a connectio
 #define BACKLOG 4
 
 int main() {
-    register int s, c;
-    int b;
+    int s, c;
+    socklen_t b;
     struct sockaddr_in sa;
     time_t t;
     struct tm *tm;
@@ -730,7 +729,7 @@ int main() {
         return 1;
     }
 
-    bzero(&sa, sizeof sa);
+    memset(&sa, '\0', sizeof(sa));
 
     sa.sin_family = AF_INET;
     sa.sin_port   = htons(13);
@@ -747,11 +746,9 @@ int main() {
         case -1:
             perror("fork");
             return 3;
-            break;
         default:
             close(s);
             return 0;
-            break;
         case 0:
             break;
     }
@@ -773,7 +770,6 @@ int main() {
 
         if ((t = time(NULL)) < 0) {
             perror("daytimed time");
-
             return 6;
         }
 
@@ -976,14 +972,14 @@ This allows us to create a much more flexible-and much more useful-version of ou
  */
 #include <stdio.h>
 #include <string.h>
+#include <unistd.h>
 #include <sys/types.h>
 #include <sys/socket.h>
 #include <netinet/in.h>
 #include <netdb.h>
 
 int main(int argc, char *argv[]) {
-  register int s;
-  register int bytes;
+  int s, bytes;
   struct sockaddr_in sa;
   struct hostent *he;
   char buf[BUFSIZ+1];
@@ -994,19 +990,19 @@ int main(int argc, char *argv[]) {
     return 1;
   }
 
-  bzero(&sa, sizeof sa);
+  memset(&sa, '\0', sizeof(sa));
 
   sa.sin_family = AF_INET;
   sa.sin_port = htons(13);
 
-  host = (argc > 1) ? (char *)argv[1] : "time.nist.gov";
+  host = (argc > 1) ? argv[1] : "time.nist.gov";
 
   if ((he = gethostbyname(host)) == NULL) {
     herror(host);
     return 2;
   }
 
-  bcopy(he->h_addr_list[0],&sa.sin_addr, he->h_length);
+  memcpy(&sa.sin_addr, he->h_addr_list[0], he->h_length);
 
   if (connect(s, (struct sockaddr *)&sa, sizeof sa) < 0) {
     perror("connect");


### PR DESCRIPTION
\* Remove the redundant register keyword from the variables, as most compilers (GCC/Clang) just ignore them, and they're mostly just noise.

\* Replace bzero() with memset(). IEEE 1003.1-2008 removes the spec of bzero(), replacing it with memset().

\* Use socklen_t (unsigned type) for variable b in the socket bind example.

\* Add unistd.h header file in the socket connect example (it is used by the write() and read() libc calls). Remove unnecessary (char *) cast from argv[1].