### PR TITLE
Get FreeBSD: STABLE is 13.4, not 13.3

### DIFF
--- a/website/content/en/where.adoc
+++ b/website/content/en/where.adoc
@@ -286,7 +286,7 @@ Installer and SD card images are available for link:{url-snapshot}/amd64/amd64/I
 
 VM images are available for link:{url-snapshot}/VM-IMAGES/{rel141-current}-STABLE/amd64/Latest/[amd64], link:{url-snapshot}/VM-IMAGES/{rel141-current}-STABLE/i386/Latest/[i386], link:{url-snapshot}/VM-IMAGES/{rel141-current}-STABLE/aarch64/Latest/[aarch64], and link:{url-snapshot}/VM-IMAGES/{rel141-current}-STABLE/riscv64/Latest/[riscv64].
 
-=== FreeBSD {rel133-current}-STABLE
+=== FreeBSD {rel134-current}-STABLE
 
 Installer and SD card images are available for link:{url-snapshot}/amd64/amd64/ISO-IMAGES/{rel133-current}/[amd64], link:{url-snapshot}/i386/i386/ISO-IMAGES/{rel133-current}/[i386], link:{url-snapshot}/powerpc/powerpc/ISO-IMAGES/{rel133-current}/[powerpc], link:{url-snapshot}/powerpc/powerpc64/ISO-IMAGES/{rel133-current}/[powerpc64], link:{url-snapshot}/powerpc/powerpc64le/ISO-IMAGES/{rel133-current}/[powerpc64le], link:{url-snapshot}/powerpc/powerpcspe/ISO-IMAGES/{rel133-current}/[powerpcspe], link:{url-snapshot}/arm/armv6/ISO-IMAGES/{rel133-current}/[armv6], link:{url-snapshot}/arm/armv7/ISO-IMAGES/{rel133-current}/[armv7], link:{url-snapshot}/arm64/aarch64/ISO-IMAGES/{rel133-current}/[aarch64], and link:{url-snapshot}/riscv/riscv64/ISO-IMAGES/{rel133-current}/[riscv64].
 


### PR DESCRIPTION
Since 13.4 is released, it seems that STABLE should be {rel134-current} …