### PR TITLE
Reword section about multiple package version

### DIFF
--- a/documentation/content/en/books/handbook/ports/_index.adoc
+++ b/documentation/content/en/books/handbook/ports/_index.adoc
@@ -96,7 +96,9 @@ Select the technology that meets your requirements for installing a particular a
 * Packages are normally compiled with conservative options because they have to run on the maximum number of systems. By compiling from the port, one can change the compilation options.
 * Some applications have compile-time options relating to which features are installed. For example, NGINX(R) can be configured with a wide variety of different built-in options.
 +
-In some cases, multiple packages will exist for the same application to specify certain settings. For example, NGINX(R) is available as a `nginx` package and a `nginx-lite` package, depending on whether or not Xorg is installed. Creating multiple packages rapidly becomes impossible if an application has more than one or two different compile-time options.
+In some cases, multiple packages will exist for the same application with different settings. For example, NGINX(R) is available as a `nginx` package and a `nginx-lite` package, the former has many more options enabled, but this in turn requires many things to be installed as dependencies for it to work, thus increasing space consumption and attack surface.
++
+The transitive dependencies can grow quite large, for example the full `nginx` package will pull in several X libraries which can be quite surprising, so building from ports allow you to choose only the options you need without a "kitchen sink" approach.In some cases, multiple packages will exist for the same application to specify certain settings.
 * The licensing conditions of some software forbid binary distribution. Such software must be distributed as source code which must be compiled by the end-user.
 * Some people do not trust binary distributions or prefer to read through source code in order to look for potential problems.
 * Source code is needed in order to apply custom patches.


### PR DESCRIPTION
The current wording implies that having X installed would result in a different nginx package being installed which is wrong. Also add a note about why the user might want to choose to build it from ports.