### PR TITLE
handbook: Guide users towards installing Plasma 6 / KDE 6 packages

### DIFF
--- a/documentation/content/en/books/handbook/desktop/_index.adoc
+++ b/documentation/content/en/books/handbook/desktop/_index.adoc
@@ -74,7 +74,7 @@ A desktop environment can range from a simple window manager to a complete suite
 
 | KDE Plasma
 | GPL 2.0 or later
-| x11/kde5
+| x11/kde
 
 | GNOME
 | GPL 2.0 or later
@@ -123,7 +123,7 @@ To install a minimal KDE Plasma execute:
 
 [source,shell]
 ....
-# pkg install plasma5-plasma
+# pkg install plasma6-plasma
 ....
 
 [TIP]

--- a/documentation/content/en/books/handbook/multimedia/_index.adoc
+++ b/documentation/content/en/books/handbook/multimedia/_index.adoc
@@ -151,7 +151,7 @@ FreeBSD has different utilities to set and display sound card mixer values built
 
 | KDE Plasma audio widget
 | GPL 2.0
-| package:audio/plasma5-plasma-pa[]
+| package:audio/plasma6-plasma-pa[]
 | Qt
 
 | mixertui


### PR DESCRIPTION
Hello,

Now that Plasma 6 and related components are out it would seem the handbook should guide users towards installing the relevant `x11/kde6` packages and friends

Apologies if there are mistakes in these changes, I'm happy to address them