### PR TITLE
handbook: Add notes to VMWare related setup guide

### DIFF
--- a/documentation/content/en/books/handbook/virtualization/_index.adoc
+++ b/documentation/content/en/books/handbook/virtualization/_index.adoc
@@ -272,6 +272,16 @@ To run FreeBSD smoothly on VMWare, drivers should be installed:
 ====
 The xf86 packages are only available for x86 FreeBSD guests.
 ====
+[.procedure]
+. Enabling the mouse
++
+Some users have reported issues using the mouse in the virtual machine.
+The mouse may be enabled by appending the following to [.filename]#/boot/loader.conf#:
++
+[.programlisting]
+....
+# ums_load=“YES”
+....
 
 [[virtualization-guest-virtualbox]]
 == FreeBSD as a Guest on VirtualBox(TM)

--- a/documentation/content/en/books/handbook/virtualization/_index.adoc
+++ b/documentation/content/en/books/handbook/virtualization/_index.adoc
@@ -268,6 +268,10 @@ To run FreeBSD smoothly on VMWare, drivers should be installed:
 ....
 # pkg install xf86-video-vmware xf86-input-vmmouse open-vm-tools
 ....
+[NOTE]
+====
+The xf86 packages are only available for x86 FreeBSD guests.
+====
 
 [[virtualization-guest-virtualbox]]
 == FreeBSD as a Guest on VirtualBox(TM)


### PR DESCRIPTION
When setting up FreeBSD 14 on my M1 macOS machine I ran across a couple of issues; I thought the fixes may be useful to other users, mainly:

* The driver packages recommended in the installation are not available for aarch64
* The mouse was not working out of the box and required modifications to `/boot/loader.conf`