### PR TITLE
handbook: Correct package name in the linuxemu chapter

### DIFF
--- a/documentation/content/en/books/handbook/linuxemu/_index.adoc
+++ b/documentation/content/en/books/handbook/linuxemu/_index.adoc
@@ -118,7 +118,7 @@ In order to run Linux software a Linux userland must be installed first.
 If all that is wanted is to run some software already included in the Ports tree, it can be installed via package manager and man:pkg[8] will automatically setup the required Linux userland.
 
 For example, to install Sublime Text 4, along with all the Linux libraries it depends on, run this command:
- 
+
 [source,shell]
 ....
 # pkg install linux-sublime-text4
@@ -135,7 +135,7 @@ To install the Rocky Linux 9 userland execute the following command:
 # pkg install linux_base-rl9
 ....
 
-package:emulators/linux_rl9[] will place the base system derived from Rocky Linux 9 into [.filename]#/compat/linux#.
+package:emulators/linux-rl9[] will place the base system derived from Rocky Linux 9 into [.filename]#/compat/linux#.
 
 After installing the package, the contents of [.filename]#/compat/linux# can be verified by running the following command to check that the Rocky Linux userland has been installed:
 
@@ -243,11 +243,11 @@ The output should be similar to the following:
 
 [.programlisting]
 ....
-I: Retrieving InRelease 
+I: Retrieving InRelease
 I: Checking Release signature
 I: Valid Release signature (key id F6ECB3762474EDA9D21B7022871920D1991BC93C)
-I: Retrieving Packages 
-I: Validating Packages 
+I: Retrieving Packages
+I: Validating Packages
 I: Resolving dependencies of required packages...
 I: Resolving dependencies of base packages...
 I: Checking component main on http://archive.ubuntu.com/ubuntu...


### PR DESCRIPTION
The correct package name is `emulators/linux-rl9`.