### PR TITLE
docs(handbook/dtrace): Update DTrace guide link

### DIFF
--- a/documentation/content/de/books/handbook/dtrace/_index.adoc
+++ b/documentation/content/de/books/handbook/dtrace/_index.adoc
@@ -55,7 +55,7 @@ DTrace ist ein bemerkenswertes Werkzeug zur Profilerstellung, mit einer beeindru
 
 Die DTrace-Implementierung in FreeBSD bietet experimentelle Unterstützung für DTrace im Userland. Userland DTrace erlaubt es Anwendern, function boundary tracing für Anwendungsprogramme über den `pid`-Provider hinweg vorzunehmen und um statische Sonden in Anwendungsprogramme für die spätere Aufzeichnung einzufügen. Manche Ports, wie beispielsweise package:databases/postgresql12-server[] und package:lang/php74[] besitzen eine DTrace-Option, um statische Sonden zu aktivieren.
 
-Eine offizielle Anleitung für DTrace wird vom Illumos Projekt im http://dtrace.org/guide[DTrace Guide] bereitgestellt.
+Eine offizielle Anleitung für DTrace wird vom Illumos Projekt im https://illumos.org/books/dtrace/bookinfo.html[DTrace Guide] bereitgestellt.
 
 Nachdem Sie dieses Kapitel gelesen haben, werden Sie Folgendes wissen:
 

--- a/documentation/content/en/books/handbook/dtrace/_index.adoc
+++ b/documentation/content/en/books/handbook/dtrace/_index.adoc
@@ -62,7 +62,7 @@ The FreeBSD implementation provides full support for kernel DTrace and experimen
 Userland DTrace allows users to perform function boundary tracing for userland programs using the `pid` provider, and to insert static probes into userland programs for later tracing.
 Some ports, such as package:databases/postgresql12-server[] and package:lang/php74[] have a DTrace option to enable static probes.
 
-The official guide to DTrace is maintained by the Illumos project at http://dtrace.org/guide[DTrace Guide].
+The official guide to DTrace is maintained by the Illumos project at https://illumos.org/books/dtrace/bookinfo.html[DTrace Guide].
 
 After reading this chapter, you will know:
 
@@ -90,7 +90,7 @@ To load all of the necessary modules:
 Beginning with FreeBSD 10.0-RELEASE, the modules are automatically loaded when `dtrace` is run.
 
 FreeBSD uses the `DDB_CTF` kernel option to enable support for loading `CTF` data from kernel modules and the kernel itself.
-`CTF` is the Solaris(TM) Compact C Type Format which encapsulates a reduced form of debugging information similar to `DWARF` and the venerable stabs. 
+`CTF` is the Solaris(TM) Compact C Type Format which encapsulates a reduced form of debugging information similar to `DWARF` and the venerable stabs.
 `CTF` data is added to binaries by the `ctfconvert` and `ctfmerge` build tools.
 The `ctfconvert` utility parses `DWARF``ELF` debug sections created by the compiler and `ctfmerge` merges `CTF``ELF` sections from objects into either executables or shared libraries.
 
@@ -98,7 +98,7 @@ Some different providers exist for FreeBSD than for Solaris(TM).
 Most notable is the `dtmalloc` provider, which allows tracing `malloc()` by type in the FreeBSD kernel.
 Some of the providers found in Solaris(TM), such as `cpc` and `mib`, are not present in FreeBSD.
 These may appear in future versions of FreeBSD.
-Moreover, some of the providers available in both operating systems are not compatible, in the sense that their probes have different argument types. 
+Moreover, some of the providers available in both operating systems are not compatible, in the sense that their probes have different argument types.
 Thus, `D` scripts written on Solaris(TM) may or may not work unmodified on FreeBSD, and vice versa.
 
 Due to security differences, only `root` may use DTrace on FreeBSD.

--- a/documentation/content/en/books/handbook/dtrace/_index.po
+++ b/documentation/content/en/books/handbook/dtrace/_index.po
@@ -80,8 +80,8 @@ msgstr ""
 #. type: Plain text
 #: documentation/content/en/books/handbook/dtrace/_index.adoc:66
 msgid ""
-"The official guide to DTrace is maintained by the Illumos project at http://"
-"dtrace.org/guide[DTrace Guide]."
+"The official guide to DTrace is maintained by the Illumos project at "
+"https://illumos.org/books/dtrace/bookinfo.html[DTrace Guide]."
 msgstr ""
 
 #. type: Plain text

--- a/documentation/content/pl/books/handbook/dtrace/_index.adoc
+++ b/documentation/content/pl/books/handbook/dtrace/_index.adoc
@@ -55,7 +55,7 @@ DTrace is a remarkable profiling tool, with an impressive array of features for 
 
 The FreeBSD implementation provides full support for kernel DTrace and experimental support for userland DTrace. Userland DTrace allows users to perform function boundary tracing for userland programs using the `pid` provider, and to insert static probes into userland programs for later tracing. Some ports, such as package:databases/postgresql12-server[] and package:lang/php74[] have a DTrace option to enable static probes.
 
-The official guide to DTrace is maintained by the Illumos project at http://dtrace.org/guide[DTrace Guide].
+The official guide to DTrace is maintained by the Illumos project at https://illumos.org/books/dtrace/bookinfo.html[DTrace Guide].
 
 After reading this chapter, you will know:
 

--- a/documentation/content/zh-tw/books/handbook/dtrace/_index.adoc
+++ b/documentation/content/zh-tw/books/handbook/dtrace/_index.adoc
@@ -63,7 +63,7 @@ FreeBSD 實做提供對核心層級的 DTrace 全面的支援，以及對使用�
 使用者層級的 DTrace 允許使用者使用 `pid` 執行函式邊界追蹤 (function boundary tracing)，並將 static probes 插入到使用者程式以供之後追蹤。
 一些 ports，像是 package:databases/postgresql12-server[] 和 package:lang/php74[] 提供 DTrace 選項，以提供 static probes 功能。
 
-DTrace 的官方指南由 Illumos 維護，在 http://dtrace.org/guide[DTrace Guide]。
+DTrace 的官方指南由 Illumos 維護，在 https://illumos.org/books/dtrace/bookinfo.html[DTrace Guide]。
 
 讀完這章，您將了解：
 


### PR DESCRIPTION
Update the link to the official DTrace guide maintained by the illumos project. `http://dtrace.org/guide` is not available right now. The new link points to `https://illumos.org/books/dtrace/bookinfo.html`.