### PR TITLE
Corrected grep command

### DIFF
--- a/documentation/content/en/books/handbook/security/_index.adoc
+++ b/documentation/content/en/books/handbook/security/_index.adoc
@@ -180,7 +180,7 @@ The following command can be run to check which hash mechanism is currently bein
 
 [source,shell]
 ....
-# grep user /etc/master.passwd
+# grep passwd_format /etc/login.conf
 ....
 
 The output should be similar to the following:


### PR DESCRIPTION
The handbook says to grep /etc/master.passwd for the user password hash mechanism, but this should be /etc/login.conf.