### PR TITLE
Fix  crossref:basics[users-modifying-chpass-su,Using `chpass` as Superuser]

### DIFF
--- a/documentation/content/en/books/handbook/basics/_index.adoc
+++ b/documentation/content/en/books/handbook/basics/_index.adoc
@@ -504,7 +504,7 @@ This is shown in crossref:basics[users-modifying-chpass-ru,Using `chpass` as Reg
 ====
 [source,shell]
 ....
-# chpass
+# chpass jru
 ....
 
 The output should be similar to the following:


### PR DESCRIPTION
The text says "the superuser has typed `chpass jru`", but the example command is just `chpass` while the output corresponds to the text command.