### PR TITLE
handbook: Adjust wording of statement in updating/upgrading

### DIFF
--- a/documentation/content/en/books/handbook/cutting-edge/_index.adoc
+++ b/documentation/content/en/books/handbook/cutting-edge/_index.adoc
@@ -1139,7 +1139,7 @@ set `PACKAGES` on the build system to a directory similar to `DISTDIR`.
 Historically, building required a FreeBSD host.
 Nowadays, FreeBSD can be built on Linux and macOS.
 
-To build FreeBSD on non-FreeBSD hosts, the recommendation is to use the `tools/build/make.py` script.
+To build on a non-FreeBSD host, the `tools/build/make.py` script is recommended.
 This script acts as a wrapper around `bmake`, which is the make implementation used by FreeBSD.
 It ensures that the necessary tooling, including the actual FreeBSD's man:make[1], is bootstrapped and that the build environment is properly configured.
 In particular, it sets the external toolchain variables, such as `XCC`, `XLD`, and others.

--- a/documentation/content/en/books/handbook/cutting-edge/_index.adoc
+++ b/documentation/content/en/books/handbook/cutting-edge/_index.adoc
@@ -1137,7 +1137,7 @@ set `PACKAGES` on the build system to a directory similar to `DISTDIR`.
 == Building on non-FreeBSD Hosts
 
 Historically, building FreeBSD required a FreeBSD host.
-Nowadays, the FreeBSD can be build on Linux distributions and macOS.
+Nowadays, FreeBSD can be built on Linux distributions and macOS.
 
 To build FreeBSD on non-FreeBSD hosts, the recommendation is to use the `tools/build/make.py` script.
 This script acts as a wrapper around `bmake`, which is the make implementation used by FreeBSD.

--- a/documentation/content/en/books/handbook/cutting-edge/_index.adoc
+++ b/documentation/content/en/books/handbook/cutting-edge/_index.adoc
@@ -1136,7 +1136,7 @@ set `PACKAGES` on the build system to a directory similar to `DISTDIR`.
 [[building-on-non-freebsd-hosts]]
 == Building on non-FreeBSD Hosts
 
-Historically, building FreeBSD required a FreeBSD host.
+Historically, building required a FreeBSD host.
 Nowadays, FreeBSD can be built on Linux distributions and macOS.
 
 To build FreeBSD on non-FreeBSD hosts, the recommendation is to use the `tools/build/make.py` script.

--- a/documentation/content/en/books/handbook/cutting-edge/_index.adoc
+++ b/documentation/content/en/books/handbook/cutting-edge/_index.adoc
@@ -1137,7 +1137,7 @@ set `PACKAGES` on the build system to a directory similar to `DISTDIR`.
 == Building on non-FreeBSD Hosts
 
 Historically, building required a FreeBSD host.
-Nowadays, FreeBSD can be built on Linux distributions and macOS.
+Nowadays, FreeBSD can be built on Linux and macOS.
 
 To build FreeBSD on non-FreeBSD hosts, the recommendation is to use the `tools/build/make.py` script.
 This script acts as a wrapper around `bmake`, which is the make implementation used by FreeBSD.


### PR DESCRIPTION
The introductory line of 26.8, "Building on non-FreeBSD Hosts" states:

"Nowadays, the FreeBSD can be build on Linux distributions and macOS."

"can be build on" should be "can be built on".

", the FreeBSD can' should be ", FreeBSD can".