### PR TITLE
14.2R/errata: news: inclusion of Wi-Fi firmware

### DIFF
--- a/website/content/en/releases/14.2R/errata.adoc
+++ b/website/content/en/releases/14.2R/errata.adoc
@@ -78,4 +78,5 @@ In particular, instructions for automatically unlocking directories at login tim
 [[late-news]]
 == Late-Breaking News
 
-No late-breaking news.
+* The announcement of 14.2-RELEASE did highlight the installer's ability to download and install firmware packages _after installing_ the FreeBSD base system, but omitted to mention addition of firmware to the images for installers.
+These additions are to automate, or simplify, Wi-Fi connection to the Internet &#8211; during installation &#8211; for the broadest possible range of use cases at this time.


### PR DESCRIPTION
Expand upon the second of the four highlights that were announced on 3rd December.