### PR TITLE
handbook/mail: add note about gmail needing app passwords

### DIFF
--- a/documentation/content/en/books/handbook/mail/_index.adoc
+++ b/documentation/content/en/books/handbook/mail/_index.adoc
@@ -138,6 +138,11 @@ Authentication can be set with one line in [.filename]#/etc/dma/auth.conf#:
 username@gmail.com|smtp.gmail.com:password
 ....
 
+If you have 2-factor authentication enabled, you will need to generate an
+application-specific password as your normal login password will be
+rejected. See Google documentation for more information on
+https://myaccount.google.com/apppasswords[app-specific passwords].
+
 Execute the following command to test the configuration:
 
 [source,shell]


### PR DESCRIPTION
I was unable to preview properly in hugo, but at least the text seems reasonable.