### PR TITLE
status/report: add 2024Q4 clusteradm report

### DIFF
--- a/website/content/en/releases/13.4R/errata.adoc
+++ b/website/content/en/releases/13.4R/errata.adoc
@@ -59,9 +59,8 @@ For a list of all FreeBSD CERT security advisories, see https://www.FreeBSD.org/
 [width="100%",cols="40%,30%,30%",options="header",]
 |===
 |Errata |Date |Topic
-
-|No errata notices.||
-
+|link:https://www.FreeBSD.org/security/advisories/FreeBSD-EN-25:02.audit.asc[FreeBSD-EN-25:02.audit] |29 January 2025 |System call auditing disabled by DTrace
+|link:https://www.FreeBSD.org/security/advisories/FreeBSD-EN-25:03.tzdata.asc[FreeBSD-EN-25:03.tzdata] |29 January 2025 |Timezone database information update
 |===
 
 [[open-issues]]

--- a/website/content/en/releases/13.4R/errata.adoc
+++ b/website/content/en/releases/13.4R/errata.adoc
@@ -49,6 +49,8 @@ For a list of all FreeBSD CERT security advisories, see https://www.FreeBSD.org/
 |link:https://www.FreeBSD.org/security/advisories/FreeBSD-SA-24:17.bhyve.asc[FreeBSD-SA-24:17.bhyve] |29 October 2024 |Multiple issues in the bhyve hypervisor
 |link:https://www.FreeBSD.org/security/advisories/FreeBSD-SA-24:18.ctl.asc[FreeBSD-SA-24:18.ctl] |29 October 2024 |Unbounded allocation in ctl(4) CAM Target Layer
 |link:https://www.FreeBSD.org/security/advisories/FreeBSD-SA-24:19.fetch.asc[FreeBSD-SA-24:19.fetch] |29 October 2024 |Certificate revocation list fetch(1) option fails
+|link:https://www.FreeBSD.org/security/advisories/FreeBSD-SA-25:02.fs.asc[FreeBSD-SA-25:02.fs] |29 January 2025 |Buffer overflow in some filesystems via NFS
+|link:https://www.FreeBSD.org/security/advisories/FreeBSD-SA-25:03.etcupdate.asc[FreeBSD-SA-25:03.etcupdate] |29 January 2025 |Unprivileged access to system files
 |===
 
 [[errata]]

--- a/website/content/en/releases/14.1R/errata.adoc
+++ b/website/content/en/releases/14.1R/errata.adoc
@@ -77,6 +77,9 @@ For a list of all FreeBSD CERT security advisories, see https://www.FreeBSD.org/
 |link:https://www.FreeBSD.org/security/advisories/FreeBSD-EN-24:15.calendar.asc[FreeBSD-EN-24:15.calendar] |4 September 2024 |cron(8) / periodic(8) session login
 |link:https://www.FreeBSD.org/security/advisories/FreeBSD-EN-24:16.pf.asc[FreeBSD-EN-24:16.pf] |19 September 2024 |Incorrect ICMPv6 state handling in pf
 |link:https://www.FreeBSD.org/security/advisories/FreeBSD-EN-24:17.pam_xdg.asc[FreeBSD-EN-24:17.pam_xdg] |29 October 2024 |XDG runtime directory's file descriptor leak at login
+|link:https://www.FreeBSD.org/security/advisories/FreeBSD-EN-25:01.rpc.asc[FreeBSD-EN-25:01.rpc] |29 January 2025 |NULL pointer dereference in the NFSv4 client
+|link:https://www.FreeBSD.org/security/advisories/FreeBSD-EN-25:02.audit.asc[FreeBSD-EN-25:02.audit] |29 January 2025 |System call auditing disabled by DTrace
+|link:https://www.FreeBSD.org/security/advisories/FreeBSD-EN-25:03.tzdata.asc[FreeBSD-EN-25:03.tzdata] |29 January 2025 |Timezone database information update
 |===
 
 [[open-issues]]

--- a/website/content/en/releases/14.1R/errata.adoc
+++ b/website/content/en/releases/14.1R/errata.adoc
@@ -60,6 +60,9 @@ For a list of all FreeBSD CERT security advisories, see https://www.FreeBSD.org/
 |link:https://www.FreeBSD.org/security/advisories/FreeBSD-SA-24:17.bhyve.asc[FreeBSD-SA-24:17.bhyve] |29 October 2024 |Multiple issues in the bhyve hypervisor
 |link:https://www.FreeBSD.org/security/advisories/FreeBSD-SA-24:18.ctl.asc[FreeBSD-SA-24:18.ctl] |29 October 2024 |Unbounded allocation in ctl(4) CAM Target Layer
 |link:https://www.FreeBSD.org/security/advisories/FreeBSD-SA-24:19.fetch.asc[FreeBSD-SA-24:19.fetch] |29 October 2024 |Certificate revocation list fetch(1) option fails
+|link:https://www.FreeBSD.org/security/advisories/FreeBSD-SA-25:01.openssh.asc[FreeBSD-SA-25:01.openssh] |29 January 2025 |OpenSSH Keystroke Obfuscation Bypass
+|link:https://www.FreeBSD.org/security/advisories/FreeBSD-SA-25:02.fs.asc[FreeBSD-SA-25:02.fs] |29 January 2025 |Buffer overflow in some filesystems via NFS
+|link:https://www.FreeBSD.org/security/advisories/FreeBSD-SA-25:03.etcupdate.asc[FreeBSD-SA-25:03.etcupdate] |29 January 2025 |Unprivileged access to system files
 |===
 
 [[errata]]

--- a/website/content/en/releases/14.2R/errata.adoc
+++ b/website/content/en/releases/14.2R/errata.adoc
@@ -55,9 +55,8 @@ For a list of all FreeBSD CERT security advisories, see https://www.FreeBSD.org/
 [width="100%",cols="40%,30%,30%",options="header",]
 |===
 |Errata |Date |Topic
-
-|No errata notices.||
-
+|link:https://www.FreeBSD.org/security/advisories/FreeBSD-EN-25:02.audit.asc[FreeBSD-EN-25:02.audit] |29 January 2025 |System call auditing disabled by DTrace
+|link:https://www.FreeBSD.org/security/advisories/FreeBSD-EN-25:03.tzdata.asc[FreeBSD-EN-25:03.tzdata] |29 January 2025 |Timezone database information update
 |===
 
 [[open-issues]]

--- a/website/content/en/releases/14.2R/errata.adoc
+++ b/website/content/en/releases/14.2R/errata.adoc
@@ -44,9 +44,9 @@ For a list of all FreeBSD CERT security advisories, see https://www.FreeBSD.org/
 [width="100%",cols="40%,30%,30%",options="header",]
 |===
 |Advisory |Date |Topic
-
-|No advisories.||
-
+|link:https://www.FreeBSD.org/security/advisories/FreeBSD-SA-25:02.fs.asc[FreeBSD-SA-25:02.fs] |29 January 2025 |Buffer overflow in some filesystems via NFS
+|link:https://www.FreeBSD.org/security/advisories/FreeBSD-SA-25:03.etcupdate.asc[FreeBSD-SA-25:03.etcupdate] |29 January 2025 |Unprivileged access to system files
+|link:https://www.FreeBSD.org/security/advisories/FreeBSD-SA-25:04.ktrace.asc[FreeBSD-SA-25:04.ktrace] |29 January 2025 |Uninitialized kernel memory disclosure via ktrace(2)
 |===
 
 [[errata]]

--- a/website/content/en/status/report-2024-10-2024-12/clusteradm.adoc
+++ b/website/content/en/status/report-2024-10-2024-12/clusteradm.adoc
@@ -1,0 +1,81 @@
+=== Cluster Administration Team
+
+Links: +
+link:https://www.freebsd.org/administration/#t-clusteradm[Cluster Administration Team members] URL: link:https://www.freebsd.org/administration/#t-clusteradm[]
+
+Contact: Cluster Administration Team <clusteradm@FreeBSD.org>
+
+FreeBSD Cluster Administration Team members are responsible for managing the machines the Project relies on to synchronize its distributed work and communications.
+
+In this quarter, the team has worked on the following:
+
+* Regular support for FreeBSD.org user accounts.
+* Regular disk and parts support (and replacement) for all physical hosts and mirrors.
+* Cluster software refresh.
+* Moving more cluster services to Chicago.
+* Supporting the Grimoirelab dashboard effort.
+
+==== Cluster software refresh
+
+Except for the package builders and developer-facing ("dogfood") machines, the FreeBSD cluster mostly tracks stable/X branches.
+
+At the time of this writing, there are 131 physical machines in the cluster.
+We have 54 machines on current, 61 on stable/14 and 14 on stable/13.
+Work continues to upgrade the remaining stable/13 machines to stable/14.
+The stable/12 machines have been slated for decommissioning for a while; they do not run production workloads.
+The remaining machines are slated for upgrading or decommissioning in the near future.
+
+Of the 297 jails in the cluster, 222 are now on stable/14.
+
+[.screen]
+----
+ 12.x: Regular   2, Jails   7
+ 13.x: Regular  14, Jails  59
+ 14.x: Regular  61, Jails 222
+>15.x: Regular  54, Jails   9
+Total: Regular 131, Jails 297
+Total installations: 428
+Running -RELEASE|{-p*}: 0
+Total geographic sites: 15
+----
+
+==== Moving cluster services to Chicago
+
+Earlier this year, we started building up our new site in Chicago.
+This quarter, we began decommissioning older machines in New Jersey and moving services to the newer machines in Chicago.
+Our long-term goal is for Chicago to become our primary location.
+This work will take several more months to complete.
+
+==== FreeBSD Official Mirrors Overview
+
+Current locations are Australia, Brazil, Germany, Japan (two full mirror sites), Malaysia, South Africa, Sweden, Taiwan, United Kingdom (full mirror site), United States of America -- California, Chicago, New Jersey (primary site), and Washington.
+
+Our mirror site in Taiwan is experiencing an extended outage.
+We hope to have it back online during the first quarter of 2025.
+
+Also during the first quarter of 2025, we expect a second mirror site in California, generously hosted by link:https://sonic.net[Sonic].
+
+The hardware and network connection have been generously provided by:
+
+* Cloud and SDN Laboratory at link:https://www.bbtower.co.jp/en/corporate/[BroadBand Tower, Inc]
+* link:https://www.cs.nycu.edu.tw/[Department of Computer Science, National Yang Ming Chiao Tung University]
+* link:https://deploy.equinix.com/[Equinix]
+* link:https://internet.asn.au/[Internet Association of Australia]
+* link:https://www.isc.org/[Internet Systems Consortium]
+* link:https://www.inx.net.za/[INX-ZA]
+* link:https://www.kddi-webcommunications.co.jp/english/[KDDI Web Communications Inc]
+* link:https://www.mohe.gov.my/en/services/research/myren[Malaysian Research & Education Network]
+* link:https://www.metapeer.com/[MetaPeer]
+* link:https://www.nyi.net/[New York Internet]
+* link:https://nic.br/[NIC.br]
+* link:https://www.teleservice.net/[Teleservice Skåne AB]
+* link:https://your.org/[Your.Org]
+
+New official mirrors are always welcome.
+We have noted the benefits of hosting single mirrors at Internet Exchange Points globally, as evidenced by our existing mirrors in Australia, Brazil, and South Africa.
+If you are affiliated with or know of any organizations willing to sponsor a single mirror server, please contact us.
+We are particularly interested in locations on the United States West Coast and throughout Europe.
+
+See link:https://wiki.freebsd.org/Teams/clusteradm/generic-mirror-layout[generic mirrored layout] for full mirror site specs and link:https://wiki.freebsd.org/Teams/clusteradm/tiny-mirror[tiny-mirror] for a single mirror site.
+
+Sponsors: The FreeBSD Foundation


### PR DESCRIPTION
First draft of a 2024Q4 status report for the clusteradm team.

Not many exciting things to report on last quarter.  Mostly upgrades and putting out fires as usual.  The long tail of stable/13 machines is very long indeed.  The two stable/12 machines are still there, as well as the seven stable/12 jails.

We helped Moin bring Grimoirelab online.  I guess there will be a status report from him about that.

A note about the Taiwan mirror being offline and the new mirror at Sonic going online.  I thought about mentioning the move of our California mirror from Fremont to Palo Alto, but that wasn't particularly exciting.

The mountain of technical debt is a bit shorter.  The FreeBSD Foundation supported two days a month of my time.

Reviews welcome.