### PR TITLE
handbook: update BMD license

### DIFF
--- a/documentation/content/en/books/handbook/virtualization/_index.adoc
+++ b/documentation/content/en/books/handbook/virtualization/_index.adoc
@@ -2206,7 +2206,7 @@ There are numerous utilities and applications available in ports to help simplif
 | link:https://www.freshports.org/sysutils/bhyve-rc/[Documentation]
 
 | bmd
-| Unknown
+| BSD-2
 | package:sysutils/bmd[]
 | link:https://github.com/yuichiro-naito/bmd[Documentation]
 


### PR DESCRIPTION
BMD is licensed under BSD-2-Clause
(source: https://github.com/yuichiro-naito/bmd)