### PR TITLE
Add troubleshooting tip for drm-kmod issues in multi-user mode

### DIFF
--- a/documentation/content/en/books/handbook/x11/_index.adoc
+++ b/documentation/content/en/books/handbook/x11/_index.adoc
@@ -117,6 +117,11 @@ The following table shows the different graphics cards supported by FreeBSD, whi
 | drm-kmod
 | `i915kms`
 
+[TIP]
+====
+If you encounter a black screen or are unable to switch to a tty using `ctrl+alt+F1, F2, ...`, try searching for DRM modules with `pkg search drm`. In addition to drm-kmod, there may be multiple versions available. Test each one to see which works best for your system, and then stick with the latest version that supports your hardware. This tip applies to AMD, NVIDIA, and other graphics cards as well.
+====
+
 | AMD(R)
 | Open Source
 | drm-kmod


### PR DESCRIPTION
I noticed that many users on Reddit, including myself, have encountered issues with drm-kmod without finding a clear solution. Initially, I considered placing this tip at the end of the handbook as is traditionally done. However, resolving the issue typically requires users to boot into single-user mode, mount the filesystem, and then comment out or remove drm-kmod before reinstalling a compatible version. In multi-user mode, the system becomes unworkable with drm-kmod enabled, which can be especially challenging for new users.

To help alleviate this difficulty, I have placed the tip before the AMD section, even though it applies to all graphics cards. This adjustment should make troubleshooting more accessible. Feedback or corrections are welcome, as this is my first commit.