### PR TITLE
Add tip for certificate related pkg errors in thin jails

### DIFF
--- a/documentation/content/en/books/handbook/jails/_index.adoc
+++ b/documentation/content/en/books/handbook/jails/_index.adoc
@@ -616,6 +616,17 @@ The next step is to create the symlinks to the `skeleton` by executing the follo
 
 With the `skeleton` ready, it will be necessary to copy the data to the jail directory.
 
+[TIP]
+====
+You have to update the certificates' symbolic links in order to avoid pkg errors in the jails.
+[source,shell]
+....
+# mount -t nullfs /usr/local/jails/templates/13.2-RELEASE-skeleton /usr/local/jails/templates/13.2-RELEASE-base/skeleton
+# chroot /usr/local/jails/templates/13.2-RELEASE-base /usr/sbin/certctl rehash
+# umount /usr/local/jails/templates/13.2-RELEASE-skeleton
+....
+====
+
 In case of using OpenZFS, OpenZFS snapshots can be used to easily create as many jails as necessary by executing the following commands:
 
 [source,shell]


### PR DESCRIPTION
Fix for jails cert symlinks in order to avoid "Certificate verification failed" errors