### PR TITLE
releases.adoc :beta2-upcoming: IGNORE

### DIFF
--- a/shared/releases.adoc
+++ b/shared/releases.adoc
@@ -52,7 +52,7 @@
 
 // Set to 'INCLUDE' when the schedule is available.
 
-:beta2-upcoming: INCLUDE
+:beta2-upcoming: IGNORE
 
 // Set to 'INCLUDE' when the installation images are available.
 


### PR DESCRIPTION
```text
13.5-RELEASE is announced, so sidenav.html should cease showing 
13.5 as an upcoming release at pages such as
https://www.freebsd.org/releases/13.5R/

Complements: doc a587e34fca7d for
13.5: Release-related website updates
```