### PR TITLE
status, 2024 q4: sponsors

### DIFF
--- a/website/content/en/status/report-2024-10-2024-12/clusteradm.adoc
+++ b/website/content/en/status/report-2024-10-2024-12/clusteradm.adoc
@@ -78,4 +78,4 @@ We are particularly interested in locations on the United States West Coast and 
 
 See link:https://wiki.freebsd.org/Teams/clusteradm/generic-mirror-layout[generic mirrored layout] for full mirror site specs and link:https://wiki.freebsd.org/Teams/clusteradm/tiny-mirror[tiny-mirror] for a single mirror site.
 
-Sponsors: The FreeBSD Foundation
+Sponsor: The FreeBSD Foundation

--- a/website/content/en/status/report-2024-10-2024-12/pot.adoc
+++ b/website/content/en/status/report-2024-10-2024-12/pot.adoc
@@ -20,4 +20,5 @@ Last not least, all images have been rebuilt several times: for FreeBSD 14.1, to
 
 As always, feedback and patches are welcome.
 
-Sponsors: Nikulipe UAB, Honeyguide Group
+Sponsor: Nikulipe UAB +
+Sponsor: Honeyguide Group

--- a/website/content/en/status/report-2024-10-2024-12/uvc.adoc
+++ b/website/content/en/status/report-2024-10-2024-12/uvc.adoc
@@ -2,7 +2,7 @@
 
 Links: +
 link:https://github.com/AlvinChen1028/freebsd-src/tree/feature-uvc[Public development repository] URL: link:https://github.com/AlvinChen1028/freebsd-src/tree/feature-uvc[] +
-link:https://github.com/lwhsu/freebsd-src/pull/3[Upstreaming preparation repository] URL: link:https://github.com/lwhsu/freebsd-src/pull/3[] +
+link:https://github.com/lwhsu/freebsd-src/pull/3[Upstreaming preparation repository] URL: link:https://github.com/lwhsu/freebsd-src/pull/3[]
 
 Contact: Alvin Chen <weike_chen@dell.com> +
 Contact: Li-Wen Hsu <lwhsu@FreeBSD.org>
@@ -13,5 +13,5 @@ The code is still cleaning up and will be submitted to official review system af
 
 The Dell ThinOS team is currently working on MIPI Webcam support, including intel XPU.
 
-Sponsor: Dell Technologies for the development
+Sponsor: Dell Technologies for the development +
 Sponsor: The FreeBSD Foundation for assistance of upstreaming


### PR DESCRIPTION
Fix markup for sponsorship lines.

Whilst here, remove superfluous markup.

Consistency: one line per sponsor.

Consistency: The FreeBSD Foundation is a sponsor (not sponsors).

