### PR TITLE
status, 2024 q4: fix broken links

### DIFF
--- a/website/content/en/status/report-2024-10-2024-12/ci.adoc
+++ b/website/content/en/status/report-2024-10-2024-12/ci.adoc
@@ -6,7 +6,7 @@ link:https://tinderbox.freebsd.org[FreeBSD CI Tinderbox view] URL: link:https://
 link:https://artifact.ci.FreeBSD.org[FreeBSD CI artifact archive] URL: link:https://artifact.ci.FreeBSD.org[] +
 link:https://wiki.FreeBSD.org/HostedCI[Hosted CI wiki] URL: link:https://wiki.FreeBSD.org/HostedCI[] +
 link:https://wiki.FreeBSD.org/3rdPartySoftwareCI[3rd Party Software CI] URL: link:https://wiki.FreeBSD.org/3rdPartySoftwareCI[] +
-link:https://bugs.freebsd.org/bugzilla/buglist.cgi?bug_status=__open__&email1=testing%40FreeBSD.org&emailassigned_to1=1&emailcc1=1&emailtype1=equals[Tickets related to freebsd-testing@] URL: link:https://bugs.freebsd.org/bugzilla/buglist.cgi?bug_status=__open__&email1=testing%40FreeBSD.org&emailassigned_to1=1&emailcc1=1&emailtype1=equals[] +
+link:++https://bugs.freebsd.org/bugzilla/buglist.cgi?bug_status=__open__&email1=testing%40FreeBSD.org&emailassigned_to1=1&emailcc1=1&emailtype1=equals++[Tickets related to freebsd-testing@] URL: link:++https://bugs.freebsd.org/bugzilla/buglist.cgi?bug_status=__open__&email1=testing%40FreeBSD.org&emailassigned_to1=1&emailcc1=1&emailtype1=equals++[] +
 link:https://github.com/freebsd/freebsd-ci[FreeBSD CI Repository] URL: link:https://github.com/freebsd/freebsd-ci[] +
 link:https://lists.FreeBSD.org/subscription/dev-ci[dev-ci Mailing List] URL: link:https://lists.FreeBSD.org/subscription/dev-ci[]
 
@@ -44,6 +44,6 @@ Open or queued tasks:
 * Helping more software get FreeBSD support in its CI pipeline (Wiki pages: link:https://wiki.FreeBSD.org/3rdPartySoftwareCI[3rdPartySoftwareCI], link:https://wiki.FreeBSD.org/HostedCI[HostedCI])
 * Working with hosted CI providers to have better FreeBSD support
 
-Please see link:https://bugs.freebsd.org/bugzilla/buglist.cgi?bug_status=__open__&email1=testing%40FreeBSD.org&emailassigned_to1=1&emailcc1=1&emailtype1=equals[freebsd-testing@ related tickets] for more WIP information, and do not hesitate to join the effort!
+Please see link:++https://bugs.freebsd.org/bugzilla/buglist.cgi?bug_status=__open__&email1=testing%40FreeBSD.org&emailassigned_to1=1&emailcc1=1&emailtype1=equals++[freebsd-testing@ related tickets] for more WIP information, and do not hesitate to join the effort!
 
 Sponsor: The FreeBSD Foundation


### PR DESCRIPTION
https://www.freebsd.org/status/report-2024-10-2024-12/#_continuous_integration

The originally published link for work in progress presents 123
reports, most of which are not WIP.

Fix the breakage. Reference: example 12 at
https://docs.asciidoctor.org/asciidoc/latest/syntax-quick-reference/#links

```text
link:++https://example.org/?q=[a b]++[URL with special characters]

https://example.org/?q=%5Ba%20b%5D[URL with special characters]
```

Starting with `++` instead of `https:` is **exceptional**; 

> … The `link:` macro prefix is not required when the target starts with a URL scheme like `https:`. … 