### PR TITLE
Add openjdk status report for 2025Q1

### DIFF
--- a/website/content/en/status/report-2025-01-2025-03/openjdk-status-2025Q1.adoc
+++ b/website/content/en/status/report-2025-01-2025-03/openjdk-status-2025Q1.adoc
@@ -1,0 +1,25 @@
+=== Improve OpenJDK on FreeBSD
+
+Links: +
+link:https://freebsdfoundation.org/project/improving-openjdk-on-freebsd/[Project description] URL: https://freebsdfoundation.org/project/improving-openjdk-on-freebsd/[] +
+link:https://github.com/freebsd/openjdk[Project repository] URL: https://github.com/freebsd/openjdk[]
+
+Contact: +
+Harald Eilertsen <haraldei@freebsdfoundation.org> +
+FreeBSD Java mailing list <freebsd-java@lists.freebsd.org>
+
+The main goal of this project is to improve OpenJDK support on FreeBSD/amd64 and FreeBSD/arm64.
+
+Java is an important runtime environment for many high performance, critical enterprise systems.
+Making sure Java based applications run correctly and efficiently on FreeBSD is important to ensure that FreeBSD will continue to be a viable and attractive platform for enterprises, as well as businesses and organizations of all sizes.
+
+We released https://cgit.freebsd.org/ports/commit/?id=aa17c509fe7c4a011e832bd1e67257cf5d0ebc81[a port for OpenJDK 23] for FreeBSD at the very end of last year, and have since then fixed an https://bugs.freebsd.org/bugzilla/show_bug.cgi?id=284503[issues with font management] and some other minor improvements.
+We have also been following the development of OpenJDK 24 closely, and are just finishing a https://reviews.freebsd.org/D49354[port for it] that that should be available by the time this status update is published.
+
+In parallel with porting OpenJDK 24 work has been ongoing on moving the BSD port also to the mainline OpenJDK development tree, and the first patches has been accepted upstream. Currently the focus is on reviving the https://openjdk.org/projects/bsd-port/[OpenJDK BSD port project], as well as getting a separate project repository set up under it.
+
+A lot of the work of this quarter has gone into cleaning up the patches of the BSD port based on the development in the upstream mainline and jdk24 branches. Also a lot of time has been spent on improving the results of the built in test suites (jtreg and gtest) on FreeBSD. This has involved both changes to the tests themselves, but also various parts of the low level OpenJDK code. More work is needed to get the final few tests passing, especially on Aarch64, but compared to previous OpenJDK releases on FreeBSD the results have been improving.
+
+Finally, a significant amount of time has been spent on communicating and discussing how to approach the goal of integrating the BSD support in the mainline OpenJDK codebase. The OpenJDK project has been very open, welcoming and supportive of the effort, and seems more than willing to help make this happen in a good way.
+
+Sponsor: The FreeBSD Foundation


### PR DESCRIPTION
Here's my status report for the Improve OpenJDK on FreeBSD project.

Sorry it's a bit late, but I wanted to get the jdk24 port mostly in place before submitting it.