### PR TITLE
handbook/kde: Mention sysctl.conf

### DIFF
--- a/documentation/content/en/books/handbook/desktop/_index.adoc
+++ b/documentation/content/en/books/handbook/desktop/_index.adoc
@@ -151,7 +151,7 @@ Enable D-BUS service in `/etc/rc.conf` to start at system boot:
 # sysrc dbus_enable="YES"
 ....
 
-To help the desktop's performance, increase message sizes for DBus' inter-process communication.
+To help the desktop environment's performance, increase message sizes.
 
 Edit the `/etc/sysctl.conf` with an editor of choice, then, add the following lines:
 
@@ -160,6 +160,15 @@ Edit the `/etc/sysctl.conf` with an editor of choice, then, add the following li
 net.local.stream.recvspace=65536
 net.local.stream.sendspace=65536
 ....
+
+Then, to apply the change you will need to execute as root:
+
+[source,shell]
+....
+sysctl -f /etc/sysctl.conf
+....
+
+Or you may alternatively reboot the system.
 
 [[kde-start]]
 ==== Start KDE Plasma

--- a/documentation/content/en/books/handbook/desktop/_index.adoc
+++ b/documentation/content/en/books/handbook/desktop/_index.adoc
@@ -151,7 +151,7 @@ Enable D-BUS service in `/etc/rc.conf` to start at system boot:
 # sysrc dbus_enable="YES"
 ....
 
-To help the desktop environment's performance, increase message sizes.
+KDE requires larger message sizes for optimal performance.
 
 Add the following lines to man:sysctl.conf[5]:
 

--- a/documentation/content/en/books/handbook/desktop/_index.adoc
+++ b/documentation/content/en/books/handbook/desktop/_index.adoc
@@ -153,7 +153,7 @@ Enable D-BUS service in `/etc/rc.conf` to start at system boot:
 
 To help the desktop environment's performance, increase message sizes.
 
-Edit the `/etc/sysctl.conf` with an editor of choice, then, add the following lines:
+Add the following lines to man:sysctl.conf[5]:
 
 [source,shell]
 ....


### PR DESCRIPTION
Update handbook entry for DBus message sizes tweak to sysctl to allow it to persist after reboot