### PR TITLE
Translations page, Russian project: removed or fixed broken links

### DIFF
--- a/website/content/en/docproj/translations.adoc
+++ b/website/content/en/docproj/translations.adoc
@@ -233,12 +233,9 @@ Handbook
 Documents available:
 
 * link:https://docs.freebsd.org/ru/books/faq/[FAQ]
-* link:https://www.freebsd.org/ru/[WWW]
-* link:http://www.freebsd.org.ua/docs.html[Other documents list]
-
-Documents currently being worked on:
-
-* link:http://www.freebsd.org.ua/doc/ru_RU.KOI8-R/books/handbook/[Handbook]
+* link:https://docs.freebsd.org/ru/[FreeBSD documentation]
+* link:https://docs.freebsd.org/ru/books/[Books]
+* link:https://docs.freebsd.org/ru/books/handbook/[Handbook]
 
 [[spanish]]
 == The FreeBSD Spanish Documentation Project


### PR DESCRIPTION
1. removed links to external site (not used for FreeBSD documentation anymore)
2. fixed links from `www` to `docs` subdomain to show correct page
3. removed the section "Documents currently being worked on", no work in progress now.