### PR TITLE
Escape a + sign in porters handbook/makefiles

### DIFF
--- a/documentation/content/en/books/porters-handbook/makefiles/_index.adoc
+++ b/documentation/content/en/books/porters-handbook/makefiles/_index.adoc
@@ -2271,7 +2271,7 @@ DISTFILES=	source1.tar.gz:source1 \
 
 Okay, so the previous example did not reflect the new port's needs? In this section we will explain in detail how the fine grained fetching mechanism `MASTER_SITES:n` works and how it can be used.
 
-. Elements can be postfixed with `:__n__` where _n_ is `[^:,]+`, that is, _n_ could conceptually be any alphanumeric string but we will limit it to `[a-zA-Z_][0-9a-zA-Z_]+` for now.
+. Elements can be postfixed with `:__n__` where _n_ is `[^:,]\+`, that is, _n_ could conceptually be any alphanumeric string but we will limit it to `[a-zA-Z_][0-9a-zA-Z_]+` for now.
 +
 Moreover, string matching is case sensitive; that is, `n` is different from `N`.
 +


### PR DESCRIPTION
The first plus sign in the "Detailed Information" section is interpreted as the start of a literal monospace section, and breaks formatting. This may be a bug in AsciiDoctor, but escaping it avoids the issue.