### PR TITLE
14.3 late-breaking bug 287482, ZFS raw VM image

### DIFF
--- a/website/content/en/releases/14.3R/errata.adoc
+++ b/website/content/en/releases/14.3R/errata.adoc
@@ -77,4 +77,6 @@ For a list of all FreeBSD CERT security advisories, see https://www.FreeBSD.org/
 == Late-Breaking News
 
 [[late-287482]]
-The ZFS raw virtual machine image for AMD64 is prone to kernel panics (link:https://bugs.freebsd.org/bugzilla/show_bug.cgi?id=287482[bug 287482]). `FreeBSD-14.3-RELEASE-amd64-zfs.raw.xz` is no longer at download.freebsd.org. Torrents of the file should be avoided.
+The ZFS raw virtual machine image for AMD64 is prone to kernel panics (link:https://bugs.freebsd.org/bugzilla/show_bug.cgi?id=287482[bug 287482]).
+`FreeBSD-14.3-RELEASE-amd64-zfs.raw.xz` is no longer at download.freebsd.org.
+Torrents of the file should be avoided.

--- a/website/content/en/releases/14.3R/errata.adoc
+++ b/website/content/en/releases/14.3R/errata.adoc
@@ -76,4 +76,5 @@ For a list of all FreeBSD CERT security advisories, see https://www.FreeBSD.org/
 [[late-news]]
 == Late-Breaking News
 
-No late-breaking news.
+[[late-287482]]
+The ZFS raw virtual machine image for AMD64 is prone to kernel panics (link:https://bugs.freebsd.org/bugzilla/show_bug.cgi?id=287482[bug 287482]). `FreeBSD-14.3-RELEASE-amd64-zfs.raw.xz` is no longer at download.freebsd.org. Torrents of the file should be avoided.


### PR DESCRIPTION
https://bugs.freebsd.org/287482

AMD64.

FreeBSD-14.3-RELEASE-amd64-zfs.raw.xz has been removed from
https://download.freebsd.org/releases/VM-IMAGES/14.3-RELEASE/amd64/Latest/