### PR TITLE
handbook: fix missing space after period in 4.2

### DIFF
--- a/documentation/content/en/books/handbook/ports/_index.adoc
+++ b/documentation/content/en/books/handbook/ports/_index.adoc
@@ -99,7 +99,7 @@ Select the technology that meets your requirements for installing a particular a
 +
 In some cases, multiple packages will exist for the same application with different settings. For example, NGINX(R) is available as a `nginx` package and a `nginx-lite` package, the former has many more options enabled, but this in turn requires many things to be installed as dependencies for it to work, thus increasing space consumption and attack surface.
 +
-The transitive dependencies can grow quite large, for example the full `nginx` package will pull in several X libraries which can be quite surprising, so building from ports allow you to choose only the options you need without a "kitchen sink" approach.In some cases, multiple packages will exist for the same application to specify certain settings.
+The transitive dependencies can grow quite large, for example the full `nginx` package will pull in several X libraries which can be quite surprising, so building from ports allow you to choose only the options you need without a "kitchen sink" approach. In some cases, multiple packages will exist for the same application to specify certain settings.
 * The licensing conditions of some software forbid binary distribution. Such software must be distributed as source code which must be compiled by the end-user.
 * Some people do not trust binary distributions or prefer to read through source code in order to look for potential problems.
 * Source code is needed in order to apply custom patches.


### PR DESCRIPTION
Fixed missing space after period in 4.2.

Before: "approach.In some cases"
After: "approach. In some cases"