### PR TITLE
handbook/cutting-edge: Add `pkg update` and `pkg upgrade`

### DIFF
--- a/documentation/content/en/books/handbook/cutting-edge/_index.adoc
+++ b/documentation/content/en/books/handbook/cutting-edge/_index.adoc
@@ -60,6 +60,7 @@ This chapter describes how to track the development system and the basic tools f
 
 After reading this chapter, you will know:
 
+* How to keep a FreeBSD system packages up-to-date with with `pkg update` and `pkg upgrade`.
 * How to keep a FreeBSD system up-to-date with freebsd-update or Git.
 * How to compare the state of an installed system against a known pristine copy.
 * How to keep the installed documentation up-to-date with Git or documentation ports.
@@ -76,6 +77,17 @@ Before reading this chapter, you should:
 Throughout this chapter, `git` is used to obtain and update FreeBSD sources.
 Optionally, the package:devel/git[] port or package may be used.
 ====
+
+[[pkg-update-upgrade]]
+== pkg upgrade
+
+To update local repositories and upgrade packages, run the following commands:
+
+[source,shell]
+....
+# pkg update
+# pkg upgrade
+....
 
 [[updating-upgrading-freebsdupdate]]
 == FreeBSD Update


### PR DESCRIPTION
The page title is "Chapter 26. Updating and Upgrading FreeBSD". Which I think should include upgrading packages. `pkg upgrade` is mentioned in  passing but I think it should be explicitly mentioned along with  `pkg update`.