### PR TITLE
shared/authors.adoc: update RE teams

### DIFF
--- a/shared/authors.adoc
+++ b/shared/authors.adoc
@@ -3798,8 +3798,8 @@
 
 // FreeBSD Release Engineering Teams
 :re: re@FreeBSD.org
-:re-members: {kib}, {dch}, {blackend}, {jhixson}, {delphij}, {emaste}, {mmokhi}, {cperciva}, {dfr}, {bofh}
-:re-members-email: {kib-email}, {dch-email}, {blackend-email}, {jhixson-email}, {delphij-email}, {emaste-email}, {mmokhi-email}, {cperciva-email}, {dfr-email}, {bofh-email}
+:re-members: {dch}, {blackend}, {jfree}, {delphij}, {emaste}, {mmokhi}, {cperciva}, {bofh}
+:re-members-email: {dch-email}, {blackend-email}, {jfree-email}, {delphij-email}, {emaste-email}, {mmokhi-email}, {cperciva-email}, {bofh-email}
 
 // FreeBSD Security Officer
 :so: {gordon}


### PR DESCRIPTION
Consistent with:

a) doc 682f0eee79f1 (2025-06-11)

b) the order of members' names at
https://www.freebsd.org/administration/#t-re