### PR TITLE
documentation: Correct link to nginx-lite

### DIFF
--- a/documentation/content/en/books/handbook/jails/_index.adoc
+++ b/documentation/content/en/books/handbook/jails/_index.adoc
@@ -1051,7 +1051,7 @@ Finally, it will be necessary to remove the jail entry in [.filename]#/etc/jail.
 
 The man:pkg[8] tool supports the `-j` argument in order to handle packages installed inside the jail.
 
-For example, to install package:nginx-lite[] in the jail, the next command can be executed *from the host*:
+For example, to install package:www/nginx-lite[] in the jail, the next command can be executed *from the host*:
 
 [source,shell]
 ....


### PR DESCRIPTION
I hope :) Clicking link as is doesn't work, maybe full description in ports, like this, will? I've not been able to test this via GH edit link. Please check.