### PR TITLE
handbook/cutting-edge: corrections, improvements

### DIFF
--- a/documentation/content/en/books/handbook/cutting-edge/_index.adoc
+++ b/documentation/content/en/books/handbook/cutting-edge/_index.adoc
@@ -1221,7 +1221,7 @@ There are different branches to choose from (by changing the url accordingly):
 
 | releng/14.3
 | twice daily – 12:00 and 00:00 UTC
-| \https://pkg.freebsd.org/${ABI}/base_release_3
+| pkg+https://pkg.freebsd.org/${ABI}/base_release_3
 |===
 
 To upgrade the system, change the configuration file according to the desired release, and run:


### PR DESCRIPTION
Add two tags:

- FreeBSD-RELEASE
- pkgbase.

Use alphabetical order for the tags.

For the table of FreeBSD-base repos: lowercase url, consistent with
what's seen in a repo configuration.

De-link the url strings, which are not intended for web browsers.

Add a subsection heading for minor upgrades from the FreeBSD-base repo.

The # command prompt implies the superuser, so `pkg update` is superfluous.

Advice to save a list of non-base packages should be more prominent.

Offer a non-alarmist example of why the list might be useful: loss of power, as a cause of interruption to an upgrade.

The precaution of listing is relevant to pkg-upgrade(8) in general, not pkgbase in particular, but for now: have it near the head of the pkgbase upgrade subsection.

Use 411.pkg-backup.in to backup the package database.

Signed-off-by: Graham Perrin <grahamperrin@gmail.com>