### PR TITLE
Status/2025Q3/drm-drivers.adoc: Add report about DRM drivers

### DIFF
--- a/website/content/en/status/report-2025-07-2025-09/drm-drivers.adoc
+++ b/website/content/en/status/report-2025-07-2025-09/drm-drivers.adoc
@@ -1,0 +1,41 @@
+=== DRM drivers
+
+Links: +
+link:https://github.com/freebsd/drm-kmod/pull/371[Update to Linux 6.10 DRM drivers] URL: link:https://github.com/freebsd/drm-kmod/pull/371[]
+
+Contact: Jean-Sébastien Pédron <dumbbell@FreeBSD.org>
+
+DRM drivers are **kernel drivers for integrated and discrete GPUs**.
+They are maintained in the Linux kernel and we port them to FreeBSD.
+As of this report, we take the AMD and Intel DRM drivers only (NVIDIA FreeBSD drivers are proprietary and provided by NVIDIA themselves).
+
+We port them one Linux version at a time.
+This allows us to ship updates more often and it eases porting and debugging because we have a smaller delta compared to a bigger jump skipping several versions.
+
+This quarter, the work was slower with the holidays.
+**DRM drivers from Linux 6.10 were ported**.
+However, there are still issues that need to be worked on:
+* There is a regression in the integration of the `amdgpu` driver with man:vt[4], causing the console to go blank once the driver is loaded.
+  A graphical session still works though.
+* There are significant changes to the `radix-tree` suppport in `linuxkpi` that needs more testing.
+* The `siphash` code committed to `linuxkpi` is not working yet.
+
+The pull request on GitHub and the associated freebsd-src branch may not have the latest versions, until the compilation and load failures are fixed.
+
+These updates target the FreeBSD 16-CURRENT development branch for now, but `linuxkpi` changes should be backported to FreeBSD 15-STABLE.
+
+The following pull request did not receive enough reviews and tests for now.
+That is why they are still in flight.
+
+* https://github.com/freebsd/drm-kmod/pull/357[`DMA_BUF_IOCTL_EXPORT_SYNC_FILE` and `DMA_BUF_IOCTL_IMPORT_SYNC_FILE` ioctls]
+* https://github.com/freebsd/drm-kmod/pull/358[`DRM_IOCTL_SYNCOBJ_EVENTFD` ioctl]
+
+They are apparently required to allow the use of wlroots-based Wayland compositors with the Vulkan API (see link:https://bugs.freebsd.org/bugzilla/show_bug.cgi?id=286311[]).
+wlroots will need a patch as well because it only expects these features on Linux for now.
+
+Both pull requests rely on patches to `linuxkpi`.
+The `linuxkpi` patches are linked in the pull requests.
+
+This work is kindly sponsored by the FreeBSD Foundation as part of the Laptop and Desktop Project.
+
+Sponsor: The FreeBSD Foundation


### PR DESCRIPTION
Sponsored by: The FreeBSD Foundation