### PR TITLE
Correctly document ARCH value

### DIFF
--- a/documentation/content/en/books/porters-handbook/porting-dads/_index.adoc
+++ b/documentation/content/en/books/porters-handbook/porting-dads/_index.adoc
@@ -120,7 +120,7 @@ Here are some important variables defined in [.filename]#bsd.port.pre.mk# (this 
 | Description
 
 |`ARCH`
-|The architecture as returned by `uname -m` (for example, `i386`)
+|The architecture as returned by `uname -p` (for example, `i386`)
 
 |`OPSYS`
 |The operating system type, as returned by `uname -s` (for example, `FreeBSD`)


### PR DESCRIPTION
ARCH has the same value as `uname -p` (as documented in bsd.port.mk) not `uname -m`.