### PR TITLE
Sync sshd policy example with freebsd-src.

### DIFF
--- a/documentation/content/en/articles/pam/_index.adoc
+++ b/documentation/content/en/articles/pam/_index.adoc
@@ -216,17 +216,17 @@ The following is FreeBSD's default policy for `sshd`:
 
 [.programlisting]
 ....
-sshd	auth		required	pam_nologin.so	no_warn
 sshd	auth		required	pam_unix.so	no_warn try_first_pass
+sshd	account		required	pam_nologin.so
 sshd	account		required	pam_login_access.so
 sshd	account		required	pam_unix.so
-sshd	session		required	pam_lastlog.so	no_fail
-sshd	password	required	pam_permit.so
+sshd	session		required	pam_permit.so
+sshd	password	required	pam_unix.so no_warn try_first_pass
 ....
 
 * This policy applies to the `sshd` service (which is not necessarily restricted to the man:sshd[8] server.)
 * `auth`, `account`, `session` and `password` are facilities.
-* [.filename]#pam_nologin.so#, [.filename]#pam_unix.so#, [.filename]#pam_login_access.so#, [.filename]#pam_lastlog.so# and [.filename]#pam_permit.so# are modules. It is clear from this example that [.filename]#pam_unix.so# provides at least two facilities (authentication and account management.)
+* [.filename]#pam_nologin.so#, [.filename]#pam_unix.so#, [.filename]#pam_login_access.so# and [.filename]#pam_permit.so# are modules. It is clear from this example that [.filename]#pam_unix.so# provides at least two facilities (authentication and account management.)
 
 [[pam-essentials]]
 == PAM Essentials


### PR DESCRIPTION
The default ``sshd'' policy from freebsd/freebsd-src is available at: https://github.com/freebsd/freebsd-src/blob/e7258c42520c18c034f644b97377d8d2a0ad8b7c/lib/libpam/pam.d/sshd

This change updates the default policy example with the source code.