### PR TITLE
Fix the number of control flags in pam doc

### DIFF
--- a/documentation/content/en/articles/pam/_index.adoc
+++ b/documentation/content/en/articles/pam/_index.adoc
@@ -298,7 +298,7 @@ A policy consists of four chains, one for each of the four PAM facilities.
 Each chain is a sequence of configuration statements, each specifying a module to invoke, some (optional) parameters to pass to the module, and a control flag that describes how to interpret the return code from the module.
 
 Understanding the control flags is essential to understanding PAM configuration files.
-There are four different control flags:
+There are five different control flags:
 
 `binding`::
 If the module succeeds and no earlier module in the chain has failed, the chain is immediately terminated and the request is granted.


### PR DESCRIPTION
The flags are: (1) binding, (2) required, (3) requisite, (4) sufficient, and (5) optional.