### PR TITLE
In "Latest Ports" section: FreeBSD --> FreeBSD-ports

### DIFF
--- a/documentation/content/en/books/handbook/ports/_index.adoc
+++ b/documentation/content/en/books/handbook/ports/_index.adoc
@@ -201,7 +201,7 @@ To switch man:pkg[8] from Quarterly to Latest run the following commands:
 [source,shell]
 ....
 # mkdir -p /usr/local/etc/pkg/repos
-# echo 'FreeBSD: { url: "pkg+https://pkg.FreeBSD.org/${ABI}/latest" }' > /usr/local/etc/pkg/repos/FreeBSD.conf
+# echo 'FreeBSD-ports: { url: "pkg+https://pkg.FreeBSD.org/${ABI}/latest" }' > /usr/local/etc/pkg/repos/FreeBSD.conf
 ....
 
 Then run this command to update the local package repositories catalogues for the Latest branch:


### PR DESCRIPTION
It looks like the name has changed as of 15-RELEASE. Found the fix via this forum thread: https://forums.freebsd.org/threads/error-when-switching-to-latest-pkg-repo.100579/

NOTE: That thread also recommends moving `FreeBSD-ports-kmods` to latest as well by adding:
```
FreeBSD-ports-kmods: {
  url: "pkg+https://pkg.FreeBSD.org/${ABI}/kmods_latest_${VERSION_MINOR}"
}
```

Should that be added to this section as well? 