### PR TITLE
Remove outdated links to TrueNAS

### DIFF
--- a/website/content/en/projects/newbies.adoc
+++ b/website/content/en/projects/newbies.adoc
@@ -27,7 +27,6 @@ The latest FreeBSD releases are available link:../../where/[here]. Before you be
 
 FreeBSD is widely used as a building block for other commercial and open-source operating systems. Some of the most widely used and publicly available systems are listed below.
 
-* https://www.truenas.com/[TrueNAS] is a Network Attached Storage (NAS) software that shares and protects data from modern-day threats like ransomware and malware. TrueNAS makes it easy for users and client devices to access shared data through virtually any sharing protocol.
 * https://www.ghostbsd.org[GhostBSD] is derived from FreeBSD, GhostBSD uses the GTK environment to provide a beautiful looks and comfortable experience on the modern BSD platform offering a natural and native UNIX(R) work environment.
 * https://nomadbsd.org[NomadBSD] is a persistent live system for USB flash drives, based on FreeBSD. Together with automatic hardware detection and setup, it is configured to be used as a desktop system that works out of the box, but can also be used for data recovery, for educational purposes, or to test FreeBSD's hardware compatibility.
 * https://www.midnightbsd.org[MidnightBSD] is a BSD-derived operating system developed with desktop users in mind. It includes all the software you'd expect for your daily tasks: mail, web browsing, word processing, gaming, and much more.


### PR DESCRIPTION
```text
TrueNAS Legacy (CORE) disappeared from the status section of
https://www.truenas.com/docs/softwarestatus/
in 2025.
```