### PR TITLE
Status/2026Q1/bananapi-r64-r2-pro-drivers.adoc: Add report

### DIFF
--- a/website/content/en/status/report-2026-01-2026-03/bananapi-r64-r2-pro-drivers.adoc
+++ b/website/content/en/status/report-2026-01-2026-03/bananapi-r64-r2-pro-drivers.adoc
@@ -1,0 +1,72 @@
+=== FreeBSD Driver Development for BananaPi-R64/R2-PRO
+
+Links: +
+link:https://wiki.freebsd.org/arm/Bananapi[Wiki] URL: link:https://wiki.freebsd.org/arm/Bananapi[]
+
+Contact: Martin Filla <freebsd@sysctl.cz>
+
+==== Introduction
+
+The Banana Pi R64 is a MediaTek MT7622-based development board (ARM Cortex-A53, dual-core ~1.35 GHz) featuring 4× Gigabit LAN, 1× Gigabit WAN, Wi-Fi (4×4n), Bluetooth 5.0, and multiple peripheral interfaces (UART, SPI, I²C, GPIO, SATA, mini-PCIe, eMMC, etc.).
+
+==== Current State of FreeBSD Support R64
+
+Implemented so far:
+
+- **UART driver**
+- **Clock management (clocks)**
+- **Pinctrl**
+- **Storage controllers (eMMC/SD/MMC) driver**
+- **Ethernet Switch mt7531 driver**
+- **Ethernet mt7622 driver**
+- **XHCI driver**
+- **Watchdog driver**
+- **RTC driver**
+- **RNG driver**
+- **Pciecfg driver**
+- **SysIRQ driver**
+
+==== Development roadmap R64
+
+Implement missing drivers:
+
+- USB3 / T-PHY
+- SATA / AHCI / T-PHY
+- Wi-Fi (likely MediaTek MT7615)
+- GPIO subsystems
+- I2C
+- SPI
+- PWM
+- PCIE
+
+Work in progress drivers:
+- T-PHY
+
+
+==== Introduction
+
+The Banana Pi BPI-R2 Pro is the next generation smart router developement board. It is powered by Rockchip RK 3568 processor.Onboard 2GB LPDDR4 memory and 16GB eMMC storage, and supports 2 USB 3.0 interface, 5 gigabit network port. M.2 key-E and mini PCIe interface, 2 mipi DSI interface(one can change to LVDS by software), 1 CSI camera interface,1 HDMI output.
+
+==== Current State of FreeBSD Support R2-PRO
+
+Implemented so far:
+
+- **UART driver**
+- **Clock management (clocks)**
+- **Pinctrl**
+- **GPIO**
+- **Storage controllers (eMMC/SD/MMC) driver**
+- **XHCI driver**
+- **Watchdog driver**
+- **PCIE driver**
+
+==== Development roadmap R2-PRO
+
+Implement missing drivers:
+- HDMI
+- MIPI
+- USB3
+
+Work in progress drivers:
+- AHCI/SATA
+- PCIE


### PR DESCRIPTION
Hi,
This status report for r64/r2-pro.
The FreeBSD Foundation does not fund this work.