### PR TITLE
Q1 2026 status report: FreeBSD HPC modernization initiative

### DIFF
--- a/website/content/en/status/report-2026-01-2026-03/hpc-ports-modernization.adoc
+++ b/website/content/en/status/report-2026-01-2026-03/hpc-ports-modernization.adoc
@@ -1,0 +1,41 @@
+=== FreeBSD HPC Modernization Initiative: Ecosystem Expansion and Upstream Integration
+
+Links: +
+link:https://cgit.freebsd.org/ports/tree/sysutils/slurm-wlm/[sysutils/slurm-wlm] URL: link:https://cgit.freebsd.org/ports/tree/sysutils/slurm-wlm/[] +
+link:https://cgit.freebsd.org/ports/tree/net/pmix/[net/pmix] URL: link:https://cgit.freebsd.org/ports/tree/net/pmix/[] +
+link:https://cgit.freebsd.org/ports/tree/net/prrte/[net/prrte] URL: link:https://cgit.freebsd.org/ports/tree/net/prrte/[] +
+link:https://cgit.freebsd.org/ports/tree/net/openmpi/[net/openmpi] URL: link:https://cgit.freebsd.org/ports/tree/net/openmpi/[] +
+link:https://cgit.freebsd.org/ports/tree/net/ucx/[net/ucx] URL: link:https://cgit.freebsd.org/ports/tree/net/ucx/[] +
+link:https://cgit.freebsd.org/ports/tree/benchmarks/py-reframe-hpc/[benchmarks/py-reframe-hpc] URL: link:https://cgit.freebsd.org/ports/tree/benchmarks/py-reframe-hpc/[] +
+link:https://cgit.freebsd.org/ports/tree/sysutils/mpifileutils/[sysutils/mpifileutils] URL: link:https://cgit.freebsd.org/ports/tree/sysutils/mpifileutils/[]
+
+Contact: Generic Rikka <rikka.goering@outlook.de>
+
+This report continues the ongoing FreeBSD HPC Ports Modernization initiative, which aims to make FreeBSD a practical and maintainable platform for modern high-performance computing (HPC) software stacks.
+
+Previous work focused on updating the core scheduler and runtime stack by modernizing package:sysutils/slurm-wlm[] and introducing standalone ports for package:net/pmix[] and package:net/prrte[].
+During this quarter the focus shifted toward expanding the surrounding HPC ecosystem, improving integration between components, and upstreaming portability fixes discovered during the porting process.
+
+The long-term goal is to provide a coherent HPC software environment in the FreeBSD Ports Collection that resembles what users expect on Linux-based HPC systems while remaining maintainable within the FreeBSD ecosystem.
+
+==== Work completed
+
+* Continued tracking upstream releases of package:sysutils/slurm-wlm[], keeping the FreeBSD port current with the latest upstream versions.
+  Recent updates confirm that Slurm can successfully schedule and execute jobs on FreeBSD with only a minimal patchset.
+* Introduced package:net/ucx[], providing the Unified Communication X framework used by modern MPI implementations for high-performance communication.
+* Added package:benchmarks/py-reframe-hpc[], enabling regression testing and validation workflows commonly used on production HPC clusters.
+* Continued improving interoperability between package:net/openmpi[], package:net/ucx[], package:net/pmix[], and package:net/prrte[] within the FreeBSD Ports Collection.
+
+==== Work in progress
+
+* Porting package:sysutils/mpifileutils[] and its dependency stack (package:devel/libcircle[], package:devel/lwgrp[], package:devel/dtcmp[]) to provide MPI-parallel file utilities commonly used on large HPC filesystems.
+* Upstreaming portability fixes discovered during the porting process to projects such as UCX and mpifileutils, reducing the need for FreeBSD-specific patches.
+* Ongoing collaboration with SchedMD developers to upstream improvements discovered while maintaining Slurm on FreeBSD.
+* Coordination with the OpenMPI ports maintainer to improve integration between OpenMPI and modern networking frameworks such as UCX.
+
+==== Future plans
+
+* Continue expanding the HPC software ecosystem available in the FreeBSD Ports Collection.
+* Further reduce local patchsets by contributing portability fixes upstream whenever possible.
+* Develop documentation describing how the Slurm + OpenMPI + PMIx + PRRTE + UCX stack can be deployed together on FreeBSD, lowering the barrier for users who want to experiment with HPC workloads on the platform.
+* Provide example configurations and integration guidance so that FreeBSD can serve as a realistic development and testing environment for HPC software.


### PR DESCRIPTION
This pull request adds the Q1 2026 status report entry for the ongoing **FreeBSD HPC Ports Modernization initiative**.

The report summarizes progress made during the quarter expanding the HPC ecosystem available in the FreeBSD Ports Collection and improving interoperability between modern HPC runtime components.

## Highlights

- Continued maintenance of `sysutils/slurm-wlm`, confirming successful job scheduling and execution on recent versions with a minimal patchset.
- Added `net/ucx`, providing the Unified Communication X framework used by modern MPI implementations.
- Added `benchmarks/py-reframe-hpc`, enabling HPC regression testing workflows.
- Continued improving interoperability between `net/openmpi`, `net/ucx`, `net/pmix`, and `net/prrte`.
- Ongoing upstream collaboration and portability work with projects such as UCX and mpifileutils.

## Ongoing work

- Porting `sysutils/mpifileutils` and its dependency stack (`libcircle`, `lwgrp`, etc.).
- Upstreaming portability improvements discovered during the porting process.
- Continued collaboration with SchedMD around Slurm improvements.

## Future direction

Planned work includes expanding the available HPC tooling in ports and documenting a reference **Slurm + OpenMPI + PMIx + PRRTE + UCX** deployment on FreeBSD to lower the barrier for experimenting with HPC workloads on the platform.