### PR TITLE
handbook/zh-tw: complete firewalls chapter translation

### DIFF
--- a/documentation/content/zh-tw/books/handbook/firewalls/_index.adoc
+++ b/documentation/content/zh-tw/books/handbook/firewalls/_index.adoc
@@ -133,46 +133,46 @@ OpenBSD 計劃有維護一份官方參考文件於 http://www.openbsd.org/faq/pf
 [WARNING]
 ====
 
-When reading the http://www.openbsd.org/faq/pf/[PF FAQ], keep in mind that FreeBSD's version of PF has diverged substantially from the upstream OpenBSD version over the years. Not all features work the same way on FreeBSD as they do in OpenBSD and vice versa.
+閱讀 http://www.openbsd.org/faq/pf/[PF FAQ] 時，請注意 FreeBSD 的 PF 版本多年來已與上游 OpenBSD 版本產生相當大的差異。並非所有功能在 FreeBSD 與 OpenBSD 上的運作方式都相同，反之亦然。
 ====
 
 要詢問有關設定與執行 PF 防火牆的問題可至 http://lists.FreeBSD.org/mailman/listinfo/freebsd-pf[FreeBSD packet filter 郵遞論壇]，在詢問問題之前請先查看該郵遞論壇的封存資料，因您的問題可能已有解答。
 
-This section of the Handbook focuses on PF as it pertains to FreeBSD. It demonstrates how to enable PF and ALTQ. It also provides several examples for creating rulesets on a FreeBSD system.
+本手冊此段落著重於 PF 在 FreeBSD 上的應用，說明如何啟用 PF 和 ALTQ，並提供幾個在 FreeBSD 系統上建立規則集的範例。
 
 === 開啟 PF
 
-To use PF, its kernel module must be first loaded. This section describes the entries that can be added to [.filename]#/etc/rc.conf# to enable PF.
+要使用 PF，必須先載入其核心模組。本段落說明可以加到 [.filename]#/etc/rc.conf# 中以啟用 PF 的設定項目。
 
-Start by adding `pf_enable=yes` to [.filename]#/etc/rc.conf#:
+首先將 `pf_enable=yes` 加入 [.filename]#/etc/rc.conf#：
 
 [source,shell]
 ....
 # sysrc pf_enable=yes
 ....
 
-Additional options, described in man:pfctl[8], can be passed to PF when it is started. Add or change this entry in [.filename]#/etc/rc.conf# and specify any required flags between the two quotes (`""`):
+PF 啟動時可以傳入其他選項，相關說明請參考 man:pfctl[8]。在 [.filename]#/etc/rc.conf# 中新增或修改以下設定項目，並在兩個引號 (`""`) 之間指定所需的旗標：
 
 [.programlisting]
 ....
 pf_flags=""                     # additional flags for pfctl startup
 ....
 
-PF will not start if it cannot find its ruleset configuration file. By default, FreeBSD does not ship with a ruleset and there is no [.filename]#/etc/pf.conf#. Example rulesets can be found in [.filename]#/usr/shared/examples/pf/#. If a custom ruleset has been saved somewhere else, add a line to [.filename]#/etc/rc.conf# which specifies the full path to the file:
+如果 PF 找不到規則集設定檔就不會啟動。FreeBSD 預設並不附帶規則集，也沒有 [.filename]#/etc/pf.conf# 檔案。範例規則集可以在 [.filename]#/usr/shared/examples/pf/# 找到。如果自訂規則集存放在其他位置，請在 [.filename]#/etc/rc.conf# 中新增一行，指定該檔案的完整路徑：
 
 [.programlisting]
 ....
 pf_rules="/path/to/pf.conf"
 ....
 
-Logging support for PF is provided by man:pflog[4]. To enable logging support, add `pflog_enable=yes` to [.filename]#/etc/rc.conf#:
+PF 的記錄功能由 man:pflog[4] 提供。要啟用記錄功能，請將 `pflog_enable=yes` 加入 [.filename]#/etc/rc.conf#：
 
 [source,shell]
 ....
 # sysrc pflog_enable=yes
 ....
 
-The following lines can also be added to change the default location of the log file or to specify any additional flags to pass to man:pflog[4] when it is started:
+也可以加入以下幾行來變更記錄檔的預設位置，或指定 man:pflog[4] 啟動時要傳入的額外旗標：
 
 [.programlisting]
 ....
@@ -180,14 +180,14 @@ pflog_logfile="/var/log/pflog"  # where pflogd should store the logfile
 pflog_flags=""                  # additional flags for pflogd startup
 ....
 
-Finally, if there is a LAN behind the firewall and packets need to be forwarded for the computers on the LAN, or NAT is required, enable the following option:
+最後，如果防火牆後方有區域網路，且需要為區域網路上的電腦轉送封包，或需要使用網路位址轉譯 (NAT)，請啟用以下選項：
 
 [.programlisting]
 ....
 gateway_enable="YES"            # Enable as LAN gateway
 ....
 
-After saving the needed edits, PF can be started with logging support by typing:
+儲存所需的編輯後，即可輸入以下指令啟動 PF 並開啟記錄功能：
 
 [source,shell]
 ....
@@ -195,9 +195,9 @@ After saving the needed edits, PF can be started with logging support by typing:
 # service pflog start
 ....
 
-By default, PF reads its configuration rules from [.filename]#/etc/pf.conf# and modifies, drops, or passes packets according to the rules or definitions specified in this file. The FreeBSD installation includes several sample files located in [.filename]#/usr/shared/examples/pf/#. Refer to the http://www.openbsd.org/faq/pf/[PF FAQ] for complete coverage of PF rulesets.
+PF 預設從 [.filename]#/etc/pf.conf# 讀取設定規則，並根據此檔案中指定的規則或定義來修改、丟棄或放行封包。FreeBSD 安裝時附帶了幾個範例檔案，位於 [.filename]#/usr/shared/examples/pf/#。關於 PF 規則集的完整說明，請參閱 http://www.openbsd.org/faq/pf/[PF FAQ]。
 
-To control PF, use `pfctl`. <<pfctl>> summarizes some useful options to this command. Refer to man:pfctl[8] for a description of all available options:
+要控制 PF，請使用 `pfctl`。<<pfctl>> 列出了這個指令的幾個實用選項。所有可用選項的說明請參閱 man:pfctl[8]：
 [[pfctl]]
 .有用的 `pfctl` 選項
 [cols="1,1", frame="none", options="header"]
@@ -206,35 +206,35 @@ To control PF, use `pfctl`. <<pfctl>> summarizes some useful options to this com
 | 用途
 
 |`pfctl -e`
-|Enable PF.
+|啟用 PF。
 
 |`pfctl -d`
-|Disable PF.
+|停用 PF。
 
 |`pfctl -F all -f /etc/pf.conf`
-|Flush all NAT, filter, state, and table rules and reload [.filename]#/etc/pf.conf#.
+|清除所有 NAT、過濾、狀態和表格規則，並重新載入 [.filename]#/etc/pf.conf#。
 
 |`pfctl -s [ rules \| nat \| states ]`
-|Report on the filter rules, NAT rules, or state table.
+|顯示過濾規則、NAT 規則或狀態表。
 
 |`pfctl -vnf /etc/pf.conf`
-|Check [.filename]#/etc/pf.conf# for errors, but do not load ruleset.
+|檢查 [.filename]#/etc/pf.conf# 是否有錯誤，但不載入規則集。
 |===
 
 [TIP]
 ====
 
-package:security/sudo[] is useful for running commands like `pfctl` that require elevated privileges. It can be installed from the Ports Collection.
+package:security/sudo[] 對於執行像 `pfctl` 這類需要較高權限的指令非常有用，可從 Port 套件集安裝。
 ====
 
-To keep an eye on the traffic that passes through the PF firewall, consider installing the package:sysutils/pftop[] package or port. Once installed, pftop can be run to view a running snapshot of traffic in a format which is similar to man:top[1].
+若要監控通過 PF 防火牆的流量，可以考慮安裝 package:sysutils/pftop[] 套件或 Port。安裝完成後，可以執行 pftop 來即時檢視流量快照，其顯示格式類似 man:top[1]。
 
 [[pf-tutorial]]
 === PF 規則集
 
-This section demonstrates how to create a customized ruleset. It starts with the simplest of rulesets and builds upon its concepts using several examples to demonstrate real-world usage of PF's many features.
+本段落示範如何建立自訂規則集。從最簡單的規則集開始，再透過幾個範例逐步擴充概念，展示 PF 多種功能在實務上的運用。
 
-The simplest possible ruleset is for a single machine that does not run any services and which needs access to one network, which may be the Internet. To create this minimal ruleset, edit [.filename]#/etc/pf.conf# so it looks like this:
+最簡單的規則集適用於不執行任何服務、只需要存取一個網路（可能是網際網路）的單機。要建立這個最基本的規則集，請編輯 [.filename]#/etc/pf.conf# 使其內容如下：
 
 [.programlisting]
 ....
@@ -242,14 +242,14 @@ block in all
 pass out all keep state
 ....
 
-The first rule denies all incoming traffic by default. The second rule allows connections created by this system to pass out, while retaining state information on those connections. This state information allows return traffic for those connections to pass back and should only be used on machines that can be trusted. The ruleset can be loaded with:
+第一條規則預設阻擋所有傳入流量。第二條規則允許本系統建立的連線通過，同時保留這些連線的狀態資訊。此狀態資訊讓回應流量可以通過，這項功能應僅用於可信任的機器。規則集可以用以下指令載入：
 
 [source,shell]
 ....
 # pfctl -e ; pfctl -f /etc/pf.conf
 ....
 
-In addition to keeping state, PF provides _lists_ and _macros_ which can be defined for use when creating rules. Macros can include lists and need to be defined before use. As an example, insert these lines at the very top of the ruleset:
+除了保持狀態外，PF 還提供了 _清單_ 和 _巨集_，可在建立規則時定義使用。巨集可以包含清單，但必須在使用前先定義。舉例來說，可以在規則集最上方插入以下幾行：
 
 [.programlisting]
 ....
@@ -257,7 +257,7 @@ tcp_services = "{ ssh, smtp, domain, www, pop3, auth, pop3s }"
 udp_services = "{ domain }"
 ....
 
-PF understands port names as well as port numbers, as long as the names are listed in [.filename]#/etc/services#. This example creates two macros. The first is a list of seven TCP port names and the second is one UDP port name. Once defined, macros can be used in rules. In this example, all traffic is blocked except for the connections initiated by this system for the seven specified TCP services and the one specified UDP service:
+PF 能辨識連接埠名稱和連接埠號碼，只要名稱有列在 [.filename]#/etc/services# 中即可。這個範例建立了兩個巨集，第一個是七個 TCP 連接埠名稱的清單，第二個是一個 UDP 連接埠名稱。巨集定義後就可以在規則中使用。在這個範例中，除了本系統發起的七個指定 TCP 服務和一個指定 UDP 服務的連線外，所有流量都會被阻擋：
 
 [.programlisting]
 ....
@@ -268,50 +268,50 @@ pass out proto tcp to any port $tcp_services keep state
 pass proto udp to any port $udp_services keep state
 ....
 
-Even though UDP is considered to be a stateless protocol, PF is able to track some state information. For example, when a UDP request is passed which asks a name server about a domain name, PF will watch for the response to pass it back.
+雖然 UDP 被視為無狀態通訊協定，PF 仍然能追蹤部分狀態資訊。例如，當一個 UDP 請求被放行去查詢名稱伺服器的網域名稱時，PF 會監視回應並讓它通過。
 
-Whenever an edit is made to a ruleset, the new rules must be loaded so they can be used:
+每次編輯規則集後，都必須載入新規則才能生效：
 
 [source,shell]
 ....
 # pfctl -f /etc/pf.conf
 ....
 
-If there are no syntax errors, `pfctl` will not output any messages during the rule load. Rules can also be tested before attempting to load them:
+如果沒有語法錯誤，`pfctl` 在載入規則時不會輸出任何訊息。規則也可以在載入前先進行測試：
 
 [source,shell]
 ....
 # pfctl -nf /etc/pf.conf
 ....
 
-Including `-n` causes the rules to be interpreted only, but not loaded. This provides an opportunity to correct any errors. At all times, the last valid ruleset loaded will be enforced until either PF is disabled or a new ruleset is loaded.
+加上 `-n` 會讓規則只進行解譯而不載入，這提供了修正錯誤的機會。最後一次成功載入的有效規則集會持續生效，直到 PF 被停用或載入新的規則集為止。
 
 [TIP]
 ====
 
-Adding `-v` to a `pfctl` ruleset verify or load will display the fully parsed rules exactly the way they will be loaded. This is extremely useful when debugging rules.
+在 `pfctl` 驗證或載入規則集時加上 `-v`，會顯示完整解析後的規則，與實際載入的內容一模一樣。這在除錯規則時非常有用。
 ====
 
 [[pftut-gateway]]
 ==== 使用 NAT 的簡單通訊閘
 
-This section demonstrates how to configure a FreeBSD system running PF to act as a gateway for at least one other machine. The gateway needs at least two network interfaces, each connected to a separate network. In this example, [.filename]#xl1# is connected to the Internet and [.filename]#xl0# is connected to the internal network.
+本段落示範如何將執行 PF 的 FreeBSD 系統設定為至少一台其他機器的閘道。閘道需要至少兩個網路介面，分別連接不同的網路。在本範例中，[.filename]#xl1# 連接網際網路，[.filename]#xl0# 連接內部網路。
 
-First, enable the gateway to let the machine forward the network traffic it receives on one interface to another interface. This sysctl setting will forward IPv4 packets:
+首先，啟用閘道功能讓機器將一個網路介面收到的流量轉送到另一個網路介面。以下 sysctl 設定會啟用 IPv4 封包轉送：
 
 [source,shell]
 ....
 # sysctl net.inet.ip.forwarding=1
 ....
 
-To forward IPv6 traffic, use:
+要轉送 IPv6 流量，請使用：
 
 [source,shell]
 ....
 # sysctl net.inet6.ip6.forwarding=1
 ....
 
-To enable these settings at system boot, use man:sysrc[8] to add them to [.filename]#/etc/rc.conf#:
+要在系統開機時啟用這些設定，請使用 man:sysrc[8] 將它們加入 [.filename]#/etc/rc.conf#：
 
 [source,shell]
 ....
@@ -319,43 +319,43 @@ To enable these settings at system boot, use man:sysrc[8] to add them to [.filen
 # sysrc ipv6_gateway_enable=yes
 ....
 
-Verify with `ifconfig` that both of the interfaces are up and running.
+使用 `ifconfig` 確認兩個網路介面都已啟動且正常運作。
 
-Next, create the PF rules to allow the gateway to pass traffic. While the following rule allows stateful traffic to pass from the Internet to hosts on the network, the `to` keyword does not guarantee passage all the way from source to destination:
+接著，建立 PF 規則讓閘道可以傳遞流量。雖然以下規則允許有狀態的流量從網際網路傳遞到網路上的主機，但 `to` 關鍵字並不保證封包能從來源一路到達目的地：
 
 [.programlisting]
 ....
 pass in on xl1 from xl1:network to xl0:network port $ports keep state
 ....
 
-That rule only lets the traffic pass in to the gateway on the internal interface. To let the packets go further, a matching rule is needed:
+這條規則只讓流量通過閘道進入內部網路介面。要讓封包繼續傳遞，還需要一條相對應的規則：
 
 [.programlisting]
 ....
 pass out on xl0 from xl1:network to xl0:network port $ports keep state
 ....
 
-While these two rules will work, rules this specific are rarely needed. For a busy network admin, a readable ruleset is a safer ruleset. The remainder of this section demonstrates how to keep the rules as simple as possible for readability. For example, those two rules could be replaced with one rule:
+雖然這兩條規則可以運作，但這麼精確的規則很少有必要。對忙碌的網路管理員來說，可讀性高的規則集就是安全的規則集。本段落接下來會示範如何盡量保持規則簡潔易讀。例如，上面兩條規則可以用一條取代：
 
 [.programlisting]
 ....
 pass from xl1:network to any port $ports keep state
 ....
 
-The `interface:network` notation can be replaced with a macro to make the ruleset even more readable. For example, a `$localnet` macro could be defined as the network directly attached to the internal interface (`$xl1:network`). Alternatively, the definition of `$localnet` could be changed to an _IP address/netmask_ notation to denote a network, such as `192.168.100.1/24` for a subnet of private addresses.
+`interface:network` 表示法可以用巨集取代，讓規則集更容易閱讀。例如，可以定義 `$localnet` 巨集為直接連接到內部介面的網路 (`$xl1:network`)。也可以將 `$localnet` 的定義改為 _IP 位址/子網路遮罩_ 表示法來代表網路，例如用 `192.168.100.1/24` 表示私有位址子網路。
 
-If required, `$localnet` could even be defined as a list of networks. Whatever the specific needs, a sensible `$localnet` definition could be used in a typical pass rule as follows:
+如果需要，`$localnet` 甚至可以定義為網路清單。無論具體需求為何，合理的 `$localnet` 定義可以在典型的放行規則中如下使用：
 
 [.programlisting]
 ....
 pass from $localnet to any port $ports keep state
 ....
 
-The following sample ruleset allows all traffic initiated by machines on the internal network. It first defines two macros to represent the external and internal 3COM interfaces of the gateway.
+以下範例規則集允許由內部網路機器發起的所有流量。首先定義兩個巨集來代表閘道的外部和內部 3COM 網路介面。
 
 [NOTE]
 ====
-For dialup users, the external interface will use [.filename]#tun0#. For an ADSL connection, specifically those using PPP over Ethernet (PPPoE), the correct external interface is [.filename]#tun0#, not the physical Ethernet interface.
+撥接用戶的外部介面應使用 [.filename]#tun0#。使用 ADSL 連線，特別是使用 PPP over Ethernet (PPPoE) 的情況，正確的外部介面是 [.filename]#tun0#，而非實體乙太網路介面。
 ====
 
 [.programlisting]
@@ -369,9 +369,9 @@ block all
 pass from { lo0, $localnet } to any keep state
 ....
 
-This ruleset introduces the `nat` rule which is used to handle the network address translation from the non-routable addresses inside the internal network to the IP address assigned to the external interface. The parentheses surrounding the last part of the nat rule `($ext_if)` is included when the IP address of the external interface is dynamically assigned. It ensures that network traffic runs without serious interruptions even if the external IP address changes.
+這個規則集引入了 `nat` 規則，用來處理從內部網路不可路由位址到外部介面 IP 位址的網路位址轉譯。nat 規則最後一部分 `($ext_if)` 的括號是在外部介面 IP 位址為動態指派時使用的，確保即使外部 IP 位址變更，網路流量仍然不會受到嚴重中斷。
 
-Note that this ruleset probably allows more traffic to pass out of the network than is needed. One reasonable setup could create this macro:
+請注意，這個規則集可能允許比實際需要更多的流量通過網路。一個合理的設定可以建立如下巨集：
 
 [.programlisting]
 ....
@@ -379,7 +379,7 @@ client_out = "{ ftp-data, ftp, ssh, domain, pop3, auth, nntp, http, \
     https, cvspserver, 2628, 5999, 8000, 8080 }"
 ....
 
-to use in the main pass rule:
+在主要放行規則中使用：
 
 [.programlisting]
 ....
@@ -387,14 +387,14 @@ pass inet proto tcp from $localnet to any port $client_out \
     flags S/SA keep state
 ....
 
-A few other pass rules may be needed. This one enables SSH on the external interface:
+可能還需要其他幾條放行規則。這一條在外部介面啟用 SSH：
 
 [.programlisting]
 ....
 pass in inet proto tcp to $ext_if port ssh
 ....
 
-This macro definition and rule allows DNS and NTP for internal clients:
+以下巨集定義和規則允許內部用戶端使用 DNS 和 NTP：
 
 [.programlisting]
 ....
@@ -402,31 +402,31 @@ udp_services = "{ domain, ntp }"
 pass quick inet proto { tcp, udp } to any port $udp_services keep state
 ....
 
-Note the `quick` keyword in this rule. Since the ruleset consists of several rules, it is important to understand the relationships between the rules in a ruleset. Rules are evaluated from top to bottom, in the sequence they are written. For each packet or connection evaluated by PF, _the last matching rule_ in the ruleset is the one which is applied. However, when a packet matches a rule which contains the `quick` keyword, the rule processing stops and the packet is treated according to that rule. This is very useful when an exception to the general rules is needed.
+請注意這條規則中的 `quick` 關鍵字。由於規則集包含多條規則，了解規則集中各規則之間的關係很重要。規則按照撰寫順序從上到下逐一評估。對於 PF 評估的每個封包或連線，規則集中 _最後一條符合的規則_ 才是實際套用的規則。但是，當封包符合含有 `quick` 關鍵字的規則時，規則處理會立即停止，封包按照該規則處理。當需要為通用規則建立例外時，這個功能非常實用。
 
 [[pftut-ftp]]
 ==== 建立 FTP Proxy
 
-Configuring working FTP rules can be problematic due to the nature of the FTP protocol. FTP pre-dates firewalls by several decades and is insecure in its design. The most common points against using FTP include:
+由於 FTP 通訊協定的本質，設定可運作的 FTP 規則可能很棘手。FTP 比防火牆早了幾十年，在設計上就不安全。反對使用 FTP 最常見的理由包括：
 
-* Passwords are transferred in the clear.
-* The protocol demands the use of at least two TCP connections (control and data) on separate ports.
-* When a session is established, data is communicated using randomly selected ports.
+* 密碼以明文傳輸。
+* 此通訊協定要求在不同連接埠上使用至少兩個 TCP 連線（控制和資料）。
+* 建立工作階段後，資料傳輸使用隨機選擇的連接埠。
 
-All of these points present security challenges, even before considering any potential security weaknesses in client or server software. More secure alternatives for file transfer exist, such as man:sftp[1] or man:scp[1], which both feature authentication and data transfer over encrypted connections..
+這些特性都帶來安全上的挑戰，還不包括用戶端或伺服器軟體本身可能存在的安全漏洞。更安全的檔案傳輸替代方案包括 man:sftp[1] 或 man:scp[1]，兩者都透過加密連線提供認證和資料傳輸。
 
-For those situations when FTP is required, PF provides redirection of FTP traffic to a small proxy program called man:ftp-proxy[8], which is included in the base system of FreeBSD. The role of the proxy is to dynamically insert and delete rules in the ruleset, using a set of anchors, to correctly handle FTP traffic.
+在必須使用 FTP 的情況下，PF 提供將 FTP 流量重導到一個名為 man:ftp-proxy[8] 的小型代理程式的功能，此程式包含在 FreeBSD 基礎系統中。該代理程式透過一組錨點 (anchor) 動態新增和刪除規則集中的規則，以正確處理 FTP 流量。
 
-To enable the FTP proxy, add this line to [.filename]#/etc/rc.conf#:
+要啟用 FTP 代理程式，請將以下這行加入 [.filename]#/etc/rc.conf#：
 
 [.programlisting]
 ....
 ftpproxy_enable="YES"
 ....
 
-Then start the proxy by running `service ftp-proxy start`.
+然後執行 `service ftp-proxy start` 啟動代理程式。
 
-For a basic configuration, three elements need to be added to [.filename]#/etc/pf.conf#. First, the anchors which the proxy will use to insert the rules it generates for the FTP sessions:
+基本設定需要在 [.filename]#/etc/pf.conf# 中加入三個元素。首先是代理程式用來插入 FTP 工作階段規則的錨點：
 
 [.programlisting]
 ....
@@ -434,50 +434,50 @@ nat-anchor "ftp-proxy/*"
 rdr-anchor "ftp-proxy/*"
 ....
 
-Second, a pass rule is needed to allow FTP traffic in to the proxy.
+第二，需要一條放行規則允許 FTP 流量進入代理程式。
 
-Third, redirection and NAT rules need to be defined before the filtering rules. Insert this `rdr` rule immediately after the `nat` rule:
+第三，重導和 NAT 規則必須定義在過濾規則之前。在 `nat` 規則後面立即插入這條 `rdr` 規則：
 
 [.programlisting]
 ....
 rdr pass on $int_if proto tcp from any to any port ftp -> 127.0.0.1 port 8021
 ....
 
-Finally, allow the redirected traffic to pass:
+最後，允許重導的流量通過：
 
 [.programlisting]
 ....
 pass out proto tcp from $proxy to any port ftp
 ....
 
-where `$proxy` expands to the address the proxy daemon is bound to.
+其中 `$proxy` 展開為代理程式常駐程序綁定的位址。
 
-Save [.filename]#/etc/pf.conf#, load the new rules, and verify from a client that FTP connections are working:
+儲存 [.filename]#/etc/pf.conf#，載入新規則，並從用戶端驗證 FTP 連線是否正常運作：
 
 [source,shell]
 ....
 # pfctl -f /etc/pf.conf
 ....
 
-This example covers a basic setup where the clients in the local network need to contact FTP servers elsewhere. This basic configuration should work well with most combinations of FTP clients and servers. As shown in man:ftp-proxy[8], the proxy's behavior can be changed in various ways by adding options to the `ftpproxy_flags=` line. Some clients or servers may have specific quirks that must be compensated for in the configuration, or there may be a need to integrate the proxy in specific ways such as assigning FTP traffic to a specific queue.
+此範例涵蓋了區域網路內用戶端需要連線到外部 FTP 伺服器的基本設定。這個基本設定應該能與大多數 FTP 用戶端和伺服器的組合正常運作。如 man:ftp-proxy[8] 所述，可以在 `ftpproxy_flags=` 行加入選項來調整代理程式的行為。部分用戶端或伺服器可能有特殊行為需要在設定中加以因應，或者可能需要以特定方式整合代理程式，例如將 FTP 流量指派到特定佇列。
 
-For ways to run an FTP server protected by PF and man:ftp-proxy[8], configure a separate `ftp-proxy` in reverse mode, using `-R`, on a separate port with its own redirecting pass rule.
+若要執行受 PF 和 man:ftp-proxy[8] 保護的 FTP 伺服器，請使用 `-R` 在反向模式下設定獨立的 `ftp-proxy`，配置在不同的連接埠並搭配專屬的重導放行規則。
 
 [[pftut-icmp]]
 ==== 管理 ICMP
 
-Many of the tools used for debugging or troubleshooting a TCP/IP network rely on the Internet Control Message Protocol (ICMP), which was designed specifically with debugging in mind.
+許多用來除錯或排除 TCP/IP 網路問題的工具都仰賴網際網路控制訊息通訊協定 (ICMP)，這個通訊協定就是專為除錯而設計的。
 
-The ICMP protocol sends and receives _control messages_ between hosts and gateways, mainly to provide feedback to a sender about any unusual or difficult conditions enroute to the target host. Routers use ICMP to negotiate packet sizes and other transmission parameters in a process often referred to as _path MTU discovery_.
+ICMP 通訊協定在主機和閘道之間傳送和接收 _控制訊息_，主要是向發送端回報通往目標主機途中遇到的異常或困難狀況。路由器使用 ICMP 來協商封包大小和其他傳輸參數，這個過程通常稱為 _路徑 MTU 探索_。
 
-From a firewall perspective, some ICMP control messages are vulnerable to known attack vectors. Also, letting all diagnostic traffic pass unconditionally makes debugging easier, but it also makes it easier for others to extract information about the network. For these reasons, the following rule may not be optimal:
+從防火牆的角度來看，某些 ICMP 控制訊息容易受到已知攻擊手法的利用。此外，無條件放行所有診斷流量雖然讓除錯更容易，但也讓他人更容易擷取網路資訊。基於這些原因，以下規則可能不是最佳選擇：
 
 [.programlisting]
 ....
 pass inet proto icmp from any to any
 ....
 
-One solution is to let all ICMP traffic from the local network through while stopping all probes from outside the network:
+一個解決方案是讓來自區域網路的所有 ICMP 流量通過，同時阻擋來自外部網路的所有探測：
 
 [.programlisting]
 ....
@@ -485,23 +485,23 @@ pass inet proto icmp from $localnet to any keep state
 pass inet proto icmp from any to $ext_if keep state
 ....
 
-Additional options are available which demonstrate some of PF's flexibility. For example, rather than allowing all ICMP messages, one can specify the messages used by man:ping[8] and man:traceroute[8]. Start by defining a macro for that type of message:
+還有其他選項可以展示 PF 的彈性。例如，與其允許所有 ICMP 訊息，可以只指定 man:ping[8] 和 man:traceroute[8] 使用的訊息類型。首先為該訊息類型定義一個巨集：
 
 [.programlisting]
 ....
 icmp_types = "echoreq"
 ....
 
-and a rule which uses the macro:
+以及使用該巨集的規則：
 
 [.programlisting]
 ....
 pass inet proto icmp all icmp-type $icmp_types keep state
 ....
 
-If other types of ICMP packets are needed, expand `icmp_types` to a list of those packet types. Type `more /usr/src/sbin/pfctl/pfctl_parser.c` to see the list of ICMP message types supported by PF. Refer to http://www.iana.org/assignments/icmp-parameters/icmp-parameters.xhtml[http://www.iana.org/assignments/icmp-parameters/icmp-parameters.xhtml] for an explanation of each message type.
+如果需要其他類型的 ICMP 封包，可以將 `icmp_types` 擴充為這些封包類型的清單。輸入 `more /usr/src/sbin/pfctl/pfctl_parser.c` 可以查看 PF 支援的 ICMP 訊息類型清單。各訊息類型的說明請參閱 http://www.iana.org/assignments/icmp-parameters/icmp-parameters.xhtml[http://www.iana.org/assignments/icmp-parameters/icmp-parameters.xhtml]。
 
-Since Unix `traceroute` uses UDP by default, another rule is needed to allow Unix `traceroute`:
+由於 Unix `traceroute` 預設使用 UDP，因此需要另一條規則來允許 Unix `traceroute`：
 
 [.programlisting]
 ....
@@ -509,40 +509,40 @@ Since Unix `traceroute` uses UDP by default, another rule is needed to allow Uni
 pass out on $ext_if inet proto udp from any to any port 33433 >< 33626 keep state
 ....
 
-Since `TRACERT.EXE` on Microsoft Windows systems uses ICMP echo request messages, only the first rule is needed to allow network traces from those systems. Unix `traceroute` can be instructed to use other protocols as well, and will use ICMP echo request messages if `-I` is used. Check the man:traceroute[8] man page for details.
+由於 Microsoft Windows 系統上的 `TRACERT.EXE` 使用 ICMP echo request 訊息，只需要第一條規則就能允許來自這些系統的網路追蹤。Unix `traceroute` 也可以設定使用其他通訊協定，使用 `-I` 時會採用 ICMP echo request 訊息。詳情請查閱 man:traceroute[8] 手冊頁。
 
 [[pftut-pathmtudisc]]
 ===== Path MTU Discovery
 
-Internet protocols are designed to be device independent, and one consequence of device independence is that the optimal packet size for a given connection cannot always be predicted reliably. The main constraint on packet size is the _Maximum Transmission Unit_ (MTU) which sets the upper limit on the packet size for an interface. Type `ifconfig` to view the MTUs for a system's network interfaces.
+網際網路通訊協定的設計與設備無關，而設備無關性的一個結果就是無法總是可靠地預測特定連線的最佳封包大小。封包大小的主要限制因素是 _最大傳輸單元_ (MTU)，它設定了網路介面封包大小的上限。輸入 `ifconfig` 可以查看系統網路介面的 MTU。
 
-TCP/IP uses a process known as path MTU discovery to determine the right packet size for a connection. This process sends packets of varying sizes with the "Do not fragment" flag set, expecting an ICMP return packet of "type 3, code 4" when the upper limit has been reached. Type 3 means "destination unreachable", and code 4 is short for "fragmentation needed, but the do-not-fragment flag is set". To allow path MTU discovery in order to support connections to other MTUs, add the `destination unreachable` type to the `icmp_types` macro:
+TCP/IP 使用一種稱為路徑 MTU 探索的機制來決定連線的適當封包大小。這個過程會發送不同大小且設定了「不分割」旗標的封包，預期在達到上限時會收到「type 3, code 4」的 ICMP 回應封包。Type 3 表示「目的地無法到達」，code 4 是「需要分割，但設定了不分割旗標」的簡稱。要允許路徑 MTU 探索以支援不同 MTU 的連線，請將 `destination unreachable` 類型加入 `icmp_types` 巨集：
 
 [.programlisting]
 ....
 icmp_types = "{ echoreq, unreach }"
 ....
 
-Since the pass rule already uses that macro, it does not need to be modified to support the new ICMP type:
+由於放行規則已經使用了該巨集，不需要修改就能支援新的 ICMP 類型：
 
 [.programlisting]
 ....
 pass inet proto icmp all icmp-type $icmp_types keep state
 ....
 
-PF allows filtering on all variations of ICMP types and codes. The list of possible types and codes are documented in man:icmp[4] and man:icmp6[4].
+PF 允許對所有 ICMP 類型和代碼的變體進行過濾。可能的類型和代碼清單記錄在 man:icmp[4] 和 man:icmp6[4] 中。
 
 [[pftut-tables]]
 ==== 使用 Tables
 
-Some types of data are relevant to filtering and redirection at a given time, but their definition is too long to be included in the ruleset file. PF supports the use of tables, which are defined lists that can be manipulated without needing to reload the entire ruleset, and which can provide fast lookups. Table names are always enclosed within `< >`, like this:
+某些類型的資料在特定時間與過濾和重導有關，但其定義太長無法放在規則集檔案中。PF 支援使用表格，表格是已定義的清單，可以在不重新載入整個規則集的情況下操作，且能提供快速查詢。表格名稱總是用 `< >` 包起來，像這樣：
 
 [.programlisting]
 ....
 table <clients> { 192.168.2.0/24, !192.168.2.5 }
 ....
 
-In this example, the `192.168.2.0/24` network is part of the table, except for the address `192.168.2.5`, which is excluded using the `!` operator. It is also possible to load tables from files where each item is on a separate line, as seen in this example [.filename]#/etc/clients#:
+在這個範例中，`192.168.2.0/24` 網路是表格的一部分，但位址 `192.168.2.5` 透過 `!` 運算子排除在外。也可以從檔案載入表格，每個項目各佔一行，如以下 [.filename]#/etc/clients# 範例：
 
 [.programlisting]
 ....
@@ -550,28 +550,28 @@ In this example, the `192.168.2.0/24` network is part of the table, except for t
 !192.168.2.5
 ....
 
-To refer to the file, define the table like this:
+要參照該檔案，請如下定義表格：
 
 [.programlisting]
 ....
 table <clients> persist file "/etc/clients"
 ....
 
-Once the table is defined, it can be referenced by a rule:
+表格定義完成後，就可以在規則中參照使用：
 
 [.programlisting]
 ....
 pass inet proto tcp from <clients> to any port $client_out flags S/SA keep state
 ....
 
-A table's contents can be manipulated live, using `pfctl`. This example adds another network to the table:
+表格的內容可以用 `pfctl` 即時操作。以下範例將另一個網路加入表格：
 
 [source,shell]
 ....
 # pfctl -t clients -T add 192.168.1.0/16
 ....
 
-Note that any changes made this way will take affect now, making them ideal for testing, but will not survive a power failure or reboot. To make the changes permanent, modify the definition of the table in the ruleset or edit the file that the table refers to. One can maintain the on-disk copy of the table using a man:cron[8] job which dumps the table's contents to disk at regular intervals, using a command such as `pfctl -t clients -T show >/etc/clients`. Alternatively, [.filename]#/etc/clients# can be updated with the in-memory table contents:
+請注意，以這種方式進行的變更會立即生效，非常適合測試，但在斷電或重新開機後不會保留。要使變更永久生效，請修改規則集中的表格定義，或編輯表格參照的檔案。可以使用 man:cron[8] 排程工作定期將表格內容傾印到磁碟，使用類似 `pfctl -t clients -T show >/etc/clients` 的指令來維護磁碟上的表格副本。或者，也可以用記憶體中的表格內容更新 [.filename]#/etc/clients#：
 
 [source,shell]
 ....
@@ -581,7 +581,7 @@ Note that any changes made this way will take affect now, making them ideal for 
 [[pftut-overload]]
 ==== 使用 Overload Tables 保護 SSH
 
-Those who run SSH on an external interface have probably seen something like this in the authentication logs:
+在外部介面上執行 SSH 的人，可能在認證記錄中看過類似這樣的內容：
 
 [.programlisting]
 ....
@@ -593,18 +593,18 @@ Sep 26 03:12:44 skapet sshd[24703]: input_userauth_request: invalid user admin
 Sep 26 03:12:44 skapet sshd[24703]: Failed password for invalid user admin from 200.72.41.31 port 41484 ssh2
 ....
 
-This is indicative of a brute force attack where somebody or some program is trying to discover the user name and password which will let them into the system.
+這表示有人或某個程式正在進行暴力破解攻擊，試圖找出能登入系統的使用者名稱和密碼。
 
-If external SSH access is needed for legitimate users, changing the default port used by SSH can offer some protection. However, PF provides a more elegant solution. Pass rules can contain limits on what connecting hosts can do and violators can be banished to a table of addresses which are denied some or all access. It is even possible to drop all existing connections from machines which overreach the limits.
+如果合法使用者需要從外部存取 SSH，更改 SSH 使用的預設連接埠可以提供一些保護。不過，PF 提供了更優雅的解決方案。放行規則可以限制連線主機的行為，違規者會被放入一個位址表格中，拒絕其部分或全部存取。甚至可以丟棄來自超過限制的機器的所有現有連線。
 
-To configure this, create this table in the tables section of the ruleset:
+要進行此設定，請在規則集的表格區段中建立以下表格：
 
 [.programlisting]
 ....
 table <bruteforce> persist
 ....
 
-Then, somewhere early in the ruleset, add rules to block brute access while allowing legitimate access:
+接著，在規則集較前面的位置，加入阻擋暴力存取同時允許合法存取的規則：
 
 [.programlisting]
 ....
@@ -615,22 +615,22 @@ pass inet proto tcp from any to $localnet port $tcp_services \
     overload <bruteforce> flush global)
 ....
 
-The part in parentheses defines the limits and the numbers should be changed to meet local requirements. It can be read as follows:
+括號中的部分定義了限制值，數字應依據本機需求調整。其內容可以解讀如下：
 
-`max-src-conn` is the number of simultaneous connections allowed from one host.
+`max-src-conn` 是允許單一主機的同時連線數。
 
-`max-src-conn-rate` is the rate of new connections allowed from any single host (_15_) per number of seconds (_5_).
+`max-src-conn-rate` 是允許任何單一主機在指定秒數 (_5_) 內的新連線速率 (_15_)。
 
-`overload <bruteforce>` means that any host which exceeds these limits gets its address added to the `bruteforce` table. The ruleset blocks all traffic from addresses in the `bruteforce` table.
+`overload <bruteforce>` 表示任何超過這些限制的主機，其位址會被加入 `bruteforce` 表格。規則集會阻擋來自 `bruteforce` 表格中所有位址的流量。
 
-Finally, `flush global` says that when a host reaches the limit, that all (`global`) of that host's connections will be terminated (`flush`).
+最後，`flush global` 表示當主機達到限制時，該主機的所有 (`global`) 連線都會被終止 (`flush`)。
 
 [NOTE]
 ====
-These rules will _not_ block slow bruteforcers, as described in http://home.nuug.no/\~peter/hailmary2013/[http://home.nuug.no/~peter/hailmary2013/].
+如 http://home.nuug.no/\~peter/hailmary2013/[http://home.nuug.no/~peter/hailmary2013/] 所述，這些規則 _不會_ 阻擋緩慢的暴力破解攻擊。
 ====
 
-This example ruleset is intended mainly as an illustration. For example, if a generous number of connections in general are wanted, but the desire is to be more restrictive when it comes to ssh, supplement the rule above with something like the one below, early on in the rule set:
+這個範例規則集主要是做為說明用途。例如，如果一般連線希望較為寬鬆，但針對 ssh 想要更嚴格的限制，可以在規則集較前面的位置，用以下類似的規則補充上面的規則：
 
 [.programlisting]
 ....
@@ -641,25 +641,25 @@ pass quick proto { tcp, udp } from any to any port ssh \
 ....
 
 [NOTE]
-.It May Not be Necessary to Block All Overloaders
+.不一定需要阻擋所有超載者
 ====
-It is worth noting that the overload mechanism is a general technique which does not apply exclusively to SSH, and it is not always optimal to entirely block all traffic from offenders.
+值得注意的是，超載機制是一種通用技術，並不專屬於 SSH，而且完全阻擋違規者的所有流量也不一定是最佳做法。
 
-For example, an overload rule could be used to protect a mail service or a web service, and the overload table could be used in a rule to assign offenders to a queue with a minimal bandwidth allocation or to redirect to a specific web page.
+例如，超載規則可以用來保護郵件服務或網頁服務，超載表格可以在規則中使用，將違規者指派到頻寬配額最小的佇列，或重導到特定網頁。
 ====
 
-Over time, tables will be filled by overload rules and their size will grow incrementally, taking up more memory. Sometimes an IP address that is blocked is a dynamically assigned one, which has since been assigned to a host who has a legitimate reason to communicate with hosts in the local network.
+隨著時間推移，表格會因超載規則不斷填入而逐漸增長，佔用更多記憶體。有時被阻擋的 IP 位址是動態分配的，之後可能已指派給有正當理由與區域網路主機通訊的主機。
 
-For situations like these, pfctl provides the ability to expire table entries. For example, this command will remove `<bruteforce>` table entries which have not been referenced for `86400` seconds:
+針對這類情況，pfctl 提供了讓表格項目到期的功能。例如，以下指令會移除 `86400` 秒內未被參照的 `<bruteforce>` 表格項目：
 
 [source,shell]
 ....
 # pfctl -t bruteforce -T expire 86400
 ....
 
-Similar functionality is provided by package:security/expiretable[], which removes table entries which have not been accessed for a specified period of time.
+package:security/expiretable[] 也提供類似功能，可以移除在指定時間內未被存取的表格項目。
 
-Once installed, expiretable can be run to remove `<bruteforce>` table entries older than a specified age. This example removes all entries older than 24 hours:
+安裝完成後，可以執行 expiretable 來移除超過指定時間的 `<bruteforce>` 表格項目。以下範例會移除所有超過 24 小時的項目：
 
 [.programlisting]
 ....
@@ -669,33 +669,33 @@ Once installed, expiretable can be run to remove `<bruteforce>` table entries ol
 [[pftut-spamd]]
 ==== SPAM 防護
 
-Not to be confused with the spamd daemon which comes bundled with spamassassin, package:mail/spamd[] can be configured with PF to provide an outer defense against SPAM. This spamd hooks into the PF configuration using a set of redirections.
+請勿與 spamassassin 附帶的 spamd 常駐程序混淆，package:mail/spamd[] 可以搭配 PF 設定來提供對抗垃圾郵件的外層防護。這個 spamd 透過一組重導規則與 PF 設定整合。
 
-Spammers tend to send a large number of messages, and SPAM is mainly sent from a few spammer friendly networks and a large number of hijacked machines, both of which are reported to _blacklists_ fairly quickly.
+垃圾郵件發送者傾向大量發送訊息，垃圾郵件主要來自少數對垃圾郵件發送者友善的網路和大量被入侵的機器，這兩者都會很快被通報到 _黑名單_。
 
-When an SMTP connection from an address in a blacklist is received, spamd presents its banner and immediately switches to a mode where it answers SMTP traffic one byte at a time. This technique, which is intended to waste as much time as possible on the spammer's end, is called _tarpitting_. The specific implementation which uses one byte SMTP replies is often referred to as _stuttering_.
+當收到來自黑名單位址的 SMTP 連線時，spamd 會顯示其橫幅標語，然後立即切換到逐位元組回應 SMTP 流量的模式。這種技術旨在盡可能浪費垃圾郵件發送端的時間，稱為 _tarpitting_（焦油坑）。使用逐位元組 SMTP 回應的特定實作方式通常稱為 _stuttering_（結巴）。
 
-This example demonstrates the basic procedure for setting up spamd with automatically updated blacklists. Refer to the man pages which are installed with package:mail/spamd[] for more information.
+此範例示範使用自動更新黑名單設定 spamd 的基本程序。更多資訊請參閱隨 package:mail/spamd[] 安裝的手冊頁。
 
 [.procedure]
 ====
-*Procedure: Configuring spamd*
+*程序：設定 spamd*
 
-. Install the package:mail/spamd[] package or port. To use spamd's greylisting features, man:fdescfs[5] must be mounted at [.filename]#/dev/fd#. Add the following line to [.filename]#/etc/fstab#:
+. 安裝 package:mail/spamd[] 套件或 Port。要使用 spamd 的灰名單功能，必須在 [.filename]#/dev/fd# 掛載 man:fdescfs[5]。將以下這行加入 [.filename]#/etc/fstab#：
 +
 [.programlisting]
 ....
  fdescfs /dev/fd fdescfs rw 0 0
 ....
 + 
-Then, mount the filesystem:
+然後掛載檔案系統：
 +
 [.programlisting]
 ....
 # mount fdescfs
 ....
 +
-. Next, edit the PF ruleset to include:
+. 接著，編輯 PF 規則集加入以下內容：
 +
 [.programlisting]
 ....
@@ -707,12 +707,12 @@ rdr pass on $ext_if inet proto tcp from !<spamd-white> to \
     { $ext_if, $localnet } port smtp -> 127.0.0.1 port 8025
 ....
 + 
-The two tables `<spamd>` and `<spamd-white>` are essential. SMTP traffic from an address listed in `<spamd>` but not in `<spamd-white>` is redirected to the spamd daemon listening at port 8025.
-. The next step is to configure spamd in [.filename]#/usr/local/etc/spamd.conf# and to add some [.filename]#rc.conf# parameters.
+`<spamd>` 和 `<spamd-white>` 這兩個表格是必要的。來自列在 `<spamd>` 但不在 `<spamd-white>` 中位址的 SMTP 流量，會被重導到監聽連接埠 8025 的 spamd 常駐程序。
+. 下一步是在 [.filename]#/usr/local/etc/spamd.conf# 中設定 spamd 並加入一些 [.filename]#rc.conf# 參數。
 + 
-The installation of package:mail/spamd[] includes a sample configuration file ([.filename]#/usr/local/etc/spamd.conf.sample#) and a man page for [.filename]#spamd.conf#. Refer to these for additional configuration options beyond those shown in this example.
+package:mail/spamd[] 的安裝包含了範例設定檔 ([.filename]#/usr/local/etc/spamd.conf.sample#) 和 [.filename]#spamd.conf# 的手冊頁。本範例以外的其他設定選項請參閱這些文件。
 + 
-One of the first lines in the configuration file that does not begin with a `#` comment sign contains the block which defines the `all` list, which specifies the lists to use:
+設定檔中最先出現的非 `#` 註解行之一，包含定義 `all` 清單的區塊，用來指定要使用的清單：
 +
 [.programlisting]
 ....
@@ -720,9 +720,9 @@ all:\
     :traplist:whitelist:
 ....
 + 
-This entry adds the desired blacklists, separated by colons (`:`). To use a whitelist to subtract addresses from a blacklist, add the name of the whitelist _immediately_ after the name of that blacklist. For example: `:blacklist:whitelist:`.
+這個項目以冒號 (`:`) 分隔，加入所需的黑名單。要使用白名單從黑名單中排除位址，請在該黑名單名稱 _緊接_ 之後加入白名單名稱。例如：`:blacklist:whitelist:`。
 + 
-This is followed by the specified blacklist's definition:
+接著是指定黑名單的定義：
 +
 [.programlisting]
 ....
@@ -733,9 +733,9 @@ traplist:\
     :file=www.openbsd.org/spamd/traplist.gz
 ....
 + 
-where the first line is the name of the blacklist and the second line specifies the list type. The `msg` field contains the message to display to blacklisted senders during the SMTP dialogue. The `method` field specifies how spamd-setup fetches the list data; supported methods are `http`, `ftp`, from a `file` in a mounted file system, and via `exec` of an external program. Finally, the `file` field specifies the name of the file spamd expects to receive.
+其中第一行是黑名單的名稱，第二行指定清單類型。`msg` 欄位包含在 SMTP 對話期間向黑名單發送者顯示的訊息。`method` 欄位指定 spamd-setup 擷取清單資料的方式；支援的方法有 `http`、`ftp`、從掛載檔案系統中的 `file`，以及透過 `exec` 執行外部程式。最後，`file` 欄位指定 spamd 預期接收的檔案名稱。
 + 
-The definition of the specified whitelist is similar, but omits the `msg` field since a message is not needed:
+指定白名單的定義類似，但省略了 `msg` 欄位，因為不需要訊息：
 +
 [.programlisting]
 ....
@@ -746,43 +746,43 @@ whitelist:\
 ....
 +
 [TIP]
-.Choose Data Sources with Care
+.謹慎選擇資料來源
 ======
-Using all the blacklists in the sample [.filename]#spamd.conf# will blacklist large blocks of the Internet. Administrators need to edit the file to create an optimal configuration which uses applicable data sources and, when necessary, uses custom lists.
+使用範例 [.filename]#spamd.conf# 中的所有黑名單會將網際網路的大片區塊列入黑名單。管理員需要編輯此檔案以建立使用適當資料來源的最佳設定，並在必要時使用自訂清單。
 ======
 + 
-Next, add this entry to [.filename]#/etc/rc.conf#. Additional flags are described in the man page specified by the comment:
+接著，將以下項目加入 [.filename]#/etc/rc.conf#。註解中指定的手冊頁有其他旗標的說明：
 +
 [.programlisting]
 ....
 spamd_flags="-v" # use "" and see spamd-setup(8) for flags
 ....
 + 
-When finished, reload the ruleset, start spamd by typing `service obspamd start`, and complete the configuration using `spamd-setup`. Finally, create a man:cron[8] job which calls `spamd-setup` to update the tables at reasonable intervals.
+完成後，重新載入規則集，輸入 `service obspamd start` 啟動 spamd，並使用 `spamd-setup` 完成設定。最後，建立一個 man:cron[8] 排程工作，以合理的間隔呼叫 `spamd-setup` 來更新表格。
 ====
 
-On a typical gateway in front of a mail server, hosts will soon start getting trapped within a few seconds to several minutes.
+在郵件伺服器前的典型閘道上，主機很快就會在幾秒到幾分鐘內開始被捕捉。
 
-PF also supports _greylisting_, which temporarily rejects messages from unknown hosts with _45n_ codes. Messages from greylisted hosts which try again within a reasonable time are let through. Traffic from senders which are set up to behave within the limits set by RFC 1123 and RFC 2821 are immediately let through.
+PF 也支援 _灰名單_，以 _45n_ 回應碼暫時拒絕來自未知主機的訊息。來自被列入灰名單的主機若在合理時間內重試，訊息就會被放行。來自設定符合 RFC 1123 和 RFC 2821 限制的發送者的流量會立即放行。
 
-More information about greylisting as a technique can be found at the http://www.greylisting.org/[greylisting.org] web site. The most amazing thing about greylisting, apart from its simplicity, is that it still works. Spammers and malware writers have been very slow to adapt to bypass this technique.
+關於灰名單技術的更多資訊可在 http://www.greylisting.org/[greylisting.org] 網站找到。灰名單除了簡單之外，最令人驚訝的是它至今仍然有效。垃圾郵件發送者和惡意軟體作者在適應並繞過此技術方面進展非常緩慢。
 
-The basic procedure for configuring greylisting is as follows:
+設定灰名單的基本程序如下：
 
 [.procedure]
 ====
-*Procedure: Configuring Greylisting*
+*程序：設定灰名單*
 
-. Make sure that man:fdescfs[5] is mounted as described in Step 1 of the previous Procedure.
-. To run spamd in greylisting mode, add this line to [.filename]#/etc/rc.conf#:
+. 確認 man:fdescfs[5] 已依照前述程序步驟 1 的說明掛載。
+. 要在灰名單模式下執行 spamd，請將以下這行加入 [.filename]#/etc/rc.conf#：
 +
 [.programlisting]
 ....
 spamd_grey="YES"  # use spamd greylisting if YES
 ....
 + 
-Refer to the spamd man page for descriptions of additional related parameters.
-. To complete the greylisting setup:
+其他相關參數的說明請參閱 spamd 手冊頁。
+. 要完成灰名單設定：
 +
 [.programlisting]
 ....
@@ -791,41 +791,41 @@ Refer to the spamd man page for descriptions of additional related parameters.
 ....
 ====
 
-Behind the scenes, the spamdb database tool and the spamlogd whitelist updater perform essential functions for the greylisting feature. spamdb is the administrator's main interface to managing the black, grey, and white lists via the contents of the [.filename]#/var/db/spamdb# database.
+在幕後，spamdb 資料庫工具和 spamlogd 白名單更新程式為灰名單功能執行必要的工作。spamdb 是管理員透過 [.filename]#/var/db/spamdb# 資料庫內容管理黑名單、灰名單和白名單的主要介面。
 
 [[pftut-hygiene]]
 ==== 網路保健
 
-This section describes how `block-policy`, `scrub`, and `antispoof` can be used to make the ruleset behave sanely.
+本段落說明如何使用 `block-policy`、`scrub` 和 `antispoof` 讓規則集運作得更合理。
 
-The `block-policy` is an option which can be set in the `options` part of the ruleset, which precedes the redirection and filtering rules. This option determines which feedback, if any, PF sends to hosts that are blocked by a rule. The option has two possible values: `drop` drops blocked packets with no feedback, and `return` returns a status code such as `Connection refused`.
+`block-policy` 是一個可以在規則集 `options` 區段設定的選項，位於重導和過濾規則之前。此選項決定 PF 對被規則阻擋的主機傳送什麼回饋訊息（如果有的話）。此選項有兩個可能的值：`drop` 會直接丟棄被阻擋的封包且不回饋，`return` 則回傳一個狀態碼，例如 `Connection refused`。
 
-If not set, the default policy is `drop`. To change the `block-policy`, specify the desired value:
+如果未設定，預設策略為 `drop`。要變更 `block-policy`，請指定所需的值：
 
 [.programlisting]
 ....
 set block-policy return
 ....
 
-In PF, `scrub` is a keyword which enables network packet normalization. This process reassembles fragmented packets and drops TCP packets that have invalid flag combinations. Enabling `scrub` provides a measure of protection against certain kinds of attacks based on incorrect handling of packet fragments. A number of options are available, but the simplest form is suitable for most configurations:
+在 PF 中，`scrub` 是啟用網路封包正規化的關鍵字。這個程序會重組被分割的封包，並丟棄具有無效旗標組合的 TCP 封包。啟用 `scrub` 可以對某些基於不正確處理封包分割的攻擊提供一定程度的保護。有多種選項可用，但最簡單的形式適用於大多數設定：
 
 [.programlisting]
 ....
 scrub in all
 ....
 
-Some services, such as NFS, require specific fragment handling options. Refer to https://home.nuug.no/\~peter/pf/en/scrub.html[https://home.nuug.no/~peter/pf/en/scrub.html] for more information.
+某些服務，例如 NFS，需要特定的分割處理選項。更多資訊請參閱 https://home.nuug.no/\~peter/pf/en/scrub.html[https://home.nuug.no/~peter/pf/en/scrub.html]。
 
-This example reassembles fragments, clears the "do not fragment" bit, and sets the maximum segment size to 1440 bytes:
+此範例會重組分割的封包、清除「不分割」位元，並將最大區段大小設定為 1440 位元組：
 
 [.programlisting]
 ....
 scrub in all fragment reassemble no-df max-mss 1440
 ....
 
-The `antispoof` mechanism protects against activity from spoofed or forged IP addresses, mainly by blocking packets appearing on interfaces and in directions which are logically not possible.
+`antispoof` 機制透過阻擋在邏輯上不可能出現在特定網路介面和方向的封包，來防護偽造或假冒 IP 位址的活動。
 
-These rules weed out spoofed traffic coming in from the rest of the world as well as any spoofed packets which originate in the local network:
+以下規則可以過濾來自外部世界的偽造流量，以及源自區域網路的偽造封包：
 
 [.programlisting]
 ....
@@ -836,9 +836,9 @@ antispoof for $int_if
 [[pftut-unrouteables]]
 ==== 處理不可路由 (Non-Routable) 的位址
 
-Even with a properly configured gateway to handle network address translation, one may have to compensate for other people's misconfigurations. A common misconfiguration is to let traffic with non-routable addresses out to the Internet. Since traffic from non-routeable addresses can play a part in several DoS attack techniques, consider explicitly blocking traffic from non-routeable addresses from entering the network through the external interface.
+即使閘道已正確設定處理網路位址轉譯，仍可能需要因應他人的錯誤設定。常見的錯誤設定是讓不可路由位址的流量流出到網際網路。由於來自不可路由位址的流量可能在多種 DoS 攻擊技術中扮演角色，請考慮明確阻擋不可路由位址的流量從外部介面進入網路。
 
-In this example, a macro containing non-routable addresses is defined, then used in blocking rules. Traffic to and from these addresses is quietly dropped on the gateway's external interface.
+在此範例中，定義了一個包含不可路由位址的巨集，然後在阻擋規則中使用。往返這些位址的流量會在閘道的外部介面上被無聲丟棄。
 
 [.programlisting]
 ....
@@ -852,11 +852,11 @@ block drop out quick on $ext_if from any to $martians
 
 === 開啟 ALTQ
 
-On FreeBSD, ALTQ can be used with PF to provide Quality of Service (QOS). Once ALTQ is enabled, queues can be defined in the ruleset which determine the processing priority of outbound packets.
+在 FreeBSD 上，ALTQ 可以搭配 PF 使用來提供服務品質 (QOS)。啟用 ALTQ 後，可以在規則集中定義佇列來決定送出封包的處理優先順序。
 
-Before enabling ALTQ, refer to man:altq[4] to determine if the drivers for the network cards installed on the system support it.
+啟用 ALTQ 之前，請參閱 man:altq[4] 以確認系統上安裝的網路卡驅動程式是否支援。
 
-ALTQ is not available as a loadable kernel module. If the system's interfaces support ALTQ, create a custom kernel using the instructions in crossref:kernelconfig[kernelconfig,設定 FreeBSD 核心]. The following kernel options are available. The first is needed to enable ALTQ. At least one of the other options is necessary to specify the queueing scheduler algorithm:
+ALTQ 無法做為可載入核心模組使用。如果系統的網路介面支援 ALTQ，請依照 crossref:kernelconfig[kernelconfig,設定 FreeBSD 核心] 中的說明建立自訂核心。以下是可用的核心選項。第一個選項是啟用 ALTQ 所必需的，其他選項中至少需要一個來指定佇列排程演算法：
 
 [.programlisting]
 ....
@@ -868,24 +868,24 @@ options         ALTQ_HFSC       # Hierarchical Packet Scheduler (HFSC)
 options         ALTQ_PRIQ       # Priority Queuing (PRIQ)
 ....
 
-The following scheduler algorithms are available:
+以下是可用的排程演算法：
 
 CBQ::
-Class Based Queuing (CBQ) is used to divide a connection's bandwidth into different classes or queues to prioritize traffic based on filter rules.
+以類別為基礎的佇列 (CBQ) 用於將連線的頻寬劃分為不同的類別或佇列，根據過濾規則來排定流量的優先順序。
 
 RED::
-Random Early Detection (RED) is used to avoid network congestion by measuring the length of the queue and comparing it to the minimum and maximum thresholds for the queue. When the queue is over the maximum, all new packets are randomly dropped.
+隨機早期偵測 (RED) 透過測量佇列長度並與佇列的最小和最大閾值比較來避免網路壅塞。當佇列超過最大值時，所有新封包會被隨機丟棄。
 
 RIO::
-In Random Early Detection In and Out (RIO) mode, RED maintains multiple average queue lengths and multiple threshold values, one for each QOS level.
+在隨機早期偵測進出 (RIO) 模式下，RED 維護多個平均佇列長度和多個閾值，每個 QOS 等級各一組。
 
 HFSC::
-Hierarchical Fair Service Curve Packet Scheduler (HFSC) is described in http://www-2.cs.cmu.edu/\~hzhang/HFSC/main.html[http://www-2.cs.cmu.edu/~hzhang/HFSC/main.html].
+階層式公平服務曲線封包排程器 (HFSC) 的說明請參閱 http://www-2.cs.cmu.edu/\~hzhang/HFSC/main.html[http://www-2.cs.cmu.edu/~hzhang/HFSC/main.html]。
 
 PRIQ::
-Priority Queuing (PRIQ) always passes traffic that is in a higher queue first.
+優先佇列 (PRIQ) 總是先傳遞較高優先順序佇列中的流量。
 
-More information about the scheduling algorithms and example rulesets are available at the https://web.archive.org/web/20151109213426/http://www.openbsd.org/faq/pf/queueing.html[OpenBSD's web archive].
+關於排程演算法和規則集範例的更多資訊，請參閱 https://web.archive.org/web/20151109213426/http://www.openbsd.org/faq/pf/queueing.html[OpenBSD 的網頁封存]。
 
 [[firewalls-ipfw]]
 == IPFW
@@ -899,46 +899,46 @@ FreeBSD 提供一個範本規則集於 [.filename]#/etc/rc.firewall#，其定義
 [[firewalls-ipfw-enable]]
 === 開啟 IPFW
 
-IPFW is included in the basic FreeBSD install as a kernel loadable module, meaning that a custom kernel is not needed in order to enable IPFW.
+IPFW 已內建於 FreeBSD 基本安裝中，以可載入核心模組的形式提供，因此不需要自訂核心即可啟用 IPFW。
 
-For those users who wish to statically compile IPFW support into a custom kernel, see <<firewalls-ipfw-kernelconfig>>.
+若您希望將 IPFW 支援靜態編譯進自訂核心，請參閱 <<firewalls-ipfw-kernelconfig>>。
 
-To configure the system to enable IPFW at boot time, add `firewall_enable="YES"` to [.filename]#/etc/rc.conf#:
+若要設定系統在開機時啟用 IPFW，請在 [.filename]#/etc/rc.conf# 中加入 `firewall_enable="YES"`：
 
 [source,shell]
 ....
 # sysrc firewall_enable="YES"
 ....
 
-To use one of the default firewall types provided by FreeBSD, add another line which specifies the type:
+若要使用 FreeBSD 提供的預設防火牆類型，請再加入一行指定類型：
 
 [source,shell]
 ....
 # sysrc firewall_type="open"
 ....
 
-The available types are:
+可用的類型如下：
 
-* `open`: passes all traffic.
-* `client`: protects only this machine.
-* `simple`: protects the whole network.
-* `closed`: entirely disables IP traffic except for the loopback interface.
-* `workstation`: protects only this machine using stateful rules.
-* `UNKNOWN`: disables the loading of firewall rules.
-* [.filename]#filename#: full path of the file containing the firewall ruleset.
+* `open`：允許所有流量通過。
+* `client`：僅保護本機。
+* `simple`：保護整個網路。
+* `closed`：完全停用 IP 流量，僅保留 loopback 介面。
+* `workstation`：使用具狀態規則僅保護本機。
+* `UNKNOWN`：停用防火牆規則的載入。
+* [.filename]#filename#：包含防火牆規則集的檔案完整路徑。
 
-If `firewall_type` is set to either `client` or `simple`, modify the default rules found in [.filename]#/etc/rc.firewall# to fit the configuration of the system.
+如果 `firewall_type` 設為 `client` 或 `simple`，請修改 [.filename]#/etc/rc.firewall# 中的預設規則以符合系統設定。
 
-Note that the `filename` type is used to load a custom ruleset.
+請注意 `filename` 類型是用來載入自訂規則集的。
 
-An alternate way to load a custom ruleset is to set the `firewall_script` variable to the absolute path of an _executable script_ that includes IPFW commands. The examples used in this section assume that the `firewall_script` is set to [.filename]#/etc/ipfw.rules#:
+另一種載入自訂規則集的方式是將 `firewall_script` 變數設為包含 IPFW 指令的 _可執行 Script_ 的絕對路徑。本節的範例假設 `firewall_script` 設定為 [.filename]#/etc/ipfw.rules#：
 
 [source,shell]
 ....
 # sysrc firewall_script="/etc/ipfw.rules"
 ....
 
-To enable logging through man:syslogd[8], include this line:
+若要透過 man:syslogd[8] 啟用記錄功能，請加入這一行：
 
 [source,shell]
 ....
@@ -948,24 +948,24 @@ To enable logging through man:syslogd[8], include this line:
 [WARNING]
 ====
 
-Only firewall rules with the `log` option will be logged. The default rules do not include this option and it must be manually added. Therefore it is advisable that the default ruleset is edited for logging. In addition, log rotation may be desired if the logs are stored in a separate file.
+只有帶有 `log` 選項的防火牆規則才會被記錄。預設規則不包含此選項，必須手動加入。因此建議編輯預設規則集以加入記錄功能。此外，如果記錄儲存在獨立的檔案中，可能還需要設定記錄輪替。
 ====
 
-There is no [.filename]#/etc/rc.conf# variable to set logging limits. To limit the number of times a rule is logged per connection attempt, specify the number using this line in [.filename]#/etc/sysctl.conf#:
+[.filename]#/etc/rc.conf# 中沒有用來設定記錄上限的變數。若要限制每次連線嘗試時某條規則被記錄的次數，請在 [.filename]#/etc/sysctl.conf# 中加入以下設定：
 
 [source,shell]
 ....
 # echo "net.inet.ip.fw.verbose_limit=5" >> /etc/sysctl.conf
 ....
 
-To enable logging through a dedicated interface named `ipfw0`, add this line to [.filename]#/etc/rc.conf# instead:
+若要改用名為 `ipfw0` 的專用介面來啟用記錄，請在 [.filename]#/etc/rc.conf# 中改加入這一行：
 
 [source,shell]
 ....
 # sysrc firewall_logif="YES"
 ....
 
-Then use tcpdump to see what is being logged:
+接著使用 tcpdump 查看記錄的內容：
 
 [source,shell]
 ....
@@ -975,10 +975,10 @@ Then use tcpdump to see what is being logged:
 [TIP]
 ====
 
-There is no overhead due to logging unless tcpdump is attached.
+除非有 tcpdump 正在監聽，否則記錄功能不會產生額外負擔。
 ====
 
-After saving the needed edits, start the firewall. To enable logging limits now, also set the `sysctl` value specified above:
+儲存所需的編輯後，啟動防火牆。若要立即啟用記錄上限，也請設定上述的 `sysctl` 值：
 
 [source,shell]
 ....
@@ -989,86 +989,86 @@ After saving the needed edits, start the firewall. To enable logging limits now,
 [[firewalls-ipfw-rules]]
 === IPFW 規則語法
 
-When a packet enters the IPFW firewall, it is compared against the first rule in the ruleset and progresses one rule at a time, moving from top to bottom in sequence. When the packet matches the selection parameters of a rule, the rule's action is executed and the search of the ruleset terminates for that packet. This is referred to as "first match wins". If the packet does not match any of the rules, it gets caught by the mandatory IPFW default rule number 65535, which denies all packets and silently discards them. However, if the packet matches a rule that contains the `count`, `skipto`, or `tee` keywords, the search continues. Refer to man:ipfw[8] for details on how these keywords affect rule processing.
+當封包進入 IPFW 防火牆時，會從規則集的第一條規則開始逐條比對，由上而下依序進行。當封包符合某條規則的篩選條件時，便會執行該規則的動作，且該封包的規則集搜尋隨即結束。這就是所謂的「先符合者優先」。如果封包沒有符合任何規則，就會被 IPFW 強制存在的預設規則 65535 攔截，該規則會拒絕所有封包並靜默丟棄。不過，如果封包符合的規則包含 `count`、`skipto` 或 `tee` 等關鍵字，搜尋會繼續進行。關於這些關鍵字如何影響規則處理，請參閱 man:ipfw[8]。
 
-When creating an IPFW rule, keywords must be written in the following order. Some keywords are mandatory while other keywords are optional. The words shown in uppercase represent a variable and the words shown in lowercase must precede the variable that follows it. The `#` symbol is used to mark the start of a comment and may appear at the end of a rule or on its own line. Blank lines are ignored.
+建立 IPFW 規則時，關鍵字必須按照以下順序撰寫。有些關鍵字是必要的，有些則是選用的。以大寫顯示的字詞代表變數，以小寫顯示的字詞則必須出現在其後變數的前面。`#` 符號用來標記註解的開頭，可以出現在規則的結尾或獨立一行。空白行會被忽略。
 
 _CMD RULE_NUMBER set SET_NUMBER ACTION log LOG_AMOUNT PROTO from SRC SRC_PORT to DST DST_PORT OPTIONS_
 
-This section provides an overview of these keywords and their options. It is not an exhaustive list of every possible option. Refer to man:ipfw[8] for a complete description of the rule syntax that can be used when creating IPFW rules.
+本節提供這些關鍵字及其選項的概要說明，並非所有可用選項的完整列表。如需建立 IPFW 規則時可使用的規則語法完整說明，請參閱 man:ipfw[8]。
 
 CMD::
-Every rule must start with [parameter]#ipfw add#.
+每條規則都必須以 [parameter]#ipfw add# 開頭。
 
 RULE_NUMBER::
-Each rule is associated with a number from `1` to `65534`. The number is used to indicate the order of rule processing. Multiple rules can have the same number, in which case they are applied according to the order in which they have been added.
+每條規則都有一個從 `1` 到 `65534` 的編號。此編號用來指定規則的處理順序。多條規則可以使用相同的編號，此時會按照加入的先後順序來套用。
 
 SET_NUMBER::
-Each rule is associated with a set number from `0` to `31`. Sets can be individually disabled or enabled, making it possible to quickly add or delete a set of rules. If a SET_NUMBER is not specified, the rule will be added to set `0`.
+每條規則都屬於一個從 `0` 到 `31` 的集合編號。集合可以個別停用或啟用，因此能快速新增或刪除一整組規則。如果未指定 SET_NUMBER，規則會被加入集合 `0`。
 
 ACTION::
-A rule can be associated with one of the following actions. The specified action will be executed when the packet matches the selection criterion of the rule.
+規則可以搭配以下其中一個動作。當封包符合規則的篩選條件時，便會執行所指定的動作。
 +
-[parameter]#allow | accept | pass | permit#: these keywords are equivalent and allow packets that match the rule.
+[parameter]#allow | accept | pass | permit#：這些關鍵字功能相同，會允許符合規則的封包通過。
 +
-[parameter]#check-state#: checks the packet against the dynamic state table. If a match is found, execute the action associated with the rule which generated this dynamic rule, otherwise move to the next rule. A `check-state` rule does not have selection criterion. If no `check-state` rule is present in the ruleset, the dynamic rules table is checked at the first `keep-state` or `limit` rule.
+[parameter]#check-state#：比對封包與動態狀態表。如果找到相符的項目，便執行產生該動態規則的原始規則所關聯的動作，否則繼續比對下一條規則。`check-state` 規則沒有篩選條件。如果規則集中沒有 `check-state` 規則，動態規則表會在第一條 `keep-state` 或 `limit` 規則時被檢查。
 +
-[parameter]#count#: updates counters for all packets that match the rule. The search continues with the next rule.
+[parameter]#count#：為所有符合規則的封包更新計數器。搜尋會繼續比對下一條規則。
 +
-[parameter]#deny | drop#: either word silently discards packets that match this rule.
+[parameter]#deny | drop#：這兩個關鍵字都會靜默丟棄符合此規則的封包。
 +
-Additional actions are available. Refer to man:ipfw[8] for details.
+還有其他可用的動作，詳情請參閱 man:ipfw[8]。
 
 LOG_AMOUNT::
-When a packet matches a rule with the `log` keyword, a message will be logged to man:syslogd[8] with a facility name of `SECURITY`. Logging only occurs if the number of packets logged for that particular rule does not exceed a specified LOG_AMOUNT. If no LOG_AMOUNT is specified, the limit is taken from the value of `net.inet.ip.fw.verbose_limit`. A value of zero removes the logging limit. Once the limit is reached, logging can be re-enabled by clearing the logging counter or the packet counter for that rule, using `ipfw resetlog`.
+當封包符合帶有 `log` 關鍵字的規則時，會以 `SECURITY` 設施名稱將訊息記錄到 man:syslogd[8]。只有在該條規則已記錄的封包數量未超過指定的 LOG_AMOUNT 時才會記錄。如果未指定 LOG_AMOUNT，上限會取自 `net.inet.ip.fw.verbose_limit` 的值。設為零則取消記錄上限。達到上限後，可以使用 `ipfw resetlog` 清除該規則的記錄計數器或封包計數器來重新啟用記錄。
 +
 
 [NOTE]
 ====
-Logging is done after all other packet matching conditions have been met, and before performing the final action on the packet. The administrator decides which rules to enable logging on.
+記錄是在所有其他封包比對條件都滿足之後、對封包執行最終動作之前進行的。由管理者決定要對哪些規則啟用記錄。
 ====
 
 PROTO::
-This optional value can be used to specify any protocol name or number found in [.filename]#/etc/protocols#.
+此選用值可用來指定 [.filename]#/etc/protocols# 中的任何通訊協定名稱或編號。
 
 SRC::
-The `from` keyword must be followed by the source address or a keyword that represents the source address. An address can be represented by `any`, `me` (any address configured on an interface on this system), `me6`, (any IPv6 address configured on an interface on this system), or `table` followed by the number of a lookup table which contains a list of addresses. When specifying an IP address, it can be optionally followed by its CIDR mask or subnet mask. For example, `1.2.3.4/25` or `1.2.3.4:255.255.255.128`.
+`from` 關鍵字後面必須接來源位址或代表來源位址的關鍵字。位址可以用 `any`、`me`（本系統任何網路介面上設定的位址）、`me6`（本系統任何網路介面上設定的 IPv6 位址）或 `table` 加上包含位址列表的查詢表編號來表示。指定 IP 位址時，可以選擇性地在後面加上 CIDR 遮罩或子網路遮罩。例如 `1.2.3.4/25` 或 `1.2.3.4:255.255.255.128`。
 
 SRC_PORT::
-An optional source port can be specified using the port number or name from [.filename]#/etc/services#.
+可以選擇性地使用 [.filename]#/etc/services# 中的連接埠號碼或名稱來指定來源連接埠。
 
 DST::
-The `to` keyword must be followed by the destination address or a keyword that represents the destination address. The same keywords and addresses described in the SRC section can be used to describe the destination.
+`to` 關鍵字後面必須接目的位址或代表目的位址的關鍵字。SRC 段落中說明的關鍵字和位址格式同樣適用於目的端。
 
 DST_PORT::
-An optional destination port can be specified using the port number or name from [.filename]#/etc/services#.
+可以選擇性地使用 [.filename]#/etc/services# 中的連接埠號碼或名稱來指定目的連接埠。
 
 OPTIONS::
-Several keywords can follow the source and destination. As the name suggests, OPTIONS are optional. Commonly used options include `in` or `out`, which specify the direction of packet flow, `icmptypes` followed by the type of ICMP message, and `keep-state`.
+來源和目的之後可以接數個關鍵字。顧名思義，OPTIONS 是選用的。常用的選項包括 `in` 或 `out`（指定封包流向）、`icmptypes` 加上 ICMP 訊息類型，以及 `keep-state`。
 +
-When a [parameter]#keep-state# rule is matched, the firewall will create a dynamic rule which matches bidirectional traffic between the source and destination addresses and ports using the same protocol.
+當封包符合 [parameter]#keep-state# 規則時，防火牆會建立一條動態規則，比對使用相同通訊協定在來源與目的位址及連接埠之間雙向流通的流量。
 +
-The dynamic rules facility is vulnerable to resource depletion from a SYN-flood attack which would open a huge number of dynamic rules. To counter this type of attack with IPFW, use `limit`. This option limits the number of simultaneous sessions by checking the open dynamic rules, counting the number of times this rule and IP address combination occurred. If this count is greater than the value specified by `limit`, the packet is discarded.
+動態規則機制容易受到 SYN 洪水攻擊的影響，這種攻擊會建立大量動態規則而耗盡資源。若要以 IPFW 對抗這類攻擊，請使用 `limit`。此選項會檢查已開啟的動態規則，計算此規則與 IP 位址組合出現的次數，藉此限制同時進行的連線數量。如果計數超過 `limit` 指定的值，該封包就會被丟棄。
 +
-Dozens of OPTIONS are available. Refer to man:ipfw[8] for a description of each available option.
+有數十種 OPTIONS 可用，各選項的說明請參閱 man:ipfw[8]。
 
 === 範例規則集
 
-This section demonstrates how to create an example stateful firewall ruleset script named [.filename]#/etc/ipfw.rules#. In this example, all connection rules use `in` or `out` to clarify the direction. They also use `via` _interface-name_ to specify the interface the packet is traveling over.
+本節示範如何建立一個名為 [.filename]#/etc/ipfw.rules# 的範例具狀態防火牆規則集 Script。在這個範例中，所有連線規則都使用 `in` 或 `out` 來明確指定方向，也使用 `via` _interface-name_ 來指定封包經過的網路介面。
 
 [NOTE]
 ====
-When first creating or testing a firewall ruleset, consider temporarily setting this tunable:
+初次建立或測試防火牆規則集時，可以考慮暫時設定這個調校參數：
 
 [.programlisting]
 ....
 net.inet.ip.fw.default_to_accept="1"
 ....
 
-This sets the default policy of man:ipfw[8] to be more permissive than the default `deny ip from any to any`, making it slightly more difficult to get locked out of the system right after a reboot.
+這會將 man:ipfw[8] 的預設政策設為比預設的 `deny ip from any to any` 更為寬鬆，讓重新開機後不容易把自己鎖在系統外面。
 ====
 
-The firewall script begins by indicating that it is a Bourne shell script and flushes any existing rules. It then creates the `cmd` variable so that `ipfw add` does not have to be typed at the beginning of every rule. It also defines the `pif` variable which represents the name of the interface that is attached to the Internet.
+防火牆 Script 開頭先宣告這是一個 Bourne shell Script，並清除所有既有的規則。接著建立 `cmd` 變數，這樣就不需要在每條規則開頭都輸入 `ipfw add`。此外也定義了 `pif` 變數，代表連接到網際網路的網路介面名稱。
 
 [.programlisting]
 ....
@@ -1081,7 +1081,7 @@ cmd="ipfw -q add"
 pif="dc0"     # interface name of NIC attached to Internet
 ....
 
-The first two rules allow all traffic on the trusted internal interface and on the loopback interface:
+前兩條規則允許受信任的內部網路介面和 loopback 介面上的所有流量：
 
 [.programlisting]
 ....
@@ -1092,14 +1092,14 @@ $cmd 00005 allow all from any to any via xl0
 $cmd 00010 allow all from any to any via lo0
 ....
 
-The next rule allows the packet through if it matches an existing entry in the dynamic rules table:
+下一條規則會在封包符合動態規則表中的既有項目時允許其通過：
 
 [.programlisting]
 ....
 $cmd 00101 check-state
 ....
 
-The next set of rules defines which stateful connections internal systems can create to hosts on the Internet:
+下一組規則定義了內部系統可以對網際網路上的主機建立哪些具狀態連線：
 
 [.programlisting]
 ....
@@ -1136,7 +1136,7 @@ $cmd 00280 allow tcp from any to any 22 out via $pif setup keep-state
 $cmd 00299 deny log all from any to any out via $pif
 ....
 
-The next set of rules controls connections from Internet hosts to the internal network. It starts by denying packets typically associated with attacks and then explicitly allows specific types of connections. All the authorized services that originate from the Internet use `limit` to prevent flooding.
+下一組規則控制從網際網路主機到內部網路的連線。首先拒絕通常與攻擊行為有關的封包，然後明確允許特定類型的連線。所有從網際網路發起的已授權服務都使用 `limit` 來防止洪水攻擊。
 
 [.programlisting]
 ....
@@ -1183,7 +1183,7 @@ $cmd 00410 allow tcp from any to me 22 in via $pif setup limit src-addr 2
 $cmd 00499 deny log all from any to any in via $pif
 ....
 
-The last rule logs all packets that do not match any of the rules in the ruleset:
+最後一條規則會記錄所有未符合規則集中任何規則的封包：
 
 [.programlisting]
 ....
@@ -1194,11 +1194,11 @@ $cmd 00999 deny log all from any to any
 [[in-kernel-nat]]
 === 核心內 NAT
 
-FreeBSD's IPFW firewall has two implementations of NAT: one being the userland man:natd[8] daemon, and the more recent IPFW's built-in NAT facility also known as in-kernel NAT. Both work in conjunction with IPFW to provide network address translation. This can be used to provide an Internet Connection Sharing solution so that several internal computers can connect to the Internet using a single public IP address.
+FreeBSD 的 IPFW 防火牆有兩種網路位址轉譯 (NAT) 的實作方式：一種是 Userland 的 man:natd[8] daemon，另一種是較新的 IPFW 內建 NAT 功能，也稱為核心內 NAT。兩者都與 IPFW 搭配運作以提供網路位址轉譯。這可用來實現網路連線共享的方案，讓多台內部電腦透過單一公用 IP 位址連接網際網路。
 
-To do this, the FreeBSD machine connected to the Internet must act as a gateway. This system must have two NICs, where one is connected to the Internet and the other is connected to the internal LAN. Each machine connected to the LAN should be assigned an IP address in the private network space, as defined by https://www.ietf.org/rfc/rfc1918.txt[RFC 1918].
+要達成此目的，連接到網際網路的 FreeBSD 機器必須擔任閘道的角色。這台系統必須有兩張網路卡，一張連接到網際網路，另一張連接到內部區域網路。區域網路上的每台機器都應分配一個私有網路位址空間的 IP 位址，如 https://www.ietf.org/rfc/rfc1918.txt[RFC 1918] 所定義。
 
-Some additional configuration is needed in order to enable the in-kernel NAT function of IPFW. To enable in-kernel NAT support at boot time, the following must be set in [.filename]#/etc/rc.conf#:
+需要一些額外的設定才能啟用 IPFW 的核心內 NAT 功能。若要在開機時啟用核心內 NAT 支援，必須在 [.filename]#/etc/rc.conf# 中設定以下項目：
 
 [.programlisting]
 ....
@@ -1209,17 +1209,17 @@ firewall_nat_enable="YES"
 
 [NOTE]
 ====
-When `firewall_enable` is not set, but `firewall_nat_enable` is, it will have no effect and do nothing, because the in-kernel NAT implementation is only compatible with IPFW.
+當未設定 `firewall_enable` 但設定了 `firewall_nat_enable` 時，不會有任何效果，因為核心內 NAT 的實作僅與 IPFW 相容。
 ====
 
-When the ruleset contains stateful rules, the positioning of the NAT rule is critical and the `skipto` action is used. The `skipto` action requires a rule number so that it knows which rule to jump to. Furthermore, because of the architecture of man:libalias[3], a library implemented as a kernel module used for the in-kernel NAT facility of IPFW, it is necessary to disable TCP segmentation offloading, or in short TSO. TSO can be disabled on a per network interface basis by using man:ifconfig[8] or on a system wide basis using man:sysctl[8]. To disable TSO system wide, the following must be set in [.filename]#/etc/sysctl.conf#:
+當規則集包含具狀態規則時，NAT 規則的位置至關重要，且會使用 `skipto` 動作。`skipto` 動作需要一個規則編號以便知道要跳轉到哪條規則。此外，由於 man:libalias[3] 的架構（這是一個以核心模組形式實作的函式庫，供 IPFW 的核心內 NAT 功能使用），必須停用 TCP 分段卸載（TSO）。TSO 可以使用 man:ifconfig[8] 針對個別網路介面停用，或使用 man:sysctl[8] 在全系統範圍停用。若要在全系統停用 TSO，必須在 [.filename]#/etc/sysctl.conf# 中設定以下項目：
 
 [.programlisting]
 ....
 net.inet.tcp.tso="0"
 ....
 
-The example below builds upon the firewall ruleset shown in the previous section. It adds some additional entries and modifies some existing rules in order to configure the firewall for in-kernel NAT. It starts by adding some additional variables which represent the rule number to skip to, the `keep-state` option, and a list of TCP ports which will be used to reduce the number of rules.
+以下範例以前一節所示的防火牆規則集為基礎，新增了一些項目並修改了一些既有規則，以便為核心內 NAT 設定防火牆。首先加入一些額外的變數，分別代表要跳轉到的規則編號、`keep-state` 選項，以及用來減少規則數量的 TCP 連接埠列表。
 
 [.programlisting]
 ....
@@ -1232,7 +1232,7 @@ ks="keep-state"
 good_tcpo="22,25,37,53,80,443,110"
 ....
 
-A NAT instance will also be configured. With in-kernel NAT it is possible to have multiple NAT instances each with their own configuration. Although, for this example only one NAT instance is needed; NAT instance number 1. The configuration takes a few arguments and flags such as: `if` which indicates the public interface, `same_ports` which takes care that alliased ports and local port numbers are mapped the same, `unreg_only` will result in only unregistered (private) address spaces to be processed by the NAT instance, and `reset` which will help to keep a functioning NAT instance even when the public IP address of the IPFW machine changes. For all possible options that can be passed to a single NAT instance configuration consult man:ipfw[8]. Furthermore, because of the nature of a stateful NATing firewall, it is neseccary to allow translated packets to be reinjected in the firewall for further processing, this can be achieved by disabling `one_pass` behavior at the start of the firewall script.
+同時也需要設定一個 NAT 實例。核心內 NAT 可以擁有多個 NAT 實例，各自有獨立的設定。不過在本範例中只需要一個 NAT 實例，即 NAT 實例編號 1。設定時需要幾個參數和旗標，例如：`if` 指定公用網路介面、`same_ports` 確保別名連接埠與本地連接埠編號對應一致、`unreg_only` 使 NAT 實例僅處理未註冊的（私有）位址空間，以及 `reset` 讓 IPFW 機器的公用 IP 位址變更時 NAT 實例仍能正常運作。所有可傳入單一 NAT 實例設定的選項，請參閱 man:ipfw[8]。此外，由於具狀態 NAT 防火牆的特性，必須允許已轉譯的封包重新注入防火牆以進行後續處理，這可以在防火牆 Script 開頭停用 `one_pass` 行為來達成。
 
 [.programlisting]
 ....
@@ -1240,13 +1240,13 @@ ipfw disable one_pass
 ipfw -q nat 1 config if $pif same_ports unreg_only reset
 ....
 
-The inbound NAT rule is inserted _after_ the two rules which allow all traffic on the trusted and loopback interfaces and after the reassamble rule but _before_ the `check-state` rule. It is important that the rule number selected for this NAT rule, in this example `100`, is higher than the first three rules and lower than the `check-state` rule. Furthermore, because of the behavior of in-kernel NAT it is advised to place a reassamble rule just before the first NAT rule and after the rules that allow traffic on trusted interface. Normally, IP fragmentation should not happen, but when dealing with IPSEC/ESP/GRE tunneling traffic it might and the reassmabling of fragments is necessary before handing the complete packet over to the in-kernel NAT engine.
+入站 NAT 規則要插在允許受信任介面和 loopback 介面所有流量的兩條規則以及重組規則 _之後_，但在 `check-state` 規則 _之前_。重要的是，為此 NAT 規則選擇的規則編號（本範例中為 `100`）必須大於前三條規則，且小於 `check-state` 規則。此外，由於核心內 NAT 的行為特性，建議在第一條 NAT 規則之前、允許受信任介面流量的規則之後放置一條重組規則。一般情況下不應發生 IP 分片，但處理 IPSEC/ESP/GRE 通道流量時可能會發生，因此在將完整封包交給核心內 NAT 引擎之前，需要先重組分片。
 
 [NOTE]
 ====
-The reassemble rule was not needed with userland man:natd[8] because the internal workings of the IPFW `divert` action already takes care of this automatically as also stated in man:ipfw[8].
+使用 Userland 的 man:natd[8] 時不需要重組規則，因為 IPFW `divert` 動作的內部運作已自動處理此事，man:ipfw[8] 中也有說明。
 
-The current NAT instance number and NAT rule number does not match with the default NAT instance number and rule number created by [.filename]#rc.firewall# which is a script to set up the baked-in default firewall rulesets present in FreeBSD.
+目前的 NAT 實例編號和 NAT 規則編號與 [.filename]#rc.firewall# 建立的預設 NAT 實例編號和規則編號並不一致，[.filename]#rc.firewall# 是用來設定 FreeBSD 內建預設防火牆規則集的 Script。
 ====
 
 [.programlisting]
@@ -1259,11 +1259,11 @@ $cmd 100 nat 1 ip from any to any in via $pif # NAT any inbound packets
 $cmd 101 check-state
 ....
 
-The outbound rules are modified to replace the `allow` action with the `$skip` variable, indicating that rule processing will continue at rule `1000`. The seven `tcp` rules have been replaced by rule `125` as the `$good_tcpo` variable contains the seven allowed outbound ports.
+出站規則經過修改，將 `allow` 動作替換為 `$skip` 變數，表示規則處理將在規則 `1000` 繼續。原本的七條 `tcp` 規則已被規則 `125` 取代，因為 `$good_tcpo` 變數包含了七個允許的出站連接埠。
 
 [NOTE]
 ====
-Remember that IPFW's firewall performance is largely determined by the number of rules present in the ruleset.
+請記住，IPFW 防火牆的效能在很大程度上取決於規則集中的規則數量。
 ====
 
 [.programlisting]
@@ -1275,7 +1275,7 @@ $cmd 125 $skip tcp from any to any $good_tcpo out via $pif setup $ks
 $cmd 130 $skip icmp from any to any out via $pif $ks
 ....
 
-The inbound rules remain the same, except for the very last rule which removes the `via $pif` in order to catch both inbound and outbound rules. The NAT rule must follow this last outbound rule, must have a higher number than that last rule, and the rule number must be referenced by the `skipto` action. In this ruleset, rule number `1000` handles passing all packets to our configured instance for NAT processing. The next rule allows any packet which has undergone NAT processing to pass.
+入站規則維持不變，唯一例外是最後一條規則移除了 `via $pif`，以便同時攔截入站和出站的規則。NAT 規則必須跟在這最後一條出站規則之後，編號必須大於該規則，且該規則編號必須被 `skipto` 動作所參照。在這個規則集中，規則編號 `1000` 負責將所有封包傳送到我們設定好的實例進行 NAT 處理。下一條規則則允許所有經過 NAT 處理的封包通過。
 
 [.programlisting]
 ....
@@ -1284,24 +1284,24 @@ $cmd 1000 nat 1 ip from any to any out via $pif # skipto location for outbound s
 $cmd 1001 allow ip from any to any
 ....
 
-In this example, rules `100`, `101`, `125`, `1000`, and `1001` control the address translation of the outbound and inbound packets so that the entries in the dynamic state table always register the private LANIP address.
+在這個範例中，規則 `100`、`101`、`125`、`1000` 和 `1001` 控制出站與入站封包的位址轉譯，使得動態狀態表中的項目始終記錄的是私有區域網路 IP 位址。
 
-Consider an internal web browser which initializes a new outbound HTTP session over port 80. When the first outbound packet enters the firewall, it does not match rule `100` because it is headed out rather than in. It passes rule `101` because this is the first packet and it has not been posted to the dynamic state table yet. The packet finally matches rule `125` as it is outbound on an allowed port and has a source IP address from the internal LAN. On matching this rule, two actions take place. First, the `keep-state` action adds an entry to the dynamic state table and the specified action, `skipto rule 1000`, is executed. Next, the packet undergoes NAT and is sent out to the Internet. This packet makes its way to the destination web server, where a response packet is generated and sent back. This new packet enters the top of the ruleset. It matches rule `100` and has its destination IP address mapped back to the original internal address. It then is processed by the `check-state` rule, is found in the table as an existing session, and is released to the LAN.
+假設有一個內部網路的瀏覽器透過連接埠 80 發起一個新的出站 HTTP 連線。當第一個出站封包進入防火牆時，不會符合規則 `100`，因為它是往外而非往內的。它也不符合規則 `101`，因為這是第一個封包，尚未被記錄到動態狀態表中。封包最終符合規則 `125`，因為它是透過允許的連接埠出站，且來源 IP 位址來自內部區域網路。符合此規則時會執行兩個動作：首先，`keep-state` 動作會在動態狀態表中新增一筆項目，然後執行指定的動作 `skipto rule 1000`。接著封包經過 NAT 處理後送往網際網路。封包到達目的端網頁伺服器後，會產生回應封包並送回。這個新封包從規則集的頂端開始處理，符合規則 `100` 並將其目的 IP 位址映射回原始的內部位址。然後由 `check-state` 規則處理，在表中找到對應的既有連線，隨即放行到區域網路。
 
-On the inbound side, the ruleset has to deny bad packets and allow only authorized services. A packet which matches an inbound rule is posted to the dynamic state table and the packet is released to the LAN. The packet generated as a response is recognized by the `check-state` rule as belonging to an existing session. It is then sent to rule `1000` to undergo NAT before being released to the outbound interface.
+在入站方面，規則集必須拒絕不良封包並僅允許已授權的服務。符合入站規則的封包會被記錄到動態狀態表中，然後放行到區域網路。其回應封包會被 `check-state` 規則辨識為屬於既有連線，接著送到規則 `1000` 進行 NAT 處理，然後才從出站介面送出。
 
 [NOTE]
 ====
-Transition from userland man:natd[8] to in-kernel NAT might seem seamless at first but there is small catch. When using the GENERIC kernel, IPFW will load the [.filename]#libalias.ko# kernel module, when `firewall_nat_enable` is enabled in [.filename]#rc.conf#. Although, the loaded module only provides basic NAT functionality, whereas the userland implementation man:natd[8] has all functionality available without any extra configuration from its userland library. All functionality refers to the following kernel modules that can additionally be loaded when needed besides the standard [.filename]#libalias.ko# kernel module: [.filename]#alias_cuseeme.ko#, [.filename]#alias_ftp.ko#, [.filename]#alias_bbt.ko#, [.filename]#skinny.ko#, [.filename]#irc.ko#, [.filename]#alias_pptp.ko# and [.filename]#alias_smedia.ko# using the `kld_list` directive in [.filename]#rc.conf# to mimic the full functionality of the userland implementation. If a custom kernel is used, the full functionality of the userland library can be compiled in, in the kernel, using the `option LIBALIAS`.
+從 Userland 的 man:natd[8] 轉換到核心內 NAT 乍看之下似乎很順暢，但有一個小地方需要注意。使用 GENERIC 核心時，當 [.filename]#rc.conf# 中啟用了 `firewall_nat_enable`，IPFW 會載入 [.filename]#libalias.ko# 核心模組。但是，載入的模組僅提供基本的 NAT 功能，而 Userland 的 man:natd[8] 實作則可透過其 Userland 函式庫提供全部功能，無需額外設定。所謂的全部功能是指除了標準的 [.filename]#libalias.ko# 核心模組之外，還可視需要額外載入以下核心模組：[.filename]#alias_cuseeme.ko#、[.filename]#alias_ftp.ko#、[.filename]#alias_bbt.ko#、[.filename]#skinny.ko#、[.filename]#irc.ko#、[.filename]#alias_pptp.ko# 和 [.filename]#alias_smedia.ko#，透過 [.filename]#rc.conf# 中的 `kld_list` 指示來模擬 Userland 實作的完整功能。如果使用自訂核心，可以透過 `option LIBALIAS` 將 Userland 函式庫的全部功能編譯進核心中。
 ====
 
 ==== Port 重新導向
 
-The drawback with NAT in general is that the LAN clients are not accessible from the Internet. Clients on the LAN can make outgoing connections to the world but cannot receive incoming ones. This presents a problem if trying to run Internet services on one of the LAN client machines. A simple way around this is to redirect selected Internet ports on the NAT providing machine to a LAN client.
+NAT 的一般缺點是區域網路上的用戶端無法從網際網路存取。區域網路上的用戶端可以向外建立連線，但無法接收傳入的連線。如果想在區域網路上的某台用戶端機器執行網際網路服務，這就會是個問題。簡單的解決方式是將提供 NAT 的機器上選定的網際網路連接埠重新導向到區域網路用戶端。
 
-For example, an IRC server runs on client `A` and a web server runs on client `B`. For this to work properly, connections received on ports 6667 (IRC) and 80 (HTTP) must be redirected to the respective machines.
+舉例來說，用戶端 `A` 上執行著 IRC 伺服器，用戶端 `B` 上執行著網頁伺服器。為了讓這些服務正常運作，連接埠 6667 (IRC) 和 80 (HTTP) 收到的連線必須分別重新導向到對應的機器。
 
-With in-kernel NAT all configuration is done in the NAT instance configuration. For a full list of options that an in-kernel NAT instance can use, consult man:ipfw[8]. The IPFW syntax follows the syntax of natd. The syntax for `redirect_port` is as follows:
+使用核心內 NAT 時，所有設定都在 NAT 實例設定中完成。核心內 NAT 實例可用選項的完整列表，請參閱 man:ipfw[8]。IPFW 語法遵循 natd 的語法。`redirect_port` 的語法如下：
 
 [.programlisting]
 ....
@@ -1310,7 +1310,7 @@ redirect_port proto targetIP:targetPORT[-targetPORT]
   [remoteIP[:remotePORT[-remotePORT]]]
 ....
 
-To configure the above example setup, the arguments should be:
+要設定上述範例，參數應為：
 
 [.programlisting]
 ....
@@ -1318,7 +1318,7 @@ redirect_port tcp 192.168.0.2:6667 6667
 redirect_port tcp 192.168.0.3:80 80
 ....
 
-After adding these arguments to the configuration of NAT instance 1 in the above ruleset, the TCP ports will be port forwarded to the LAN client machines running the IRC and HTTP services.
+將這些參數加入上述規則集中 NAT 實例 1 的設定後，TCP 連接埠就會被轉送到執行 IRC 和 HTTP 服務的區域網路用戶端機器。
 
 [.programlisting]
 ....
@@ -1327,20 +1327,20 @@ ipfw -q nat 1 config if $pif same_ports unreg_only reset \
   redirect_port tcp 192.1683.0.3:80 80
 ....
 
-Port ranges over individual ports can be indicated with `redirect_port`. For example, _tcp 192.168.0.2:2000-3000 2000-3000_ would redirect all connections received on ports 2000 to 3000 to ports 2000 to 3000 on client `A`.
+透過 `redirect_port` 也可以指定連接埠範圍而非個別連接埠。例如 _tcp 192.168.0.2:2000-3000 2000-3000_ 會將連接埠 2000 到 3000 收到的所有連線重新導向到用戶端 `A` 的連接埠 2000 到 3000。
 
 ==== 位址重新導向
 
-Address redirection is useful if more than one IP address is available. Each LAN client can be assigned its own external IP address by man:ipfw[8], which will then rewrite outgoing packets from the LAN clients with the proper external IP address and redirects all traffic incoming on that particular IP address back to the specific LAN client. This is also known as static NAT. For example, if IP addresses `128.1.1.1`, `128.1.1.2`, and `128.1.1.3` are available, `128.1.1.1` can be used as the man:ipfw[8] machine's external IP address, while `128.1.1.2` and `128.1.1.3` are forwarded back to LAN clients `A` and `B`.
+當有多個 IP 位址可用時，位址重新導向就很有用。man:ipfw[8] 可以為每個區域網路用戶端分配各自的外部 IP 位址，然後將區域網路用戶端的出站封包改寫為正確的外部 IP 位址，並將該特定 IP 位址收到的所有傳入流量重新導向回對應的區域網路用戶端。這也稱為靜態 NAT。舉例來說，如果有 `128.1.1.1`、`128.1.1.2` 和 `128.1.1.3` 三個 IP 位址可用，`128.1.1.1` 可作為 man:ipfw[8] 機器的外部 IP 位址，而 `128.1.1.2` 和 `128.1.1.3` 則分別轉送回區域網路用戶端 `A` 和 `B`。
 
-The `redirect_address` syntax is as below, where `localIP` is the internal IP address of the LAN client, and `publicIP` the external IP address corresponding to the LAN client.
+`redirect_address` 的語法如下，其中 `localIP` 是區域網路用戶端的內部 IP 位址，`publicIP` 是對應到該區域網路用戶端的外部 IP 位址。
 
 [.programlisting]
 ....
 redirect_address localIP publicIP
 ....
 
-In the example, the arguments would read:
+以此範例來說，參數如下：
 
 [.programlisting]
 ....
@@ -1348,13 +1348,13 @@ redirect_address 192.168.0.2 128.1.1.2
 redirect_address 192.168.0.3 128.1.1.3
 ....
 
-Like `redirect_port`, these arguments are placed in a NAT instance configuration. With address redirection, there is no need for port redirection, as all data received on a particular IP address is redirected.
+與 `redirect_port` 一樣，這些參數放在 NAT 實例的設定中。使用位址重新導向時，不需要連接埠重新導向，因為特定 IP 位址收到的所有資料都會被重新導向。
 
-The external IP addresses on the man:ipfw[8] machine must be active and aliased to the external interface. Refer to man:rc.conf[5] for details.
+man:ipfw[8] 機器上的外部 IP 位址必須處於啟用狀態並以別名方式綁定到外部網路介面。詳情請參閱 man:rc.conf[5]。
 
 ==== Userspace NAT
 
-Let us start with a statement: the userspace NAT implementation: man:natd[8], has more overhead than in-kernel NAT. For man:natd[8] to translate packets, the packets have to be copied from the kernel to userspace and back which brings in extra overhead that is not present with in-kernel NAT.
+首先說明一點：Userspace 的 NAT 實作 man:natd[8] 的負擔比核心內 NAT 更大。man:natd[8] 在轉譯封包時，封包必須從核心複製到 Userspace 再複製回來，這會帶來核心內 NAT 所沒有的額外負擔。
 
 要在開機時啟動 Userspace 的 NAT daemon man:natd[8] 需在 [.filename]#/etc/rc.conf# 中做以下最小設定，其中 `natd_interface` 要設成連接到網際網路的 NIC 名稱，man:rc[8] script of man:natd[8] 會自動檢查是否有使用動態 IP 位址，並且自行設定並處理。
 
@@ -1365,7 +1365,7 @@ natd_enable="YES"
 natd_interface="rl0"
 ....
 
-In general, the above ruleset as explained for in-kernel NAT can also be used together with man:natd[8]. The only exceptions are the configuration of the in-kernel NAT instance `(ipfw -q nat 1 config ...)` not being applicable any more, rule number 100 and 1000 will have to change sligthly as below, and reassemble rule 99 is not needed anymore as the `divert` action is used which covers fragmentation.
+一般來說，前面為核心內 NAT 說明的規則集也可以搭配 man:natd[8] 使用。唯一的例外是核心內 NAT 實例的設定 `(ipfw -q nat 1 config ...)` 不再適用，規則編號 100 和 1000 需要稍作修改如下所示，而且重組規則 99 也不再需要，因為所使用的 `divert` 動作已涵蓋分片處理。
 
 [.programlisting]
 ....
@@ -1373,7 +1373,7 @@ $cmd 100 divert natd ip from any to any in via $pif
 $cmd 1000 divert natd ip from any to any out via $pif
 ....
 
-To configure port or address redirection, a similar syntax as with in-kernel NAT is used. Although, now, instead of specifying the configuration in our ruleset script like with in-kernel NAT, configuration of man:natd[8] is best done in a configuration file. To do this, an extra flag must be passed via [.filename]#/etc/rc.conf# which specifies the path of the configuration file.
+若要設定連接埠或位址重新導向，使用的語法與核心內 NAT 類似。不過現在不是像核心內 NAT 那樣在規則集 Script 中指定設定，man:natd[8] 的設定最好寫在設定檔中。為此，需要透過 [.filename]#/etc/rc.conf# 傳入一個額外的旗標來指定設定檔的路徑。
 
 [.programlisting]
 ....
@@ -1382,7 +1382,7 @@ natd_flags="-f /etc/natd.conf"
 
 [NOTE]
 ====
-The specified file must contain a list of configuration options, one per line. For more information about the configuration file and possible variables, consult man:natd[8]. Below are two example entries, one per line:
+指定的檔案必須包含一份設定選項列表，每行一個。關於設定檔和可用變數的更多資訊，請參閱 man:natd[8]。以下是兩個範例項目，每行一個：
 
 [.programlisting]
 ....
@@ -1395,53 +1395,53 @@ redirect_address 192.168.0.3 128.1.1.3
 [[firewalls-ipfw-cmd]]
 === IPFW 指令
 
-`ipfw` can be used to make manual, single rule additions or deletions to the active firewall while it is running. The problem with using this method is that all the changes are lost when the system reboots. It is recommended to instead write all the rules in a file and to use that file to load the rules at boot time and to replace the currently running firewall rules whenever that file changes.
+`ipfw` 可以在防火牆運作中手動新增或刪除單條規則。但這種方式的問題是，所有變更在系統重新開機後都會遺失。建議改為將所有規則寫在檔案中，利用該檔案在開機時載入規則，並在檔案變更時取代目前正在運作的防火牆規則。
 
-`ipfw` is a useful way to display the running firewall rules to the console screen. The IPFW accounting facility dynamically creates a counter for each rule that counts each packet that matches the rule. During the process of testing a rule, listing the rule with its counter is one way to determine if the rule is functioning as expected.
+`ipfw` 也是在主控台畫面上顯示運作中防火牆規則的好工具。IPFW 的計帳設施會為每條規則動態建立一個計數器，計算符合該規則的每個封包。在測試規則的過程中，列出規則及其計數器是判斷規則是否如預期運作的一種方式。
 
-To list all the running rules in sequence:
+依序列出所有運作中的規則：
 
 [source,shell]
 ....
 # ipfw list
 ....
 
-To list all the running rules with a time stamp of when the last time the rule was matched:
+列出所有運作中的規則，並顯示每條規則最後一次被符合的時間戳記：
 
 [source,shell]
 ....
 # ipfw -t list
 ....
 
-The next example lists accounting information and the packet count for matched rules along with the rules themselves. The first column is the rule number, followed by the number of matched packets and bytes, followed by the rule itself.
+下一個範例列出計帳資訊和已符合規則的封包計數，以及規則本身。第一欄是規則編號，接著是符合的封包數和位元組數，最後是規則本身。
 
 [source,shell]
 ....
 # ipfw -a list
 ....
 
-To list dynamic rules in addition to static rules:
+除了靜態規則外，也列出動態規則：
 
 [source,shell]
 ....
 # ipfw -d list
 ....
 
-To also show the expired dynamic rules:
+同時顯示已過期的動態規則：
 
 [source,shell]
 ....
 # ipfw -d -e list
 ....
 
-To zero the counters:
+將計數器歸零：
 
 [source,shell]
 ....
 # ipfw zero
 ....
 
-To zero the counters for just the rule with number _NUM_:
+僅將規則編號 _NUM_ 的計數器歸零：
 
 [source,shell]
 ....
@@ -1450,27 +1450,27 @@ To zero the counters for just the rule with number _NUM_:
 
 ==== 記錄防火牆訊息
 
-Even with the logging facility enabled, IPFW will not generate any rule logging on its own. The firewall administrator decides which rules in the ruleset will be logged, and adds the `log` keyword to those rules. Normally only deny rules are logged. It is customary to duplicate the "ipfw default deny everything" rule with the `log` keyword included as the last rule in the ruleset. This way, it is possible to see all the packets that did not match any of the rules in the ruleset.
+即使啟用了記錄設施，IPFW 也不會自動產生任何規則記錄。防火牆管理者決定規則集中哪些規則要記錄，並對這些規則加入 `log` 關鍵字。通常只記錄拒絕規則。慣例做法是複製一份「ipfw default deny everything」規則，加上 `log` 關鍵字作為規則集的最後一條規則。這樣就能看到所有未符合規則集中任何規則的封包。
 
-Logging is a two edged sword. If one is not careful, an over abundance of log data or a DoS attack can fill the disk with log files. Log messages are not only written to syslogd, but also are displayed on the root console screen and soon become annoying.
+記錄是一把雙面刃。如果不小心，過多的記錄資料或 DoS 攻擊可能會把磁碟塞滿記錄檔。記錄訊息不僅會寫入 syslogd，也會顯示在 root 主控台畫面上，很快就會令人困擾。
 
-The `IPFIREWALL_VERBOSE_LIMIT=5` kernel option limits the number of consecutive messages sent to man:syslogd[8], concerning the packet matching of a given rule. When this option is enabled in the kernel, the number of consecutive messages concerning a particular rule is capped at the number specified. There is nothing to be gained from 200 identical log messages. With this option set to five, five consecutive messages concerning a particular rule would be logged to syslogd and the remainder identical consecutive messages would be counted and posted to syslogd with a phrase like the following:
+`IPFIREWALL_VERBOSE_LIMIT=5` 核心選項會限制針對特定規則的封包比對，連續送往 man:syslogd[8] 的訊息數量。在核心中啟用此選項後，關於特定規則的連續訊息數量會被限制在指定的數字。200 條相同的記錄訊息毫無意義。此選項設為五時，關於特定規則的連續訊息只會有五條記錄到 syslogd，其餘相同的連續訊息會被計數，並以類似以下的詞句發送到 syslogd：
 
 [.programlisting]
 ....
 last message repeated 45 times
 ....
 
-All logged packets messages are written by default to [.filename]#/var/log/security#, which is defined in [.filename]#/etc/syslog.conf#.
+所有已記錄的封包訊息預設會寫入 [.filename]#/var/log/security#，此路徑定義在 [.filename]#/etc/syslog.conf# 中。
 
 [[firewalls-ipfw-rules-script]]
 ==== 建立規則 Script
 
-Most experienced IPFW users create a file containing the rules and code them in a manner compatible with running them as a script. The major benefit of doing this is the firewall rules can be refreshed in mass without the need of rebooting the system to activate them. This method is convenient in testing new rules as the procedure can be executed as many times as needed. Being a script, symbolic substitution can be used for frequently used values to be substituted into multiple rules.
+大多數有經驗的 IPFW 使用者會建立一個包含規則的檔案，並以可作為 Script 執行的方式來撰寫。這麼做的主要好處是防火牆規則可以大量更新，不需要重新開機即可生效。這個方式在測試新規則時很方便，因為程序可以視需要執行多次。由於是 Script，可以使用符號替換，將常用的值代入多條規則中。
 
-This example script is compatible with the syntax used by the man:sh[1], man:csh[1], and man:tcsh[1] shells. Symbolic substitution fields are prefixed with a dollar sign ($). Symbolic fields do not have the $ prefix. The value to populate the symbolic field must be enclosed in double quotes ("").
+此範例 Script 的語法相容於 man:sh[1]、man:csh[1] 和 man:tcsh[1] shell。符號替換欄位以錢號 ($) 為前綴。符號欄位本身沒有 $ 前綴。用來填入符號欄位的值必須以雙引號 ("") 括起。
 
-Start the rules file like this:
+規則檔案的開頭如下：
 
 [.programlisting]
 ....
@@ -1491,18 +1491,18 @@ $cmd 00611 allow udp from any to $odns 53 out via $oif $ks
 ################### End of example ipfw rules script ############
 ....
 
-The rules are not important as the focus of this example is how the symbolic substitution fields are populated.
+規則本身不是重點，此範例的重點是展示符號替換欄位如何被填入。
 
-If the above example was in [.filename]#/etc/ipfw.rules#, the rules could be reloaded by the following command:
+如果上述範例存放在 [.filename]#/etc/ipfw.rules# 中，可以使用以下指令重新載入規則：
 
 [source,shell]
 ....
 # sh /etc/ipfw.rules
 ....
 
-[.filename]#/etc/ipfw.rules# can be located anywhere and the file can have any name.
+[.filename]#/etc/ipfw.rules# 可以放在任何位置，檔案名稱也不限。
 
-The same thing could be accomplished by running these commands by hand:
+同樣的事情也可以手動執行以下指令來完成：
 
 [source,shell]
 ....
@@ -1518,7 +1518,7 @@ The same thing could be accomplished by running these commands by hand:
 [[firewalls-ipfw-kernelconfig]]
 === IPFW 核心選項
 
-In order to statically compile IPFW support into a custom kernel, refer to the instructions in crossref:kernelconfig[kernelconfig,設定 FreeBSD 核心]. The following options are available for the custom kernel configuration file:
+若要將 IPFW 支援靜態編譯進自訂核心，請參閱 crossref:kernelconfig[kernelconfig,設定 FreeBSD 核心] 中的說明。以下是自訂核心設定檔可用的選項：
 
 [.programlisting]
 ....
@@ -1535,7 +1535,7 @@ options    IPDIVERT			# enables NAT through natd(8)
 
 [NOTE]
 ====
-IPFW can be loaded as a kernel module: options above are built by default as modules or can be set at runtime using tunables.
+IPFW 可以作為核心模組載入：上述選項預設會編譯為模組，也可以在執行期間透過調校參數來設定。
 ====
 
 [[firewalls-ipf]]
@@ -1553,9 +1553,9 @@ IPF FAQ 位於 http://www.phildev.net/ipf/index.html[http://www.phildev.net/ipf/
 
 === 開啟 IPF
 
-IPF is included in the basic FreeBSD install as a kernel loadable module, meaning that a custom kernel is not needed in order to enable IPF.
+IPF 已包含在 FreeBSD 基本安裝中，以可載入核心模組的形式提供，這表示不需要自訂核心就能啟用 IPF。
 
-For users who prefer to statically compile IPF support into a custom kernel, refer to the instructions in crossref:kernelconfig[kernelconfig,設定 FreeBSD 核心]. The following kernel options are available:
+若偏好將 IPF 支援靜態編譯進自訂核心，請參閱 crossref:kernelconfig[kernelconfig,設定 FreeBSD 核心] 中的說明。以下為可用的核心選項：
 
 [.programlisting]
 ....
@@ -1565,9 +1565,9 @@ options IPFILTER_LOOKUP
 options IPFILTER_DEFAULT_BLOCK
 ....
 
-where `options IPFILTER` enables support for IPFILTER, `options IPFILTER_LOG` enables IPF logging using the [.filename]#ipl# packet logging pseudo-device for every rule that has the `log` keyword, `IPFILTER_LOOKUP` enables IP pools in order to speed up IP lookups, and `options IPFILTER_DEFAULT_BLOCK` changes the default behavior so that any packet not matching a firewall `pass` rule gets blocked.
+其中 `options IPFILTER` 啟用 IPFILTER 支援，`options IPFILTER_LOG` 使用 [.filename]#ipl# 封包記錄虛擬裝置為每條含有 `log` 關鍵字的規則啟用 IPF 記錄功能，`IPFILTER_LOOKUP` 啟用 IP 集區以加速 IP 查詢，而 `options IPFILTER_DEFAULT_BLOCK` 則變更預設行為，使任何不符合防火牆 `pass` 規則的封包都被阻擋。
 
-To configure the system to enable IPF at boot time, add the following entries to [.filename]#/etc/rc.conf#. These entries will also enable logging and `default pass all`. To change the default policy to `block all` without compiling a custom kernel, remember to add a `block all` rule at the end of the ruleset.
+要設定系統在開機時啟用 IPF，請將以下項目加入 [.filename]#/etc/rc.conf#。這些項目也會啟用記錄功能及 `default pass all`。若要在不編譯自訂核心的情況下將預設策略改為 `block all`，請記得在規則集的最後加上一條 `block all` 規則。
 
 [.programlisting]
 ....
@@ -1580,7 +1580,7 @@ ipmon_flags="-Ds"                 # D = start as daemon
                                   # n = map IP & port to names
 ....
 
-If NAT functionality is needed, also add these lines:
+若需要 NAT 功能，也請加入以下這幾行：
 
 [.programlisting]
 ....
@@ -1589,121 +1589,121 @@ ipnat_enable="YES"                # Start ipnat function
 ipnat_rules="/etc/ipnat.rules"    # rules definition file for ipnat
 ....
 
-Then, to start IPF now:
+接著，立即啟動 IPF：
 
 [.programlisting]
 ....
 # service ipfilter start
 ....
 
-To load the firewall rules, specify the name of the ruleset file using `ipf`. The following command can be used to replace the currently running firewall rules:
+要載入防火牆規則，請使用 `ipf` 指定規則集檔案名稱。以下指令可用來取代目前正在執行的防火牆規則：
 
 [source,shell]
 ....
 # ipf -Fa -f /etc/ipf.rules
 ....
 
-where `-Fa` flushes all the internal rules tables and `-f` specifies the file containing the rules to load.
+其中 `-Fa` 會清除所有內部規則表，`-f` 則指定要載入的規則檔案。
 
-This provides the ability to make changes to a custom ruleset and update the running firewall with a fresh copy of the rules without having to reboot the system. This method is convenient for testing new rules as the procedure can be executed as many times as needed.
+這樣就能修改自訂規則集，並以全新的規則更新執行中的防火牆，而不需要重新開機。此方法對於測試新規則相當方便，因為可以視需要重複執行。
 
-Refer to man:ipf[8] for details on the other flags available with this command.
+關於此指令可用的其他旗標，請參閱 man:ipf[8]。
 
 === IPF 規則語法
 
-This section describes the IPF rule syntax used to create stateful rules. When creating rules, keep in mind that unless the `quick` keyword appears in a rule, every rule is read in order, with the _last matching rule_ being the one that is applied. This means that even if the first rule to match a packet is a `pass`, if there is a later matching rule that is a `block`, the packet will be dropped. Sample rulesets can be found in [.filename]#/usr/shared/examples/ipfilter#.
+本節說明用來建立具狀態規則的 IPF 規則語法。建立規則時請注意，除非規則中有 `quick` 關鍵字，否則每條規則會依序讀取，以_最後一個符合的規則_為準。這表示即使第一條符合的規則是 `pass`，若後面還有符合的 `block` 規則，封包仍然會被丟棄。範例規則集可在 [.filename]#/usr/shared/examples/ipfilter# 中找到。
 
-When creating rules, a `#` character is used to mark the start of a comment and may appear at the end of a rule, to explain that rule's function, or on its own line. Any blank lines are ignored.
+建立規則時，`#` 字元用來標記註解的開頭，可以出現在規則的結尾以說明該規則的功能，也可以獨立成一行。空白行會被忽略。
 
-The keywords which are used in rules must be written in a specific order, from left to right. Some keywords are mandatory while others are optional. Some keywords have sub-options which may be keywords themselves and also include more sub-options. The keyword order is as follows, where the words shown in uppercase represent a variable and the words shown in lowercase must precede the variable that follows it:
+規則中使用的關鍵字必須依特定順序由左到右撰寫。部分關鍵字為必要，其餘則為選用。有些關鍵字有子選項，而子選項本身也可能是關鍵字並包含更多子選項。關鍵字的順序如下，其中大寫字母代表變數，小寫字母則必須放在其後方變數之前：
 
 _ACTION DIRECTION OPTIONS proto PROTO_TYPE from SRC_ADDR SRC_PORT to DST_ADDR DST_PORT TCP_FLAG|ICMP_TYPE keep state STATE_
 
-This section describes each of these keywords and their options. It is not an exhaustive list of every possible option. Refer to man:ipf[5] for a complete description of the rule syntax that can be used when creating IPF rules and examples for using each keyword.
+本節說明每個關鍵字及其選項，但並非所有可能選項的完整清單。關於建立 IPF 規則時可使用的完整規則語法說明與各關鍵字的使用範例，請參閱 man:ipf[5]。
 
 ACTION::
-The action keyword indicates what to do with the packet if it matches that rule. Every rule _must_ have an action. The following actions are recognized:
+動作 (action) 關鍵字指示封包符合該規則時要執行的操作。每條規則都__必須__有一個動作。以下為可辨識的動作：
 +
-`block`: drops the packet.
+`block`：丟棄封包。
 +
-`pass`: allows the packet.
+`pass`：允許封包通過。
 +
-`log`: generates a log record.
+`log`：產生一筆記錄。
 +
-`count`: counts the number of packets and bytes which can provide an indication of how often a rule is used.
+`count`：計算封包數量與位元組數，可用來了解某條規則的使用頻率。
 +
-`auth`: queues the packet for further processing by another program.
+`auth`：將封包排入佇列，交由其他程式進一步處理。
 +
-`call`: provides access to functions built into IPF that allow more complex actions.
+`call`：存取 IPF 內建的函式，以執行更複雜的動作。
 +
-`decapsulate`: removes any headers in order to process the contents of the packet.
+`decapsulate`：移除所有標頭，以便處理封包的內容。
 
 DIRECTION::
-Next, each rule must explicitly state the direction of traffic using one of these keywords:
+接著，每條規則必須使用以下其中一個關鍵字明確指定流量方向：
 +
-`in`: the rule is applied against an inbound packet.
+`in`：此規則套用於傳入的封包。
 +
-`out`: the rule is applied against an outbound packet.
+`out`：此規則套用於傳出的封包。
 +
-`all`: the rule applies to either direction.
+`all`：此規則同時套用於兩個方向。
 +
-If the system has multiple interfaces, the interface can be specified along with the direction. An example would be `in on fxp0`.
+若系統有多個網路介面，可以在方向之後指定介面。例如 `in on fxp0`。
 
 OPTIONS::
-Options are optional. However, if multiple options are specified, they must be used in the order shown here.
+選項為非必要項目。不過，若指定多個選項，必須按此處列出的順序使用。
 +
-`log`: when performing the specified ACTION, the contents of the packet's headers will be written to the man:ipl[4] packet log pseudo-device.
+`log`：執行指定的 ACTION 時，封包標頭的內容會被寫入 man:ipl[4] 封包記錄虛擬裝置。
 +
-`quick`: if a packet matches this rule, the ACTION specified by the rule occurs and no further processing of any following rules will occur for this packet.
+`quick`：若封包符合此規則，即執行規則指定的 ACTION，不再繼續處理後續的規則。
 +
-`on`: must be followed by the interface name as displayed by man:ifconfig[8]. The rule will only match if the packet is going through the specified interface in the specified direction.
+`on`：後面必須接 man:ifconfig[8] 所顯示的介面名稱。只有當封包以指定方向通過指定介面時，此規則才會符合。
 +
-When using the `log` keyword, the following qualifiers may be used in this order:
+使用 `log` 關鍵字時，可按以下順序使用這些修飾詞：
 +
-`body`: indicates that the first 128 bytes of the packet contents will be logged after the headers.
+`body`：表示在標頭之後，會一併記錄封包內容的前 128 位元組。
 +
-`first`: if the `log` keyword is being used in conjunction with a `keep state` option, this option is recommended so that only the triggering packet is logged and not every packet which matches the stateful connection.
+`first`：若 `log` 關鍵字與 `keep state` 選項搭配使用，建議加上此選項，這樣只會記錄觸發的封包，而非每個符合該狀態連線的封包。
 +
-Additional options are available to specify error return messages. Refer to man:ipf[5] for more details.
+此外還有其他選項可用來指定錯誤回傳訊息，詳情請參閱 man:ipf[5]。
 
 PROTO_TYPE::
-The protocol type is optional. However, it is mandatory if the rule needs to specify a SRC_PORT or a DST_PORT as it defines the type of protocol. When specifying the type of protocol, use the `proto` keyword followed by either a protocol number or name from [.filename]#/etc/protocols#. Example protocol names include `tcp`, `udp`, or `icmp`. If PROTO_TYPE is specified but no SRC_PORT or DST_PORT is specified, all port numbers for that protocol will match that rule.
+通訊協定類型為選用項目。但如果規則需要指定 SRC_PORT 或 DST_PORT，由於需定義通訊協定類型，此欄位就變成必要的。指定通訊協定類型時，請使用 `proto` 關鍵字，後接通訊協定編號或 [.filename]#/etc/protocols# 中的名稱。常見的通訊協定名稱有 `tcp`、`udp` 或 `icmp`。若指定了 PROTO_TYPE 但未指定 SRC_PORT 或 DST_PORT，該通訊協定的所有連接埠號碼都會符合此規則。
 
 SRC_ADDR::
-The `from` keyword is mandatory and is followed by a keyword which represents the source of the packet. The source can be a hostname, an IP address followed by the CIDR mask, an address pool, or the keyword `all`. Refer to man:ipf[5] for examples.
+`from` 關鍵字為必要項目，後面接代表封包來源的關鍵字。來源可以是主機名稱、IP 位址加 CIDR 遮罩、位址集區，或關鍵字 `all`。範例請參閱 man:ipf[5]。
 +
-There is no way to match ranges of IP addresses which do not express themselves easily using the dotted numeric form / mask-length notation. The package:net-mgmt/ipcalc[] package or port may be used to ease the calculation of the CIDR mask. Additional information is available at the utility's web page: http://jodies.de/ipcalc[http://jodies.de/ipcalc].
+對於無法輕易用「點分十進位 / 遮罩長度」表示法表示的 IP 位址範圍，沒有直接的比對方式。可使用 package:net-mgmt/ipcalc[] 套件或 Port 來簡化 CIDR 遮罩的計算。更多資訊可在該工具的網頁取得：http://jodies.de/ipcalc[http://jodies.de/ipcalc]。
 
 SRC_PORT::
-The port number of the source is optional. However, if it is used, it requires PROTO_TYPE to be first defined in the rule. The port number must also be preceded by the `proto` keyword.
+來源連接埠號碼為選用項目。但若要使用，規則中必須先定義 PROTO_TYPE。連接埠號碼前面也必須有 `proto` 關鍵字。
 +
-A number of different comparison operators are supported: `=` (equal to), `!=` (not equal to), `<` (less than), `>` (greater than), `<=` (less than or equal to), and `>=` (greater than or equal to).
+支援多種比較運算子：`=`（等於）、`!=`（不等於）、`<`（小於）、`>`（大於）、`<=`（小於或等於）、`>=`（大於或等於）。
 +
-To specify port ranges, place the two port numbers between `<>` (less than and greater than ), `><` (greater than and less than ), or `:` (greater than or equal to and less than or equal to).
+要指定連接埠範圍，請將兩個連接埠號碼放在 `<>`（小於且大於）、`><`（大於且小於）或 `:`（大於或等於且小於或等於）之間。
 
 DST_ADDR::
-The `to` keyword is mandatory and is followed by a keyword which represents the destination of the packet. Similar to SRC_ADDR, it can be a hostname, an IP address followed by the CIDR mask, an address pool, or the keyword `all`.
+`to` 關鍵字為必要項目，後面接代表封包目的地的關鍵字。與 SRC_ADDR 類似，可以是主機名稱、IP 位址加 CIDR 遮罩、位址集區，或關鍵字 `all`。
 
 DST_PORT::
-Similar to SRC_PORT, the port number of the destination is optional. However, if it is used, it requires PROTO_TYPE to be first defined in the rule. The port number must also be preceded by the `proto` keyword.
+與 SRC_PORT 類似，目的地連接埠號碼為選用項目。但若要使用，規則中必須先定義 PROTO_TYPE。連接埠號碼前面也必須有 `proto` 關鍵字。
 
 TCP_FLAG|ICMP_TYPE::
-If `tcp` is specified as the PROTO_TYPE, flags can be specified as letters, where each letter represents one of the possible TCP flags used to determine the state of a connection. Possible values are: `S` (SYN), `A` (ACK), `P` (PSH), `F` (FIN), `U` (URG), `R` (RST), `C` (CWN), and `E` (ECN).
+若 PROTO_TYPE 指定為 `tcp`，可以用字母來指定旗標，每個字母代表一個用來判斷連線狀態的 TCP 旗標。可用的值有：`S` (SYN)、`A` (ACK)、`P` (PSH)、`F` (FIN)、`U` (URG)、`R` (RST)、`C` (CWN) 及 `E` (ECN)。
 +
-If `icmp` is specified as the PROTO_TYPE, the ICMP type to match can be specified. Refer to man:ipf[5] for the allowable types.
+若 PROTO_TYPE 指定為 `icmp`，可以指定要比對的 ICMP 類型。可用的類型請參閱 man:ipf[5]。
 
 STATE::
-If a `pass` rule contains `keep state`, IPF will add an entry to its dynamic state table and allow subsequent packets that match the connection. IPF can track state for TCP, UDP, and ICMP sessions. Any packet that IPF can be certain is part of an active session, even if it is a different protocol, will be allowed.
+若 `pass` 規則包含 `keep state`，IPF 會在其動態狀態表中新增一筆記錄，並允許後續符合該連線的封包通過。IPF 可追蹤 TCP、UDP 及 ICMP 工作階段的狀態。任何 IPF 能確定屬於進行中工作階段的封包，即使使用不同的通訊協定，也會被允許通過。
 +
-In IPF, packets destined to go out through the interface connected to the public Internet are first checked against the dynamic state table. If the packet matches the next expected packet comprising an active session conversation, it exits the firewall and the state of the session conversation flow is updated in the dynamic state table. Packets that do not belong to an already active session are checked against the outbound ruleset. Packets coming in from the interface connected to the public Internet are first checked against the dynamic state table. If the packet matches the next expected packet comprising an active session, it exits the firewall and the state of the session conversation flow is updated in the dynamic state table. Packets that do not belong to an already active session are checked against the inbound ruleset.
+在 IPF 中，要通過連接公開網際網路介面送出的封包，會先比對動態狀態表。若封包符合進行中工作階段交談的下一個預期封包，就會通過防火牆，同時動態狀態表中的工作階段交談流程狀態也會更新。不屬於任何進行中工作階段的封包，則會比對傳出規則集。從連接公開網際網路的介面傳入的封包，同樣先比對動態狀態表。若封包符合進行中工作階段的下一個預期封包，就通過防火牆並更新動態狀態表中的工作階段交談流程狀態。不屬於任何進行中工作階段的封包，則會比對傳入規則集。
 +
-Several keywords can be added after `keep state`. If used, these keywords set various options that control stateful filtering, such as setting connection limits or connection age. Refer to man:ipf[5] for the list of available options and their descriptions.
+`keep state` 之後可以加上多個關鍵字。這些關鍵字用來設定控制具狀態過濾的各種選項，例如連線數量限制或連線存活時間。可用選項及其說明請參閱 man:ipf[5]。
 
 === 範例規則集
 
-This section demonstrates how to create an example ruleset which only allows services matching `pass` rules and blocks all others.
+本節示範如何建立一個範例規則集，只允許符合 `pass` 規則的服務通過，其餘全部阻擋。
 
-FreeBSD uses the loopback interface ([.filename]#lo0#) and the IP address `127.0.0.1` for internal communication. The firewall ruleset must contain rules to allow free movement of these internally used packets:
+FreeBSD 使用迴路介面 ([.filename]#lo0#) 及 IP 位址 `127.0.0.1` 進行內部通訊。防火牆規則集必須包含規則，允許這些內部使用的封包自由傳輸：
 
 [.programlisting]
 ....
@@ -1712,9 +1712,9 @@ pass in quick on lo0 all
 pass out quick on lo0 all
 ....
 
-The public interface connected to the Internet is used to authorize and control access of all outbound and inbound connections. If one or more interfaces are cabled to private networks, those internal interfaces may require rules to allow packets originating from the LAN to flow between the internal networks or to the interface attached to the Internet. The ruleset should be organized into three major sections: any trusted internal interfaces, outbound connections through the public interface, and inbound connections through the public interface.
+連接到網際網路的公開介面用來授權及控制所有傳出與傳入連線的存取。若有一個或多個介面連接到私人網路，這些內部介面可能需要規則來允許來自區域網路的封包在內部網路之間流動，或是流向連接網際網路的介面。規則集應組織為三大區段：受信任的內部介面、通過公開介面的傳出連線、以及通過公開介面的傳入連線。
 
-These two rules allow all traffic to pass through a trusted LAN interface named [.filename]#xl0#:
+以下兩條規則允許所有流量通過名為 [.filename]#xl0# 的受信任區域網路介面：
 
 [.programlisting]
 ....
@@ -1723,9 +1723,9 @@ pass out quick on xl0 all
 pass in quick on xl0 all
 ....
 
-The rules for the public interface's outbound and inbound sections should have the most frequently matched rules placed before less commonly matched rules, with the last rule in the section blocking and logging all packets for that interface and direction.
+公開介面的傳出及傳入區段規則，應將最常被比對到的規則放在較少被比對到的規則之前，區段中的最後一條規則則負責阻擋並記錄該介面及方向的所有封包。
 
-This set of rules defines the outbound section of the public interface named [.filename]#dc0#. These rules keep state and identify the specific services that internal systems are authorized for public Internet access. All the rules use `quick` and specify the appropriate port numbers and, where applicable, destination addresses.
+以下這組規則定義名為 [.filename]#dc0# 的公開介面傳出區段。這些規則保留狀態，並指定內部系統被授權存取公開網際網路的特定服務。所有規則都使用 `quick`，並指定適當的連接埠號碼，以及在適用的情況下指定目的地位址。
 
 [.programlisting]
 ....
@@ -1770,7 +1770,7 @@ pass out quick on dc0 proto icmp from any to any icmp-type 8 keep state
 block out log first quick on dc0 all
 ....
 
-This example of the rules in the inbound section of the public interface blocks all undesirable packets first. This reduces the number of packets that are logged by the last rule.
+這個公開介面傳入區段的規則範例，會先阻擋所有不需要的封包，藉此減少被最後一條規則記錄的封包數量。
 
 [.programlisting]
 ....
@@ -1811,9 +1811,9 @@ block in log first quick on dc0 proto tcp/udp from any to any port = 139
 block in log first quick on dc0 proto tcp/udp from any to any port = 81
 ....
 
-Any time there are logged messages on a rule with the `log first` option, run `ipfstat -hio` to evaluate how many times the rule has been matched. A large number of matches may indicate that the system is under attack.
+只要有使用 `log first` 選項的規則產生記錄訊息，就應執行 `ipfstat -hio` 來評估該規則被比對到的次數。大量的比對次數可能表示系統正遭受攻擊。
 
-The rest of the rules in the inbound section define which connections are allowed to be initiated from the Internet. The last rule denies all connections which were not explicitly allowed by previous rules in this section.
+傳入區段的其餘規則定義了哪些連線可以從網際網路發起。最後一條規則則拒絕所有未被本區段先前規則明確允許的連線。
 
 [.programlisting]
 ....
@@ -1830,7 +1830,7 @@ block in log first quick on dc0 all
 
 === 設定 NAT
 
-To enable NAT, add these statements to [.filename]#/etc/rc.conf# and specify the name of the file containing the NAT rules:
+要啟用 NAT，請將以下敘述加入 [.filename]#/etc/rc.conf#，並指定包含 NAT 規則的檔案名稱：
 
 [.programlisting]
 ....
@@ -1839,38 +1839,38 @@ ipnat_enable="YES"
 ipnat_rules="/etc/ipnat.rules"
 ....
 
-NAT rules are flexible and can accomplish many different things to fit the needs of both commercial and home users. The rule syntax presented here has been simplified to demonstrate common usage. For a complete rule syntax description, refer to man:ipnat[5].
+NAT 規則相當靈活，可以達成許多不同的功能來滿足商業及家庭使用者的需求。此處呈現的規則語法已簡化，以示範常見用法。完整的規則語法說明請參閱 man:ipnat[5]。
 
-The basic syntax for a NAT rule is as follows, where `map` starts the rule and _IF_ should be replaced with the name of the external interface:
+NAT 規則的基本語法如下，其中 `map` 為規則的起始，_IF_ 應替換為外部介面的名稱：
 
 [.programlisting]
 ....
 map IF LAN_IP_RANGE -> PUBLIC_ADDRESS
 ....
 
-The _LAN_IP_RANGE_ is the range of IP addresses used by internal clients. Usually, it is a private address range such as `192.168.1.0/24`. The _PUBLIC_ADDRESS_ can either be the static external IP address or the keyword `0/32` which represents the IP address assigned to _IF_.
+_LAN_IP_RANGE_ 是內部用戶端使用的 IP 位址範圍，通常是私人位址範圍，例如 `192.168.1.0/24`。_PUBLIC_ADDRESS_ 可以是靜態的外部 IP 位址，或是關鍵字 `0/32`，代表指派給 _IF_ 的 IP 位址。
 
-In IPF, when a packet arrives at the firewall from the LAN with a public destination, it first passes through the outbound rules of the firewall ruleset. Then, the packet is passed to the NAT ruleset which is read from the top down, where the first matching rule wins. IPF tests each NAT rule against the packet's interface name and source IP address. When a packet's interface name matches a NAT rule, the packet's source IP address in the private LAN is checked to see if it falls within the IP address range specified in _LAN_IP_RANGE_. On a match, the packet has its source IP address rewritten with the public IP address specified by _PUBLIC_ADDRESS_. IPF posts an entry in its internal NAT table so that when the packet returns from the Internet, it can be mapped back to its original private IP address before being passed to the firewall rules for further processing.
+在 IPF 中，當封包從區域網路到達防火牆且目的地為公開位址時，會先通過防火牆規則集的傳出規則。接著封包被傳到 NAT 規則集，由上而下讀取，第一條符合的規則即生效。IPF 會將每條 NAT 規則與封包的介面名稱及來源 IP 位址進行比對。當封包的介面名稱符合某條 NAT 規則時，會檢查封包在私人區域網路中的來源 IP 位址是否落在 _LAN_IP_RANGE_ 指定的 IP 位址範圍內。若符合，封包的來源 IP 位址會被改寫為 _PUBLIC_ADDRESS_ 指定的公開 IP 位址。IPF 會在其內部 NAT 表中記錄一筆項目，這樣當封包從網際網路返回時，就能將它對應回原本的私人 IP 位址，再交給防火牆規則做進一步處理。
 
-For networks that have large numbers of internal systems or multiple subnets, the process of funneling every private IP address into a single public IP address becomes a resource problem. Two methods are available to relieve this issue.
+對於擁有大量內部系統或多個子網路的網路，將所有私人 IP 位址集中到單一公開 IP 位址的過程會成為資源問題。有兩種方法可以緩解此問題。
 
-The first method is to assign a range of ports to use as source ports. By adding the `portmap` keyword, NAT can be directed to only use source ports in the specified range:
+第一種方法是指派一個連接埠範圍作為來源連接埠。加上 `portmap` 關鍵字後，NAT 就只會使用指定範圍內的來源連接埠：
 
 [.programlisting]
 ....
 map dc0 192.168.1.0/24 -> 0/32 portmap tcp/udp 20000:60000
 ....
 
-Alternately, use the `auto` keyword which tells NAT to determine the ports that are available for use:
+或者，使用 `auto` 關鍵字讓 NAT 自行決定可用的連接埠：
 
 [.programlisting]
 ....
 map dc0 192.168.1.0/24 -> 0/32 portmap tcp/udp auto
 ....
 
-The second method is to use a pool of public addresses. This is useful when there are too many LAN addresses to fit into a single public address and a block of public IP addresses is available. These public addresses can be used as a pool from which NAT selects an IP address as a packet's address is mapped on its way out.
+第二種方法是使用一組公開位址集區。當區域網路位址太多而無法塞進單一公開位址，且有一整組公開 IP 位址可用時，這個方法就很實用。這些公開位址可作為集區使用，NAT 會在封包送出時從中選取一個 IP 位址來進行對應。
 
-The range of public IP addresses can be specified using a netmask or CIDR notation. These two rules are equivalent:
+公開 IP 位址的範圍可以使用子網路遮罩或 CIDR 表示法來指定。以下兩條規則是等效的：
 
 [.programlisting]
 ....
@@ -1878,23 +1878,23 @@ map dc0 192.168.1.0/24 -> 204.134.75.0/255.255.255.0
 map dc0 192.168.1.0/24 -> 204.134.75.0/24
 ....
 
-A common practice is to have a publically accessible web server or mail server segregated to an internal network segment. The traffic from these servers still has to undergo NAT, but port redirection is needed to direct inbound traffic to the correct server. For example, to map a web server using the internal address `10.0.10.25` to its public IP address of `20.20.20.5`, use this rule:
+常見的做法是將可公開存取的網頁伺服器或郵件伺服器隔離到內部網路區段。這些伺服器的流量仍然需要經過 NAT，但需要連接埠重新導向才能將傳入流量導到正確的伺服器。例如，要將使用內部位址 `10.0.10.25` 的網頁伺服器對應到其公開 IP 位址 `20.20.20.5`，請使用以下規則：
 
 [.programlisting]
 ....
 rdr dc0 20.20.20.5/32 port 80 -> 10.0.10.25 port 80
 ....
 
-If it is the only web server, this rule would also work as it redirects all external HTTP requests to `10.0.10.25`:
+如果這是唯一的網頁伺服器，以下規則也可以使用，因為它會將所有外部 HTTP 請求重新導向到 `10.0.10.25`：
 
 [.programlisting]
 ....
 rdr dc0 0.0.0.0/0 port 80 -> 10.0.10.25 port 80
 ....
 
-IPF has a built in FTP proxy which can be used with NAT. It monitors all outbound traffic for active or passive FTP connection requests and dynamically creates temporary filter rules containing the port number used by the FTP data channel. This eliminates the need to open large ranges of high order ports for FTP connections.
+IPF 有內建的 FTP 代理程式可搭配 NAT 使用。它會監控所有傳出流量中的主動或被動 FTP 連線請求，並動態建立包含 FTP 資料通道所用連接埠號碼的暫時過濾規則。這樣就不需要為 FTP 連線開啟大範圍的高位連接埠。
 
-In this example, the first rule calls the proxy for outbound FTP traffic from the internal LAN. The second rule passes the FTP traffic from the firewall to the Internet, and the third rule handles all non-FTP traffic from the internal LAN:
+以下範例中，第一條規則為來自內部區域網路的傳出 FTP 流量呼叫代理程式。第二條規則讓 FTP 流量從防火牆通過到網際網路，第三條規則則處理來自內部區域網路的所有非 FTP 流量：
 
 [.programlisting]
 ....
@@ -1903,9 +1903,9 @@ map dc0 0.0.0.0/0 -> 0/32 proxy port 21 ftp/tcp
 map dc0 10.0.10.0/29 -> 0/32
 ....
 
-The FTP `map` rules go before the NAT rule so that when a packet matches an FTP rule, the FTP proxy creates temporary filter rules to let the FTP session packets pass and undergo NAT. All LAN packets that are not FTP will not match the FTP rules but will undergo NAT if they match the third rule.
+FTP 的 `map` 規則必須放在 NAT 規則之前，這樣當封包符合 FTP 規則時，FTP 代理程式就會建立暫時過濾規則，讓 FTP 工作階段封包通過並進行 NAT。所有非 FTP 的區域網路封包不會符合 FTP 規則，但若符合第三條規則，仍會進行 NAT。
 
-Without the FTP proxy, the following firewall rules would instead be needed. Note that without the proxy, all ports above `1024` need to be allowed:
+若不使用 FTP 代理程式，則需要以下防火牆規則。請注意，沒有代理程式的情況下，必須允許所有 `1024` 以上的連接埠：
 
 [.programlisting]
 ....
@@ -1920,28 +1920,28 @@ pass out quick on rl0 proto tcp from any to any port > 1024 flags S keep state
 pass in quick on rl0 proto tcp from any to any port = 20 flags S keep state
 ....
 
-Whenever the file containing the NAT rules is edited, run `ipnat` with `-CF` to delete the current NAT rules and flush the contents of the dynamic translation table. Include `-f` and specify the name of the NAT ruleset to load:
+每當編輯包含 NAT 規則的檔案後，請以 `-CF` 執行 `ipnat` 來刪除目前的 NAT 規則並清除動態轉譯表的內容。加上 `-f` 並指定要載入的 NAT 規則集名稱：
 
 [source,shell]
 ....
 # ipnat -CF -f /etc/ipnat.rules
 ....
 
-To display the NAT statistics:
+顯示 NAT 統計資訊：
 
 [source,shell]
 ....
 # ipnat -s
 ....
 
-To list the NAT table's current mappings:
+列出 NAT 表目前的對應：
 
 [source,shell]
 ....
 # ipnat -l
 ....
 
-To turn verbose mode on and display information relating to rule processing and active rules and table entries:
+開啟詳細模式，顯示規則處理及作用中規則與表格項目的相關資訊：
 
 [source,shell]
 ....
@@ -1950,9 +1950,9 @@ To turn verbose mode on and display information relating to rule processing and 
 
 === 檢視 IPF 統計資訊
 
-IPF includes man:ipfstat[8] which can be used to retrieve and display statistics which are gathered as packets match rules as they go through the firewall. Statistics are accumulated since the firewall was last started or since the last time they were reset to zero using `ipf -Z`.
+IPF 包含 man:ipfstat[8]，可用來擷取並顯示封包通過防火牆時比對規則所收集的統計資訊。統計資料從防火牆上次啟動起，或上次以 `ipf -Z` 歸零後開始累積。
 
-The default `ipfstat` output looks like this:
+預設的 `ipfstat` 輸出如下所示：
 
 [source,shell]
 ....
@@ -1975,7 +1975,7 @@ input packets: blocked 99286 passed 1255609 nomatch 14686 counted 0
  Packet log flags set: (0)
 ....
 
-Several options are available. When supplied with either `-i` for inbound or `-o` for outbound, the command will retrieve and display the appropriate list of filter rules currently installed and in use by the kernel. To also see the rule numbers, include `-n`. For example, `ipfstat -on` displays the outbound rules table with rule numbers:
+有多個選項可用。指定 `-i` 代表傳入、`-o` 代表傳出時，指令會擷取並顯示目前安裝在核心中使用的對應過濾規則清單。要同時顯示規則編號，請加上 `-n`。例如，`ipfstat -on` 會顯示含有規則編號的傳出規則表：
 
 [source,shell]
 ....
@@ -1984,7 +1984,7 @@ Several options are available. When supplied with either `-i` for inbound or `-o
 @3 pass out quick on dc0 proto tcp/udp from any to any keep state
 ....
 
-Include `-h` to prefix each rule with a count of how many times the rule was matched. For example, `ipfstat -oh` displays the outbound internal rules table, prefixing each rule with its usage count:
+加上 `-h` 可在每條規則前面顯示該規則被比對到的次數。例如，`ipfstat -oh` 會顯示傳出內部規則表，每條規則前面附有使用次數：
 
 [source,shell]
 ....
@@ -1993,13 +1993,13 @@ Include `-h` to prefix each rule with a count of how many times the rule was mat
 430918 pass out quick on dc0 proto tcp/udp from any to any keep state
 ....
 
-To display the state table in a format similar to man:top[1], use `ipfstat -t`. When the firewall is under attack, this option provides the ability to identify and see the attacking packets. The optional sub-flags give the ability to select the destination or source IP, port, or protocol to be monitored in real time. Refer to man:ipfstat[8] for details.
+要以類似 man:top[1] 的格式顯示狀態表，請使用 `ipfstat -t`。當防火牆遭受攻擊時，此選項能幫助辨識並檢視攻擊封包。選用的子旗標可指定要即時監控的目的地或來源 IP、連接埠或通訊協定。詳情請參閱 man:ipfstat[8]。
 
 === IPF 日誌
 
-IPF provides `ipmon`, which can be used to write the firewall's logging information in a human readable format. It requires that `options IPFILTER_LOG` be first added to a custom kernel using the instructions in crossref:kernelconfig[kernelconfig,設定 FreeBSD 核心].
+IPF 提供 `ipmon`，可將防火牆的記錄資訊以人類可讀的格式寫出。使用前必須先依照 crossref:kernelconfig[kernelconfig,設定 FreeBSD 核心] 中的說明，將 `options IPFILTER_LOG` 加入自訂核心。
 
-This command is typically run in daemon mode in order to provide a continuous system log file so that logging of past events may be reviewed. Since FreeBSD has a built in man:syslogd[8] facility to automatically rotate system logs, the default [.filename]#rc.conf#`ipmon_flags` statement uses `-Ds`:
+此指令通常以常駐程式模式執行，以提供持續的系統記錄檔，方便事後檢閱過往事件。由於 FreeBSD 內建 man:syslogd[8] 機制可自動輪替系統記錄，預設的 [.filename]#rc.conf#`ipmon_flags` 設定使用 `-Ds`：
 
 [.programlisting]
 ....
@@ -2009,11 +2009,11 @@ ipmon_flags="-Ds" # D = start as daemon
                   # n = map IP & port to names
 ....
 
-Logging provides the ability to review, after the fact, information such as which packets were dropped, what addresses they came from, and where they were going. This information is useful in tracking down attackers.
+記錄功能讓您能事後檢閱哪些封包被丟棄、來自什麼位址、以及要送往何處等資訊，這些資訊對於追蹤攻擊者相當有用。
 
-Once the logging facility is enabled in [.filename]#rc.conf# and started with `service ipmon start`, IPF will only log the rules which contain the `log` keyword. The firewall administrator decides which rules in the ruleset should be logged and normally only deny rules are logged. It is customary to include the `log` keyword in the last rule in the ruleset. This makes it possible to see all the packets that did not match any of the rules in the ruleset.
+在 [.filename]#rc.conf# 中啟用記錄功能並以 `service ipmon start` 啟動後，IPF 只會記錄包含 `log` 關鍵字的規則。防火牆管理員決定規則集中哪些規則應該記錄，通常只記錄拒絕規則。慣例上會在規則集的最後一條規則中加入 `log` 關鍵字，這樣就能看到所有未符合規則集中任何規則的封包。
 
-By default, `ipmon -Ds` mode uses `local0` as the logging facility. The following logging levels can be used to further segregate the logged data:
+預設情況下，`ipmon -Ds` 模式使用 `local0` 作為記錄設施。以下記錄層級可用來進一步區隔記錄資料：
 
 [source,shell]
 ....
@@ -2023,56 +2023,56 @@ LOG_WARNING - packets logged which are also blocked
 LOG_ERR - packets which have been logged and which can be considered short due to an incomplete header
 ....
 
-In order to setup IPF to log all data to [.filename]#/var/log/ipfilter.log#, first create the empty file:
+要設定 IPF 將所有資料記錄到 [.filename]#/var/log/ipfilter.log#，請先建立空檔案：
 
 [source,shell]
 ....
 # touch /var/log/ipfilter.log
 ....
 
-Then, to write all logged messages to the specified file, add the following statement to [.filename]#/etc/syslog.conf#:
+接著，要將所有記錄訊息寫入指定檔案，請將以下敘述加入 [.filename]#/etc/syslog.conf#：
 
 [.programlisting]
 ....
 local0.* /var/log/ipfilter.log
 ....
 
-To activate the changes and instruct man:syslogd[8] to read the modified [.filename]#/etc/syslog.conf#, run `service syslogd reload`.
+要啟用變更並指示 man:syslogd[8] 讀取修改後的 [.filename]#/etc/syslog.conf#，請執行 `service syslogd reload`。
 
-Do not forget to edit [.filename]#/etc/newsyslog.conf# to rotate the new log file.
+別忘了編輯 [.filename]#/etc/newsyslog.conf# 來輪替新的記錄檔。
 
-Messages generated by `ipmon` consist of data fields separated by white space. Fields common to all messages are:
+`ipmon` 產生的訊息由以空白分隔的資料欄位組成。所有訊息共通的欄位有：
 
-. The date of packet receipt.
-. The time of packet receipt. This is in the form HH:MM:SS.F, for hours, minutes, seconds, and fractions of a second.
-. The name of the interface that processed the packet.
-. The group and rule number of the rule in the format `@0:17`.
-. The action: `p` for passed, `b` for blocked, `S` for a short packet, `n` did not match any rules, and `L` for a log rule.
-. The addresses written as three fields: the source address and port separated by a comma, the -> symbol, and the destination address and port. For example: `209.53.17.22,80 -> 198.73.220.17,1722`.
-. `PR` followed by the protocol name or number: for example, `PR tcp`.
-. `len` followed by the header length and total length of the packet: for example, `len 20 40`.
+. 封包接收日期。
+. 封包接收時間，格式為 HH:MM:SS.F，分別代表時、分、秒及秒的小數部分。
+. 處理該封包的介面名稱。
+. 規則的群組及規則編號，格式為 `@0:17`。
+. 動作：`p` 代表通過、`b` 代表阻擋、`S` 代表短封包、`n` 代表未符合任何規則、`L` 代表記錄規則。
+. 位址以三個欄位呈現：來源位址與連接埠以逗號分隔、-> 符號、以及目的地位址與連接埠。例如：`209.53.17.22,80 -> 198.73.220.17,1722`。
+. `PR` 後接通訊協定名稱或編號，例如 `PR tcp`。
+. `len` 後接標頭長度與封包總長度，例如 `len 20 40`。
 
-If the packet is a TCP packet, there will be an additional field starting with a hyphen followed by letters corresponding to any flags that were set. Refer to man:ipf[5] for a list of letters and their flags.
+若封包為 TCP 封包，會有一個額外欄位，以連字號開頭，後接對應已設定旗標的字母。字母與旗標的對照清單請參閱 man:ipf[5]。
 
-If the packet is an ICMP packet, there will be two fields at the end: the first always being "icmp" and the next being the ICMP message and sub-message type, separated by a slash. For example: `icmp 3/3` for a port unreachable message.
+若封包為 ICMP 封包，結尾會有兩個欄位：第一個固定為 "icmp"，第二個為 ICMP 訊息類型及子訊息類型，以斜線分隔。例如：`icmp 3/3` 代表連接埠不可達訊息。
 
 [[firewalls-blacklistd]]
 == Blacklistd
 
-Blacklistd is a daemon listening to sockets to receive notifications from other daemons about connection attempts that failed or were successful. It is most widely used in blocking too many connection attempts on open ports. A prime example is SSH running on the internet getting a lot of requests from bots or scripts trying to guess passwords and gain access. Using blacklistd, the daemon can notify the firewall to create a filter rule to block excessive connection attempts from a single source after a number of tries. Blacklistd was first developed on NetBSD and appeared there in version 7. FreeBSD 11 imported blacklistd from NetBSD.
+Blacklistd 是一個監聽 socket 的常駐程式，用來接收其他常駐程式所發出關於連線嘗試成功或失敗的通知。它最常用於阻擋對開放連接埠的過多連線嘗試。一個典型的例子是在網際網路上執行的 SSH，會收到大量來自機器人或指令碼嘗試猜密碼以取得存取權限的請求。透過 Blacklistd，常駐程式可以通知防火牆建立過濾規則，在嘗試次數達到上限後，阻擋來自單一來源的過多連線嘗試。Blacklistd 最初在 NetBSD 開發，於該系統 7 版首次出現。FreeBSD 11 從 NetBSD 引入了 Blacklistd。
 
-This chapter describes how to set up blacklistd, configure it, and provides examples on how to use it. Readers should be familiar with basic firewall concepts like rules. For details, refer to the firewall chapter. PF is used in the examples, but other firewalls available on FreeBSD should be able to work with blacklistd, too.
+本章說明如何設定及使用 Blacklistd，並提供使用範例。讀者應熟悉防火牆的基本概念如規則等。詳情請參閱防火牆章節。範例中使用 PF，但 FreeBSD 上其他可用的防火牆也能與 Blacklistd 搭配使用。
 
 === 開啟 Blacklistd
 
-The main configuration for blacklistd is stored in man:blacklistd.conf[5]. Various command line options are also available to change blacklistd's run-time behavior. Persistent configuration across reboots should be stored in [.filename]#/etc/blacklistd.conf#. To enable the daemon during system boot, add a `blacklistd_enable` line to [.filename]#/etc/rc.conf# like this:
+Blacklistd 的主要設定存放在 man:blacklistd.conf[5]。另有多個命令列選項可變更 Blacklistd 的執行時期行為。要跨重開機保留的持久設定應存放在 [.filename]#/etc/blacklistd.conf# 中。要在系統開機時啟用此常駐程式，請將 `blacklistd_enable` 這行加入 [.filename]#/etc/rc.conf#，如下所示：
 
 [source,shell]
 ....
 # sysrc blacklistd_enable=yes
 ....
 
-To start the service manually, run this command:
+要手動啟動服務，請執行以下指令：
 
 [source,shell]
 ....
@@ -2081,11 +2081,11 @@ To start the service manually, run this command:
 
 === 建立 Blacklistd 規則集
 
-Rules for blacklistd are configured in man:blacklistd.conf[5] with one entry per line. Each rule contains a tuple separated by spaces or tabs. Rules either belong to a `local` or a `remote`, which applies to the machine where blacklistd is running or an outside source, respectively.
+Blacklistd 的規則在 man:blacklistd.conf[5] 中設定，每行一筆。每條規則包含以空格或 Tab 分隔的欄位組合。規則分為 `local`（本地）或 `remote`（遠端），分別套用於 Blacklistd 所執行的機器或外部來源。
 
 ==== 本地規則
 
-An example blacklistd.conf entry for a local rule looks like this:
+以下是本地規則在 blacklistd.conf 中的設定範例：
 
 [.programlisting]
 ....
@@ -2093,24 +2093,24 @@ An example blacklistd.conf entry for a local rule looks like this:
 ssh             stream  *       *               *       3       24h
 ....
 
-All rules that follow the `[local]` section are treated as local rules (which is the default), applying to the local machine. When a `[remote]` section is encountered, all rules that follow it are handled as remote machine rules.
+所有在 `[local]` 區段之後的規則都視為本地規則（這是預設值），套用於本機。當遇到 `[remote]` 區段時，其後的所有規則都會當作遠端機器規則處理。
 
-Seven fields define a rule separated by either tabs or spaces. The first four fields identify the traffic that should be blacklisted. The three fields that follow define backlistd's behavior. Wildcards are denoted as asterisks (`*`), matching anything in this field. The first field defines the location. In local rules, these are the network ports. The syntax for the location field is as follows:
+每條規則由七個欄位組成，以 Tab 或空格分隔。前四個欄位用來辨識應被列入黑名單的流量，後三個欄位定義 Blacklistd 的行為。萬用字元以星號 (`*`) 表示，代表該欄位可比對任何值。第一個欄位定義位置，在本地規則中就是網路連接埠。位置欄位的語法如下：
 
 [.programlisting]
 ....
 [address|interface][/mask][:port]
 ....
 
-Adressses can be specified as IPv4 in numeric format or IPv6 in square brackets. An interface name like `_em0_` can also be used.
+位址可以用數字格式的 IPv4 或方括號括住的 IPv6 指定。也可以使用介面名稱，例如 `_em0_`。
 
-The socket type is defined by the second field. TCP sockets are of type `stream`, whereas UDP is denoted as `dgram`. The example above uses TCP, since SSH is using that protocol.
+第二個欄位定義 socket 類型。TCP socket 的類型為 `stream`，UDP 則以 `dgram` 表示。上述範例使用 TCP，因為 SSH 使用該通訊協定。
 
-A protocol can be used in the third field of a blacklistd rule. The following protocols can be used: `tcp`, `udp`, `tcp6`, `udp6`, or numeric. A wildcard, like in the example, is typically used to match all protocols unless there is a reason to distinguish traffic by a certain protocol.
+第三個欄位可指定通訊協定。可使用的通訊協定有：`tcp`、`udp`、`tcp6`、`udp6` 或數字編號。除非有必要依特定通訊協定區分流量，否則通常使用萬用字元來比對所有通訊協定，如同範例所示。
 
-In the fourth field, the effective user or owner of the daemon process that is reporting the event is defined. The username or UID can be used here, as well as a wildcard (see example rule above).
+第四個欄位定義回報事件的常駐程式程序之有效使用者或擁有者。此處可使用使用者名稱或 UID，也可使用萬用字元（請參考上述規則範例）。
 
-The packet filter rule name is declared by the fifth field, which starts the behavior part of the rule. By default, blacklistd puts all blocks under a pf anchor called `blacklistd` in [.filename]#pf.conf# like this:
+第五個欄位宣告封包過濾器的規則名稱，這也是規則行為部分的起始。預設情況下，Blacklistd 會將所有阻擋規則放在 [.filename]#pf.conf# 中名為 `blacklistd` 的 pf anchor 底下，如下所示：
 
 [.programlisting]
 ....
@@ -2119,16 +2119,16 @@ block in
 pass out
 ....
 
-For separate blacklists, an anchor name can be used in this field. In other cases, the wildcard will suffice. When a name starts with a hyphen (`-`) it means that an anchor with the default rule name prepended should be used. A modified example from the above using the hyphen would look like this:
+若要使用不同的黑名單，可以在此欄位指定 anchor 名稱。其他情況下使用萬用字元即可。當名稱以連字號 (`-`) 開頭時，表示應使用預設規則名稱加上此名稱的 anchor。以下是使用連字號的修改範例：
 
 [.programlisting]
 ....
 ssh             stream  *       *               -ssh       3       24h
 ....
 
-With such a rule, any new blacklist rules are added to an anchor called `blacklistd-ssh`.
+使用這樣的規則，任何新的黑名單規則都會被加入名為 `blacklistd-ssh` 的 anchor。
 
-To block whole subnets for a single rule violation, a `/` in the rule name can be used. This causes the remaining portion of the name to be interpreted as the mask to be applied to the address specified in the rule. For example, this rule would block every address adjoining `/24`.
+要因單一規則違規而阻擋整個子網路，可在規則名稱中使用 `/`。這會使名稱的剩餘部分被解讀為套用在規則中指定位址上的遮罩。例如，以下規則會阻擋 `/24` 範圍內的所有位址。
 
 [.programlisting]
 ....
@@ -2137,20 +2137,20 @@ To block whole subnets for a single rule violation, a `/` in the rule name can b
 
 [NOTE]
 ====
-It is important to specify the proper protocol here. IPv4 and IPv6 treat /24 differently, that is the reason why `*` cannot be used in the third field for this rule.
+此處務必指定正確的通訊協定。IPv4 和 IPv6 對 /24 的解讀不同，這就是為什麼此規則的第三個欄位不能使用 `*` 的原因。
 ====
 
-This rule defines that if any one host in that network is misbehaving, everything else on that network will be blocked, too.
+此規則表示只要該網路中有任何一台主機行為異常，該網路中的其他所有主機也會被阻擋。
 
-The sixth field, called `nfail`, sets the number of login failures required to blacklist the remote IP in question. When a wildcard is used at this position, it means that blocks will never happen. In the example rule above, a limit of three is defined meaning that after three attempts to log into SSH on one connection, the IP is blocked.
+第六個欄位稱為 `nfail`，設定將該遠端 IP 列入黑名單所需的登入失敗次數。若此位置使用萬用字元，表示永遠不會進行阻擋。上述範例規則中定義的限制為三次，表示在同一連線中嘗試登入 SSH 三次後，該 IP 就會被阻擋。
 
-The last field in a blacklistd rule definition specifies how long a host is blacklisted. The default unit is seconds, but suffixes like `m`, `h`, and `d` can also be specified for minutes, hours, and days, respectively.
+Blacklistd 規則定義中的最後一個欄位指定主機被列入黑名單的時間長度。預設單位為秒，但也可以使用 `m`、`h` 及 `d` 字尾分別代表分鐘、小時和天。
 
-The example rule in its entirety means that after three times authenticating to SSH will result in a new PF block rule for that host. Rule matches are performed by first checking local rules one after another, from most specific to least specific. When a match occurs, the `remote` rules are applied and the name, `nfail`, and disable fields are changed by the `remote` rule that matched.
+完整來看，此範例規則表示對 SSH 進行三次驗證失敗後，就會為該主機產生一條新的 PF 阻擋規則。規則比對的執行方式是先逐一檢查本地規則，從最具體的到最不具體的。當比對成功時，會套用 `remote` 規則，並由符合的 `remote` 規則變更名稱、`nfail` 及停用欄位。
 
 ==== 遠端規則
 
-Remote rules are used to specify how blacklistd changes its behavior depending on the remote host currently being evaluated. Each field in a remote rule is the same as in a local rule. The only difference is in the way blacklistd is using them. To explain it, this example rule is used:
+遠端規則用來指定 Blacklistd 依目前評估的遠端主機如何變更其行為。遠端規則中的每個欄位與本地規則相同，唯一的差異在於 Blacklistd 使用它們的方式。以下範例規則用來說明此概念：
 
 [.programlisting]
 ....
@@ -2158,17 +2158,17 @@ Remote rules are used to specify how blacklistd changes its behavior depending o
 203.0.113.128/25 *      *       *               =/25    =       48h
 ....
 
-The address field can be an IP address (either v4 or v6), a port or both. This allows setting special rules for a specific remote address range like in this example. The fields for type, protocol and owner are identically interpreted as in the local rule.
+位址欄位可以是 IP 位址（v4 或 v6）、連接埠或兩者皆有。這使得可以像此範例一樣，為特定遠端位址範圍設定特殊規則。類型、通訊協定及擁有者欄位的解讀方式與本地規則完全相同。
 
-The name fields is different though: the equal sign (`=`) in a remote rule tells blacklistd to use the value from the matching local rule. It means that the firewall rule entry is taken and the `/25` prefix (a netmask of `255.255.255.128`) is added. When a connection from that address range is blacklisted, the entire subnet is affected. A PF anchor name can also be used here, in which case blacklistd will add rules for this address block to the anchor of that name. The default table is used when a wildcard is specified.
+但名稱欄位有所不同：遠端規則中的等號 (`=`) 告訴 Blacklistd 使用符合的本地規則的值。這表示會取用防火牆規則項目，並加上 `/25` 前置碼（子網路遮罩 `255.255.255.128`）。當來自該位址範圍的連線被列入黑名單時，整個子網路都會受到影響。此處也可使用 PF anchor 名稱，在這種情況下，Blacklistd 會將此位址區塊的規則加入該名稱的 anchor。指定萬用字元時會使用預設表格。
 
-A custom number of failures in the `nfail` column can be defined for an address. This is useful for exceptions to a specific rule, to maybe allow someone a less strict application of rules or a bit more leniency in login tries. Blocking is disabled when an asterisk is used in this sixth field.
+可以為某個位址在 `nfail` 欄位自訂失敗次數。這對於特定規則的例外狀況相當實用，例如對某些對象套用較寬鬆的規則或給予更多登入嘗試機會。當此第六個欄位使用星號時，阻擋功能會被停用。
 
-Remote rules allow a stricter enforcement of limits on attempts to log in compared to attempts coming from a local network like an office.
+與來自辦公室等區域網路的嘗試相比，遠端規則允許對登入嘗試實施更嚴格的限制。
 
 === Blacklistd 客戶端設定
 
-There are a few software packages in FreeBSD that can utilize blacklistd's functionality. The two most prominent ones are man:ftpd[8] and man:sshd[8] to block excessive connection attempts. To activate blacklistd in the SSH daemon, add the following line to [.filename]#/etc/ssh/sshd_config#:
+FreeBSD 中有幾個軟體套件可以利用 Blacklistd 的功能。其中最主要的兩個是 man:ftpd[8] 及 man:sshd[8]，用來阻擋過多的連線嘗試。要在 SSH 常駐程式中啟用 Blacklistd，請將以下行加入 [.filename]#/etc/ssh/sshd_config#：
 
 [.programlisting]
 ....
@@ -2177,18 +2177,18 @@ UseBlacklist yes
 
 接著重新啟動 sshd 來使變更生效。
 
-Blacklisting for man:ftpd[8] is enabled using `-B`, either in [.filename]#/etc/inetd.conf# or as a flag in [.filename]#/etc/rc.conf# like this:
+man:ftpd[8] 的黑名單功能透過 `-B` 啟用，可在 [.filename]#/etc/inetd.conf# 中設定，或作為 [.filename]#/etc/rc.conf# 中的旗標，如下所示：
 
 [.programlisting]
 ....
 ftpd_flags="-B"
 ....
 
-That is all that is needed to make these programs talk to blacklistd.
+以上就是讓這些程式與 Blacklistd 溝通所需的全部設定。
 
 === Blacklistd 管理
 
-Blacklistd provides the user with a management utility called man:blacklistctl[8]. It displays blocked addresses and networks that are blacklisted by the rules defined in man:blacklistd.conf[5]. To see the list of currently blocked hosts, use `dump` combined with `-b` like this.
+Blacklistd 提供一個名為 man:blacklistctl[8] 的管理工具。它會顯示被 man:blacklistd.conf[5] 中定義的規則列入黑名單的已阻擋位址及網路。要檢視目前被阻擋的主機清單，請搭配使用 `dump` 與 `-b`，如下所示。
 
 [source,shell]
 ....
@@ -2197,9 +2197,9 @@ Blacklistd provides the user with a management utility called man:blacklistctl[8
 213.0.123.128/25:22   OK      6/3     2019/06/08 14:30:19
 ....
 
-This example shows that there were 6 out of three permitted attempts on port 22 coming from the address range `213.0.123.128/25`. There are more attempts listed than are allowed because SSH allows a client to try multiple logins on a single TCP connection. A connection that is currently going on is not stopped by blacklistd. The last connection attempt is listed in the `last access` column of the output.
+此範例顯示來自位址範圍 `213.0.123.128/25` 在連接埠 22 上，在允許的三次中已有六次嘗試。列出的嘗試次數比允許的多，是因為 SSH 允許用戶端在單一 TCP 連線中嘗試多次登入。目前進行中的連線不會被 Blacklistd 中斷。最後一次連線嘗試列在輸出的 `last access` 欄位中。
 
-To see the remaining time that this host will be on the blacklist, add `-r` to the previous command.
+要查看此主機在黑名單上的剩餘時間，請在前述指令中加上 `-r`。
 
 [source,shell]
 ....
@@ -2208,11 +2208,11 @@ To see the remaining time that this host will be on the blacklist, add `-r` to t
 213.0.123.128/25:22   OK      6/3     36s
 ....
 
-In this example, there are 36s seconds left until this host will not be blocked any more.
+在此範例中，還剩 36 秒此主機就不再被阻擋。
 
 === 從封鎖清單移除主機
 
-Sometimes it is necessary to remove a host from the block list before the remaining time expires. Unfortunately, there is no functionality in blacklistd to do that. However, it is possible to remove the address from the PF table using pfctl. For each blocked port, there is a child anchor inside the blacklistd anchor defined in [.filename]#/etc/pf.conf#. For example, if there is a child anchor for blocking port 22 it is called `blacklistd/22`. There is a table inside that child anchor that contains the blocked addresses. This table is called port followed by the port number. In this example, it would be called `port22`. With that information at hand, it is now possible to use man:pfctl[8] to display all addresses listed like this:
+有時候需要在剩餘時間到期前將主機從封鎖清單中移除。很遺憾，Blacklistd 本身沒有提供這項功能。不過，可以使用 pfctl 從 PF 表格中移除位址。每個被阻擋的連接埠在 [.filename]#/etc/pf.conf# 中定義的 blacklistd anchor 底下都有一個子 anchor。例如，阻擋連接埠 22 的子 anchor 稱為 `blacklistd/22`。該子 anchor 中有一個包含被阻擋位址的表格，表格名稱為 port 加上連接埠號碼。以此範例而言，表格名稱為 `port22`。有了這些資訊，就可以使用 man:pfctl[8] 顯示所有被列出的位址，如下所示：
 
 [source,shell]
 ....
@@ -2222,11 +2222,11 @@ Sometimes it is necessary to remove a host from the block list before the remain
 ...
 ....
 
-After identifying the address to be unblocked from the list, the following command removes it from the list:
+找出要從清單中解除封鎖的位址後，以下指令可將其從清單中移除：
 
 [source,shell]
 ....
 # pfctl -a blacklistd/22 -T delete 213.0.123.128/25
 ....
 
-The address is now removed from PF, but will still show up in the blacklistctl list, since it does not know about any changes made in PF. The entry in blacklistd's database will eventually expire and be removed from its output eventually. The entry will be added again if the host is matching one of the block rules in blacklistd again.
+該位址現在已從 PF 中移除，但仍會出現在 blacklistctl 清單中，因為它不知道 PF 中所做的變更。Blacklistd 資料庫中的項目最終會過期並從輸出中移除。若該主機再次符合 Blacklistd 中的某條阻擋規則，該項目將會再次被加入。


### PR DESCRIPTION
## Summary

- Complete the zh-TW translation for the Firewalls chapter (Chapter 33)
- Translate all remaining English sections: PF rulesets, IPFW rules/NAT, IPFILTER syntax/NAT, and Blacklistd
- Previously ~40-50% was translated; now fully translated

## Notes

- File: `documentation/content/zh-tw/books/handbook/firewalls/_index.adoc`
- Section headings were already translated; this PR fills in all the English prose that remained
- Terminology consistent with existing zh-TW translations