### PR TITLE
handbook: update outdated version references

### DIFF
--- a/documentation/content/en/books/handbook/bsdinstall/_index.adoc
+++ b/documentation/content/en/books/handbook/bsdinstall/_index.adoc
@@ -1044,7 +1044,7 @@ Here is a summary of the services that can be enabled in this menu:
 * `local_unbound` - Enable the DNS local unbound. It is necessary to keep in mind that this is a configuration only meant for use as a local caching forwarding resolver. If the objective is to set up a resolver for the entire network, install package:dns/unbound[].
 * `sshd` - The Secure Shell (SSH) daemon is used to remotely access a system over an encrypted connection. Only enable this service if the system should be available for remote logins.
 * `moused` - Enable this service if the mouse will be used from the command-line system console.
-* `ntpdate` - Enable automatic clock synchronization at boot time. Note that the functionality of this program is now available in the man:ntpd[8] daemon and the man:ntpdate[8] utility will soon be retired.
+* `ntpdate` - Enable automatic clock synchronization at boot time. Note that man:ntpdate[8] has been deprecated in favor of man:ntpd[8], which provides the same functionality.
 * `ntpd` - The Network Time Protocol (NTP) daemon for automatic clock synchronization. Enable this service when wanting to synchronise the system clock with a remote time server or pool.
 * `powerd` - System power control utility for power control and energy saving.
 * `dumpdev` - Crash dumps are useful when debugging issues with the system, so users are encouraged to enable them.

--- a/documentation/content/en/books/handbook/cutting-edge/_index.adoc
+++ b/documentation/content/en/books/handbook/cutting-edge/_index.adoc
@@ -818,7 +818,7 @@ A new checkout of the source is required.
 |`stable/_X_`
 |
 
-The Release version plus all additional development on that branch. _STABLE_ refers to the Applications Binary Interface (ABI) not changing, so software compiled for earlier versions still runs. For example, software compiled to run on FreeBSD 10.1 will still run on FreeBSD 10-STABLE compiled later.
+The Release version plus all additional development on that branch. _STABLE_ refers to the Applications Binary Interface (ABI) not changing, so software compiled for earlier versions still runs. For example, software compiled to run on FreeBSD 14.1 will still run on FreeBSD 14-STABLE compiled later.
 
 STABLE branches occasionally have bugs or incompatibilities which might affect users, although these are typically fixed quickly.
 

--- a/documentation/content/en/books/handbook/cutting-edge/_index.adoc
+++ b/documentation/content/en/books/handbook/cutting-edge/_index.adoc
@@ -818,7 +818,7 @@ A new checkout of the source is required.
 |`stable/_X_`
 |
 
-The Release version plus all additional development on that branch. _STABLE_ refers to the Applications Binary Interface (ABI) not changing, so software compiled for earlier versions still runs. For example, software compiled to run on FreeBSD 14.1 will still run on FreeBSD 14-STABLE compiled later.
+The Release version plus all additional development on that branch. _STABLE_ refers to the Applications Binary Interface (ABI) not changing, so software compiled for earlier versions still runs. For example, software compiled to run on FreeBSD {rel-legacy} will still run on FreeBSD {rel-legacy-major}-STABLE compiled later.
 
 STABLE branches occasionally have bugs or incompatibilities which might affect users, although these are typically fixed quickly.
 


### PR DESCRIPTION
Couple of things I noticed that are a bit out of date:

- The ntpdate entry in bsdinstall still says it "will soon be retired" — it's been deprecated for a while now, so I reworded it to just say that.
- The STABLE branch explanation in cutting-edge used FreeBSD 10.1 as the example, bumped it to 14.1.