### PR TITLE
website/features: fix hast to hastd under Capsicum

### DIFF
--- a/website/content/en/features.adoc
+++ b/website/content/en/features.adoc
@@ -101,7 +101,7 @@ Capsicum allows sandboxing of several programs that work within the "capabilitie
 
 * tcpdump
 * dhclient
-* hast
+* hastd
 * rwhod
 * kdump.
 


### PR DESCRIPTION
The Capsicum section on the features page lists "hast" but there is no hast(8) manual page. The correct name is hastd(8).

PR: 293950