### PR TITLE
faq: fix single-user mode boot instructions

### DIFF
--- a/documentation/content/en/books/faq/_index.adoc
+++ b/documentation/content/en/books/faq/_index.adoc
@@ -436,10 +436,10 @@ bindkey ^[[3~ delete-char # for xterm
 === I have forgotten the root password! What do I do?
 
 Do not panic!
-Restart the system, type `boot -s` at the `Boot:` prompt to enter single-user mode.
+Restart the system and select `Boot Single User` from the boot loader menu, or press `Escape` at the menu and type `boot -s` at the loader prompt, to enter single-user mode.
 At the question about the shell to use, hit kbd:[Enter] which will display a # prompt.
 Enter `mount -urw /` to remount the root file system read/write, then run `mount -a` to remount all the file systems.
-Run `passwd root` to change the `root` password then run man:exit[1] to continue booting.
+Run `passwd root` to change the `root` password then run `exit` to continue booting.
 
 [TIP]
 ====
@@ -458,7 +458,7 @@ For more information see the section about encrypted disks in the FreeBSD extref
 [[rcconf-readonly]]
 === I made a mistake in rc.conf, or another startup file, and now I cannot edit it because the file system is read-only. What should I do?
 
-Restart the system using `boot -s` at the loader prompt to enter single-user mode.
+Restart the system and select `Boot Single User` from the boot loader menu, or press `Escape` at the menu and type `boot -s` at the loader prompt, to enter single-user mode.
 When prompted for a shell pathname, press kbd:[Enter] and run `mount -urw /` to re-mount the root file system in read/write mode.
 You may also need to run `mount -a -t ufs` to mount the file system where your favorite editor is defined.
 If that editor is on a network file system, either configure the network manually before mounting the network file systems, or use an editor which resides on a local file system, such as man:ed[1].


### PR DESCRIPTION
The FAQ referenced a `Boot:` prompt which no longer appears in modern FreeBSD. The boot loader now presents a menu where users can select "Boot Single User" directly, or press Escape to reach the loader prompt.

Changes:
- Update both single-user boot instructions (forgot root password, read-only rc.conf) to describe the boot loader menu
- Simplify `man:exit[1]` to just `exit`

PR: 291048