### PR TITLE
status/2026Q1/lldb.adoc: Add report

### DIFF
--- a/website/content/en/status/report-2026-01-2026-03/lldb.adoc
+++ b/website/content/en/status/report-2026-01-2026-03/lldb.adoc
@@ -1,0 +1,28 @@
+=== LLDB Improvement on FreeBSD
+
+Links: +
+link:https://github.com/llvm/llvm-project/issues/180061[LLVM Meta Issue] URL: link:https://github.com/llvm/llvm-project/issues/180061[] +
+
+Contact: Minsoo Choo <minsoochoo0122@proton.me>
+
+Due to the licensing issue with GDB (GPLv3), FreeBSD has adopted LLVM, including LLDB, in its base system since FreeBSD 10.0.
+However, most kernel developers still rely on KGDB, a patched version of a recent GDB, to debug the kernel.
+This is partly a matter of personal preference (some find GDB's command syntax more comfortable), but there are also practical reasons:
+LLDB lacks several features that KGDB provides (see below for details) and has insufficient support even in the base system.
+My work aims to achieve feature parity with KGDB by the end of April.
+
+The improvements I have made so far are listed in the link above.
+Note that small bug fixes are not included in that list.
+
+The following are not supported: i386, arm, powerpc32, powerpc64be, and mips*. FreeBSD 13 and earlier are also unsupported.
+The targeted LLVM version is 23, although this work may be backported to FreeBSD's in-tree LLVM and MFCed to stable/14 and stable/15 after dim@ finishes his LLVM 21 MFV.
+
+I started this work in late January, and it is projected to be complete by April.
+Beyond feature parity, there are further possible improvements, such as minidump2elf support and adding UUIDs to kernel and core dump ELF headers.
+
+The biggest blocker for this project is a lack of reviewers knowledgeable in both FreeBSD internals and KGDB internals.
+If you have time, please provide feedback on my pull requests.
+Testers on non-x86 and non-arm64 machines would also be very welcome.
+If you find any issues, please file a bug and ping me on llvm/llvm-project.
+
+Sponsor: The FreeBSD Foundation


### PR DESCRIPTION
I have works other than LLDB (e.g. hybrid scheduler and Forgejo CI), but they are not mature enough to create a status report.