### PR TITLE
status/report: add 2026Q1 clusteradm report

### DIFF
--- a/website/content/en/status/report-2026-01-2026-03/clusteradm.adoc
+++ b/website/content/en/status/report-2026-01-2026-03/clusteradm.adoc
@@ -1,0 +1,81 @@
+=== Cluster Administration Team
+
+Links: +
+link:https://www.freebsd.org/administration/#t-clusteradm[Cluster Administration Team members] URL: link:https://www.freebsd.org/administration/#t-clusteradm[]
+
+Contact: Cluster Administration Team <clusteradm@FreeBSD.org>
+Contact: Philip Paeps <philip@FreeBSD.org>
+
+FreeBSD Cluster Administration Team members are responsible for managing the machines the Project relies on to synchronize its distributed work and communications.
+
+In this quarter, the team has worked on the following:
+
+* Regular support for FreeBSD.org user accounts.
+* Regular disk and parts support (and replacement) for all physical hosts and mirrors.
+* Cluster software refresh.
+* Coordinate community mirrors.
+
+==== Cluster refresh
+
+The stable/13 branch will stop being supported by the FreeBSD security-officer@ team at the end of April 2026.
+Several pieces of critical FreeBSD Project infrastructure were upgraded from FreeBSD stable/13 to FreeBSD stable/14 and FreeBSD stable/15.
+This work is ongoing at the end of the month.
+
+The clusteradm team refreshes the production package builders (circa 35 physical machines) on a roughtly six- to eight-week cadence.
+These machines run FreeBSD current snapshots.
+
+Other machines are upgraded on an as-needed basis, keeping up with security fixes depending on how exposed they are.
+
+At the time of this writing there are 146 physical machines in the cluster.
+We have 42 machines on current, 17 on stable/15 and 80 on stable/14.
+
+Most of the remaining stable/13 jails will be upgraded to stable/15.
+
+[.screen]
+----
+ 12.x: Regular   0, Jails   7
+ 13.x: Regular   7, Jails  33
+ 14.x: Regular  80, Jails 263
+ 15.x: Regular  17, Jails   4
+>16.x: Regular  42, Jails   6
+Total: Regular 146, Jails 313
+Total installations: 459
+Runnning -RELEASE|{-p*}: 0
+Total geographic sites: 13
+----
+
+==== FreeBSD official mirrors
+
+Current locations are Australia, Brazil, Japan (two full mirror sites), Malaysia, South Africa, Sweden, Taiwan and United States of America -- California, Chicago, New Jersey, and Washington.
+
+Our mirror site in Taiwan is experiencing an extended outage.
+
+One of our mirror sites in Japan will get a complete hardware refresh in 2026Q2.
+
+The hardware and network connection have been generously provided by:
+
+* Cloud and SDN Laboratory at link:https://www.bbtower.co.jp/en/corporate/[BroadBand Tower, Inc]
+* link:https://www.cs.nycu.edu.tw/[Department of Computer Science, National Yang Ming Chiao Tung University]
+* link:https://internet.asn.au/[Internet Association of Australia]
+* link:https://www.isc.org/[Internet Systems Consortium]
+* link:https://www.inx.net.za/[INX-ZA]
+* link:https://www.kddi-webcommunications.co.jp/english/[KDDI Web Communications Inc]
+* link:https://www.mohe.gov.my/en/services/research/myren[Malaysian Research & Education Network]
+* link:https://www.metapeer.com/[MetaPeer]
+* link:https://www.nyi.net/[New York Internet]
+* link:https://nic.br/[NIC.br]
+* link:https://sonic.net[Sonic]
+* link:https://www.teleservice.net/[Teleservice Skåne AB]
+* link:https://your.org/[Your.Org]
+
+New official mirrors are always welcome.
+We have noted the benefits of hosting single mirrors at Internet Exchange Points globally, as evidenced by our existing mirrors in Australia, Brazil, and South Africa.
+If you are affiliated with or know of any organizations willing to sponsor a single mirror server, please contact us.
+We are particularly interested in locations in Europe.
+
+See link:https://wiki.freebsd.org/Teams/clusteradm/generic-mirror-layout[generic mirrored layout] for full mirror site specs and link:https://wiki.freebsd.org/Teams/clusteradm/tiny-mirror[tiny-mirror] for a single mirror site.
+
+The FreeBSD Foundation does not fund work on the FreeBSD.org cluster.
+
+Sponsor: Several anonymous individuals and companies
+Sponsor: https://github.com/sponsors/ppaeps


### PR DESCRIPTION
Mostly business as usual this quarter.

Note the cluster refresh for the upcoming stable/13 EoL.  Give a tally of the current machines we have in the cluster and note what the update cadence is.

The FreeBSD Foundation does not fund this work.