### PR TITLE
handbook/bsdinstall: Remove defunct hardening options

### DIFF
--- a/documentation/content/en/books/handbook/bsdinstall/_index.adoc
+++ b/documentation/content/en/books/handbook/bsdinstall/_index.adoc
@@ -1070,10 +1070,8 @@ Here is a summary of the options that can be enabled in this menu:
 * `random_pid` - Randomize the PID of processes.
 * `clear_tmp` - Clean `/tmp` when the system starts up.
 * `disable_syslogd` - Disable opening the syslogd network socket. By default, FreeBSD runs syslogd in a secure way with `-s`. This prevents the daemon from listening for incoming UDP requests on port 514. With this option enabled, syslogd will instead run with `-ss`, which prevents syslogd from opening any port. For more information, see man:syslogd[8].
-* `disable_sendmail` - Disable the sendmail mail transport agent.
 * `secure_console` - Make the command prompt request the `root` password when entering single-user mode.
 * `disable_ddtrace` - DTrace can run in a mode that affects the running kernel. Destructive actions may not be used unless explicitly enabled. Use `-w` to enable this option when using DTrace. For more information, see man:dtrace[1].
-* `enable_aslr` - Enable address layout randomization. For more information about address layout randomization the link:https://en.wikipedia.org/wiki/Address_space_layout_randomization[Wikipedia article] can be consulted.
 
 [[bsdinstall-addusers]]
 === Add Users


### PR DESCRIPTION
The bsdinstall hardening script no longer offers knobs for disable_sendmail or enable_aslr.

By default, sendmail is now disabled and ASLR enabled. No need to document this in chapter for fresh installations.

Note: I've checked this applies to all supported releases except 13.5R, which reaches EOL in on April 30, 2026 and is deemed "legacy" by RE so is not recommended for fresh installations anyway. I'm fine if it's preferred not to commit these changes for 3 weeks just in case!