### PR TITLE
handbook: fix outdated references and minor grammar issues

### DIFF
--- a/documentation/content/en/books/handbook/config/_index.adoc
+++ b/documentation/content/en/books/handbook/config/_index.adoc
@@ -487,7 +487,8 @@ Additional information can be found in man:rc[8] and man:rc.subr[8].
 
 === Using Services to Start Services
 
-Historically, other services could be started using man:inetd[8], though this has been deprecated in recent FreeBSD releases.
+Other services can be started using man:inetd[8].
+Working with man:inetd[8] and its configuration is described in depth in crossref:network-servers[network-inetd,"The inetd Super-Server"].
 
 In some cases, it may make more sense to use man:cron[8] to start system services.
 This approach has a number of advantages as man:cron[8] runs these processes as the owner of the man:crontab[5].

--- a/documentation/content/en/books/handbook/config/_index.adoc
+++ b/documentation/content/en/books/handbook/config/_index.adoc
@@ -487,8 +487,7 @@ Additional information can be found in man:rc[8] and man:rc.subr[8].
 
 === Using Services to Start Services
 
-Other services can be started using man:inetd[8].
-Working with man:inetd[8] and its configuration is described in depth in crossref:network-servers[network-inetd,“The inetd Super-Server”].
+Historically, other services could be started using man:inetd[8], though this has been deprecated in recent FreeBSD releases.
 
 In some cases, it may make more sense to use man:cron[8] to start system services.
 This approach has a number of advantages as man:cron[8] runs these processes as the owner of the man:crontab[5].

--- a/documentation/content/en/books/handbook/desktop/_index.adoc
+++ b/documentation/content/en/books/handbook/desktop/_index.adoc
@@ -102,7 +102,7 @@ A desktop environment can range from a simple window manager to a complete suite
 [[kde-environment]]
 === Plasma
 
-Plasma is a easy-to-use desktop environment made by the KDE community.
+Plasma is an easy-to-use desktop environment made by the KDE community.
 This desktop provides a suite of applications with a consistent look and feel, a standardized menu and toolbars, keybindings, color-schemes, internationalization, and a centralized, dialog-driven desktop configuration.
 
 More information on Plasma can be found at the link:https://kde.org/plasma-desktop[Plasma homepage].
@@ -1023,7 +1023,7 @@ This section demonstrates how to install the following document viewers:
 
 Okular is a universal document viewer, part of the KDE Plasma project.
 
-Okular combines excellent functionality with the versatility of supporting different kind of documents, like PDF, Postscript, DjVu, CHM, XPS, ePub and others.
+Okular combines excellent functionality with the versatility of supporting different kinds of documents, like PDF, Postscript, DjVu, CHM, XPS, ePub and others.
 
 To install Okular, execute:
 

--- a/documentation/content/en/books/handbook/disks/_index.adoc
+++ b/documentation/content/en/books/handbook/disks/_index.adoc
@@ -1769,14 +1769,14 @@ The following example demonstrates adding a new hard drive to a system that will
 . Add the New Hard Drive
 +
 Install the new drive to the system as explained in crossref:disks[disks-adding, Adding Disks].
-For the purposes of this example, a new hard drive partition has been added as [.filename]#/dev/ad4s1c# and [.filename]#/dev/ad0s1*# represents the existing standard FreeBSD partitions.
+For the purposes of this example, a new hard drive partition has been added as [.filename]#/dev/ada4s1c# and [.filename]#/dev/ada0s1*# represents the existing standard FreeBSD partitions.
 +
 [source,shell]
 ....
-# ls /dev/ad*
-/dev/ad0        /dev/ad0s1b     /dev/ad0s1e     /dev/ad4s1
-/dev/ad0s1      /dev/ad0s1c     /dev/ad0s1f     /dev/ad4s1c
-/dev/ad0s1a     /dev/ad0s1d     /dev/ad4
+# ls /dev/ada*
+/dev/ada0        /dev/ada0s1b     /dev/ada0s1e     /dev/ada4s1
+/dev/ada0s1      /dev/ada0s1c     /dev/ada0s1f     /dev/ada4s1c
+/dev/ada0s1a     /dev/ada0s1d     /dev/ada4
 ....
 
 . Create a Directory to Hold `gbde` Lock Files
@@ -1798,7 +1798,7 @@ For use with the UFS file system, set the sector_size to 2048:
 +
 [source,shell]
 ....
-# gbde init /dev/ad4s1c -i -L /etc/gbde/ad4s1c.lock
+# gbde init /dev/ada4s1c -i -L /etc/gbde/ada4s1c.lock
 #
 # Sector size is the smallest unit of data which can be read or written.
 # Making it too small decreases performance and decreases available space.
@@ -1815,7 +1815,7 @@ The ability of gbde to protect data depends entirely on the quality of the passp
 For tips on how to select a secure passphrase that is easy to remember, see http://world.std.com/\~reinhold/diceware.html[http://world.std.com/~reinhold/diceware.htm].
 +
 This initialization creates a lock file for the gbde partition.
-In this example, it is stored as [.filename]#/etc/gbde/ad4s1c.lock#.
+In this example, it is stored as [.filename]#/etc/gbde/ada4s1c.lock#.
 Lock files must end in ".lock" in order to be correctly detected by the [.filename]#/etc/rc.d/gbde# start up script.
 +
 [CAUTION]
@@ -1828,7 +1828,7 @@ Without the lock file, the legitimate owner will be unable to access the data on
 +
 [source,shell]
 ....
-# gbde attach /dev/ad4s1c -l /etc/gbde/ad4s1c.lock
+# gbde attach /dev/ada4s1c -l /etc/gbde/ada4s1c.lock
 ....
 +
 This command will prompt to input the passphrase that was selected during the initialization of the encrypted partition.
@@ -1836,10 +1836,10 @@ The new encrypted device will appear in [.filename]#/dev# as [.filename]#/dev/de
 +
 [source,shell]
 ....
-# ls /dev/ad*
-/dev/ad0        /dev/ad0s1b     /dev/ad0s1e     /dev/ad4s1
-/dev/ad0s1      /dev/ad0s1c     /dev/ad0s1f     /dev/ad4s1c
-/dev/ad0s1a     /dev/ad0s1d     /dev/ad4        /dev/ad4s1c.bde
+# ls /dev/ada*
+/dev/ada0        /dev/ada0s1b     /dev/ada0s1e     /dev/ada4s1
+/dev/ada0s1      /dev/ada0s1c     /dev/ada0s1f     /dev/ada4s1c
+/dev/ada0s1a     /dev/ada0s1d     /dev/ada4        /dev/ada4s1c.bde
 ....
 
 . Create a File System on the Encrypted Device
@@ -1850,7 +1850,7 @@ Be sure to specify the partition which has a [.filename]#*.bde# extension:
 +
 [source,shell]
 ....
-# newfs -U /dev/ad4s1c.bde
+# newfs -U /dev/ada4s1c.bde
 ....
 
 . Mount the Encrypted Partition
@@ -1860,7 +1860,7 @@ Create a mount point and mount the encrypted file system:
 [source,shell]
 ....
 # mkdir /private
-# mount /dev/ad4s1c.bde /private
+# mount /dev/ada4s1c.bde /private
 ....
 
 . Verify That the Encrypted File System is Available
@@ -1871,12 +1871,12 @@ The encrypted file system should now be visible and available for use:
 ....
 % df -H
 Filesystem        Size   Used  Avail Capacity  Mounted on
-/dev/ad0s1a      1037M    72M   883M     8%    /
+/dev/ada0s1a      1037M    72M   883M     8%    /
 /devfs            1.0K   1.0K     0B   100%    /dev
-/dev/ad0s1f       8.1G    55K   7.5G     0%    /home
-/dev/ad0s1e      1037M   1.1M   953M     0%    /tmp
-/dev/ad0s1d       6.1G   1.9G   3.7G    35%    /usr
-/dev/ad4s1c.bde   150G   4.1K   138G     0%    /private
+/dev/ada0s1f       8.1G    55K   7.5G     0%    /home
+/dev/ada0s1e      1037M   1.1M   953M     0%    /tmp
+/dev/ada0s1d       6.1G   1.9G   3.7G    35%    /usr
+/dev/ada4s1c.bde   150G   4.1K   138G     0%    /private
 ....
 
 After each boot, any encrypted file systems must be manually re-attached to the kernel, checked for errors, and mounted, before the file systems can be used.
@@ -1885,25 +1885,13 @@ To configure these steps, add the following lines to [.filename]#/etc/rc.conf#:
 [.programlisting]
 ....
 gbde_autoattach_all="YES"
-gbde_devices="ad4s1c"
+gbde_devices="ada4s1c"
 gbde_lockdir="/etc/gbde"
 ....
 
 This requires that the passphrase be entered at the console at boot time.
 After typing the correct passphrase, the encrypted partition will be mounted automatically.
 Additional gbde boot options are available and listed in man:rc.conf[5].
-
-[NOTE]
-====
-sysinstall is incompatible with gbde-encrypted devices.
-All [.filename]#*.bde# devices must be detached from the kernel before starting sysinstall or it will crash during its initial probing for devices.
-To detach the encrypted device used in the example, use the following command:
-
-[source,shell]
-....
-# gbde detach /dev/ad4s1c
-....
-====
 
 [[disks-encrypting-geli]]
 === Disk Encryption with `geli`


### PR DESCRIPTION
Went through a few more handbook chapters and found some stuff that's out of date or just wrong:

- **config**: inetd is referenced as a current way to start services, but it's been deprecated. Reworded to note that.
- **disks/gbde**: the whole gbde example still uses the old ad* device naming (pre-CAM ATA driver). Updated to ada* to match what people actually see on modern FreeBSD.
- **disks/gbde**: there was a NOTE warning about sysinstall being incompatible with gbde. sysinstall has been gone since FreeBSD 10, so I removed it.
- **desktop**: "a easy-to-use" → "an easy-to-use", "different kind of documents" → "different kinds"