### PR TITLE
Add Valgrind status report for Q1 2026

### DIFF
--- a/website/content/en/status/report-2026-01-2026-03/valgrind.adoc
+++ b/website/content/en/status/report-2026-01-2026-03/valgrind.adoc
@@ -7,7 +7,7 @@ link:https://www.valgrind.org/docs/manual/dist.news.html[Valgrind News] URL: lin
 Contact: Paul Floyd <pjfloyd@wanadoo.fr>
 
 When FreeBSD 14.4-REELEASE came out and all went smoothely I thought that there would be little to say for this quarterly status report.
-Then I started using a cpuple of 16.0-CURRENT machines that are part of the GCC server farm.
+Then I started using a couple of 16.0-CURRENT machines that are part of the GCC server farm.
 There I saw several issues.
 At first there were many more failures than I would normally expect.
 A bit later the servers were updated and Valgrind broke quite badly, asserting early on in start up.

--- a/website/content/en/status/report-2026-01-2026-03/valgrind.adoc
+++ b/website/content/en/status/report-2026-01-2026-03/valgrind.adoc
@@ -1,0 +1,31 @@
+=== Valgrind: stabilization, FreeBSD 16 fixes and additions
+
+Links: +
+link:https://www.valgrind.org/[Valgrind Home Page] URL: link:https://www.valgrind.org/[] +
+link:https://www.valgrind.org/docs/manual/dist.news.html[Valgrind News] URL: link:https://www.valgrind.org/docs/manual/dist.news.html[] +
+
+Contact: Paul Floyd <pjfloyd@wanadoo.fr>
+
+When FreeBSD 14.4-REELEASE came out and all went smoothely I thought that there would be little to say for this quarterly status report.
+Then I started using a cpuple of 16.0-CURRENT machines that are part of the GCC server farm.
+There I saw several issues.
+At first there were many more failures than I would normally expect.
+A bit later the servers were updated and Valgrind broke quite badly, asserting early on in start up.
+Some of these issues were the usual high maintenance expected with Valgrind.
+A new Helgrind suppresion was required for internal locks used by `pthread_create`.
+The servers were built and installed from source which affects the error callstacks occasionally.
+The Valgrind regression tests are quite sensitive to that kind of change and some extra filtering was required.
+The asserts were caused by incorrect assumptions in Valgrind that are used when the tool reads its own binary, mainly to enable it to print its own callstack if there is a crash.
+The final problem was caused by a change in the way that library split debug files files are produced.
+
+Overall, this is more of a stabilization release. There are relatively few new features.
+
+Valgrind 3.27 is due out at the end of April 2026 and package:devel/valgrind[] will be updated shortly after that.
+
+Here is a list of bugfixes since my last report, Q3 2025.
+
+* Internal cleanup of syscall arg handling.
+* More checking during client stack creation.
+* Some tweaks to the default suppressions.
+* Added syscall wrappers for `kexec_load`, `pdwait`, `renameat2`
+* Syscall `pdrfork` added with flag "not implemented" (`rfork`-like syscalls are very difficult to implement in Valgrind).


### PR DESCRIPTION
First draft. Mainly fixes for FreeBSD 16.