### PR TITLE
Status/2026Q1/bugmeister.adoc: Fix links

### DIFF
--- a/website/content/en/status/report-2026-01-2026-03/bugmeister.adoc
+++ b/website/content/en/status/report-2026-01-2026-03/bugmeister.adoc
@@ -1,7 +1,7 @@
 === Bugmeister Team
 
 Links: +
-link:bugs.freebsd.org/[FreeBSD Bugzilla] URL: link:bugs.freebsd.org/[]
+link:https://bugs.freebsd.org/[FreeBSD Bugzilla] URL: link:https://bugs.freebsd.org/[]
 
 Contact: Bugmeister <bugmeister@FreeBSD.org>
 


### PR DESCRIPTION
Prefix links with https:// so they no longer point at https://www.freebsd.org/status/report-2026-01-2026-03/bugs.freebsd.org/ and get "Page not found" error.