### PR TITLE
usergroups: Update Portland, remove 5 defunct

### DIFF
--- a/website/content/en/usergroups/_index.adoc
+++ b/website/content/en/usergroups/_index.adoc
@@ -79,13 +79,8 @@ link:http://berklix.org/bim/[Berkeley in Munich (BIM)]::
 The Berkeley in Munich (BIM) caters for users of BSD based systems in Oberbayern.
 Located in Germany, Munich.
 
-link:http://www.u-bus.de[Ulmer BSD User Stammtisch]::
-The U-BUS meets every last Thursday of the month.
-For more information about meetings and related issues, please check the web page (link:http://www.u-bus.de[u-bus]).
-Located in Germany, Ulm.
-
 link:http://www.bluefrogs.de/[Bluefrogs e.V.]::
-Unix and Linux User Group in Bergisch Gladbach (near Cologne), German.
+Unix and Linux User Group in Bergisch Gladbach (near Cologne), Germany.
 Meetings are held twice a month.
 We are working with all Open Source Unix derivates: FreeBSD, NetBSD, OpenBSD, Linux and others.
 We give workshops, lectures, talks and install parties.
@@ -107,7 +102,7 @@ We are interested in how the BSDs can help both sysadmins and application develo
 For more information please visit our link:https://www.meetup.com/Dublin-BSD-User-Group/[website].
 
 link:http://www.lissyara.su[Lissyara.su]::
-We are a russian FreeBSD community.
+We are a Russian FreeBSD community.
 On our site we offer several articles for setting up FreeBSD and various other applications.
 In addtition to the articles we also provide a link:http://forum.lissyara.su/[user forum] where experienced users of FreeBSD are pleased to be able to help other users.
 
@@ -164,16 +159,6 @@ link:https://lists.stacken.kth.se/mailman/listinfo/bus[BSD Users Sweden (BUS)]::
 The BSD Users Sweden (BUS) maintains a mailing list.
 To join send an email to link:mailto:majordomo@stacken.kth.se[majordomo@stacken.kth.se] with `subscribe bus` in the body.
 Located in Sweden.
-
-link:http://www.bsdgroups.org.uk/manchester[Manchester BSD Users Group]::
-The Manchester BSD Users Group meets reasonably often in the Lass O'Gowrie, on Charles Street, Manchester.
-Contact link:mailto:sams@bsdgroups.org.uk[Sam Smith] for more information.
-Located in The United Kingdom, Manchester.
-
-link:http://mailman.uk.freebsd.org/mailman/listinfo/ukfreebsd[FreeBSD UK Users group (FreeBSD UKUG)]::
-The FreeBSD UKUG (FreeBSD UK User's Group) exists for the benefit of FreeBSD users in the United Kingdom.
-Please follow the link for more information.
-Located in the United Kingdom.
 
 link:https://twitter.com/bsdbelfast[The BSD in Belfast Group]::
 Meet the BSD Belfast Group the third Friday of the month.
@@ -249,19 +234,16 @@ The Western Pennsylvania Linux Users Group (WPLUG) has a strong and growing comm
 See our home page (link:http://www.wplug.org[http://www.wplug.org]) for information on regular meetings and join the mailing lists.
 Located in Pennsylvania.
 
-link:mailto:pdx-freebsd@toybox.placo.com[Portland (Oregon) FreeBSD Users Group]::
+link:https://bsd.pizza[Portland (Oregon) FreeBSD Users Group]::
 The Portland (Oregon) FreeBSD Users Group meets on the third Thursday of each month.
-Mail link:mailto:pdx-freebsd@toybox.placo.com[The Portland FreeBSD Users Group].
+If you're in the area and want to join, search link:https://calagator.org/events/search?query=BSD+Pizza+Night[BSD Pizza Night on Calagator], a website for tech events in Portland.
+Visit link:https://bsd.pizza[https://bsd.pizza] for contact details.
 Located in Portland, OR.
 
 link:http://www.rlug.org[Reno Linux Users Group (RLUG)]::
 The Reno Linux Users Group (RLUG) meets monthly in Reno, Nevada and discusses the use of BSD and Linux.
 Visit link:http://www.rlug.org[our website] for more information, where you may also join our mailing list.
 Located in Reno, NV.
-
-link:http://www.seabug.org[Seattle BSD Users Group (SeaBUG)]::
-The Seattle BSD Users Group (SeaBUG) meets occasionally. View our web site for more details and for information on how to join our mailing list.
-Located in Seattle, WA.
 
 link:https://sdbug.org/[San Diego BSD Users Group (SDBUG)]::
 The San Diego BSD Users Group meets on the first Thursday of every
@@ -328,10 +310,6 @@ Located in Kansai, Japan.
 link:https://www.ebug.jp/[The Echigo BSD Users Group (EBUG)]::
 The Echigo BSD Users Group is the users group for BSD users around Echigo (aka Niigata).
 For more information on our events and mailing lists, please check the EBUG web site.
-
-link:mailto:22961476@students.ukdw.ac.id[The Jogja FreeBSD Users Group]::
-The Jogja FreeBSD Users Group is based in Yogyakarta City, Indonesia.
-Send email to 22961476@students.ukdw.ac.id for more information.
 
 link:http://www.meetbsd.ir[meetBSD Iran]::
 meetbsd.ir is an Iranian BSD user group that provides conferences, iso, ebooks, and PKGs for BSD local users.


### PR DESCRIPTION
New information on various user groups, crowdsourced via https://www.reddit.com/r/freebsd/comments/1sskgr5/

```
Updated:
Portland   new website with contact details, remove outdated email,
           schedule confirmed still correct by u/patmaddox on Reddit

Removed:
Ulm        website live but states group has disbanded
UK         dead link, defunct according to Sam Smith via email
Manchester squatted link, confirmed defunct by Sam Smith via email
Seattle    dead link, confirmed defunct by u/linkslice on Reddit
Jogja      dead email address, no link, no web presence found

```

Re Portland: the new website contains X/Mastodon accounts for two organisers as a means of contact, replacing the previous email address. Pat Maddox suggests it's better to let their website be the source of truth on contact details in case of future changes, rather than list those social media accounts here. The group uses Calagator similarly to how some other groups use meetup.com; adding it here provides some redundancy to check if the group is still active even if their site goes dead.

Re Jogja: this is the only removed group I wasn't able to get direct confirmation for. But the sole information provided when this entry was added 20+ years ago was a university student email address, which has likely been dead for decades. I could find no trace of a web presence.

The list has many other dead links that suggest groups have disbanded, though - as Portland proves - information here can become stale and sometimes contact details have just changed! I intend to ask around for further confirmations on other forums I'm active in. Several defunct groups also appear on the equivalent NetBSD and OpenBSD lists, whose maintainers I intend to notify.

My search may throw up user groups not listed here. I was informed BSD Sul in Brazil, previously removed from this list, has reactivated and participates in activities like BSD Day. Unfortunately their new site has no contact information and is effectively a personal BSD blog: https://bsdsul.com.br/?action=view&url=voltamos-depois-de-oito-anos

My plan for new discoveries is to suggest they file a Bugzilla PR with website plus contact details, as per the instructions at https://www.freebsd.org/usergroups/ ... but I'm aware instructions can be outdated. Are Bugzilla PRs preferable these days?