### PR TITLE
releases.adoc: Fix rel-legacy-next macro

### DIFF
--- a/shared/releases.adoc
+++ b/shared/releases.adoc
@@ -40,7 +40,7 @@
 // Current latest legacy RELEASE.
 :rel-legacy-major: 14
 :rel-legacy: {rel-legacy-major}.4
-:rel-legacy-previous: {rel-legacy-major}.5
+:rel-legacy-next: {rel-legacy-major}.5
 :rel-legacy-previous: {rel-legacy-major}.3
 
 // If there is no release currently in the release cycle (i.e. we


### PR DESCRIPTION
An instance of rel-legacy-previous was clearly intended as rel-legacy-next.

Stumbled upon this because I have been working on some documentation that would benefit from having an exemplar version number and didn't want to introduce it in a way that would need bumping. So I was about to propose something almost identical to these macros, then was pleasantly surprised to discover I'd been beaten to it!