### PR TITLE
usergroups: Update venues for Hamburg and Portland

### DIFF
--- a/website/content/en/usergroups/_index.adoc
+++ b/website/content/en/usergroups/_index.adoc
@@ -54,7 +54,7 @@ Please visit our link:http://www.augusta.de/[web site] for more information on d
 We have all kinds of BSD, but mainly FreeBSD and Mac OS X. Located in Germany, Augsburg.
 
 link:http://www.bsdhh.org/bsdhh-de-index.html[BSD User Group Hamburg (BSDHH)]::
-The BSD User Group Hamburg (BSDHH) meets on the first Wednesday of the month at 7.00pm in the restaurant _Léon_ (Koppel 1, 20099 Hamburg).
+The BSD User Group Hamburg (BSDHH) link:https://www.bsdhh.org/bsdhh-de-treffen.html[meets on the first Wednesday of the month at 7.00pm] in the Restaurant Shanghai House (Borsteler Chaussee 110, 22453 Hamburg).
 Most members are FreeBSD users, although users of all BSD flavors are welcome.
 Located in Germany, Hamburg.
 
@@ -236,7 +236,7 @@ Located in Pennsylvania.
 
 link:https://bsd.pizza[Portland (Oregon) FreeBSD Users Group]::
 The Portland (Oregon) FreeBSD Users Group meets on the third Thursday of each month.
-If you're in the area and want to join, search link:https://calagator.org/events/search?query=BSD+Pizza+Night[BSD Pizza Night on Calagator], a website for tech events in Portland.
+If you're in the area and want to join, search link:https://calagator.org/events/search?query=%22bsd+pizza+night%22["BSD Pizza Night" on Calagator], a website for tech events in Portland.
 Visit link:https://bsd.pizza[https://bsd.pizza] for contact details.
 Located in Portland, OR.
 


### PR DESCRIPTION
My crowdsourced request for updates on usergroups has found two more changes.

Hamburg changed venue after 30 years. Include link to their meeting page and update venue to match. Reported by cracauer@ on https://forums.freebsd.org/threads/102512/#post-757478

Portland website has updated their meeting link. Calagator search now quotes "BSD Pizza Night". This removes false positives.