### PR TITLE
Update webcamd rc.conf flags suggestion

### DIFF
--- a/documentation/content/en/books/handbook/multimedia/_index.adoc
+++ b/documentation/content/en/books/handbook/multimedia/_index.adoc
@@ -528,13 +528,13 @@ Configure the available webcam executing the following command:
 
 [source,shell]
 ....
-# sysrc webcamd_0_flags="-d ugen0.2" <.>
+# sysrc webcamd_0_flags="-N SunplusIT-Inc-HP-TrueVision-HD-Camera" <.>
 ....
 
 [NOTE]
 ====
-Note here that if this is a plug-and-play USB webcam, changing the USB port to which it is connected will change the output from `webcamd -l`, and the entry in rc.conf might need to be updated.
-For laptops that use USB integrated webcams, this should not be an issue.
+Note here that if this is a plug-and-play USB webcam, changing the USB port to which it is connected will change the output from `webcamd -l`, specifically the device identifier, and the entry in rc.conf might need to be updated. To avoid this issue either use the device name (`-N` option) and/or match with the device serial number if known (`-S` option) as displayed in the output of `webcamd -l`.
+For static devices, for example integrated laptop cameras, you can use the device identifier (`-d` option).
 ====
 
 The man:webcamd[8] service must be started by executing the following command:


### PR DESCRIPTION
The current suggestion of using the device id for webcamd rc.conf settings is not very useful as per the existing NOTE already says. Change the default to use the device name which is much better and avoids the issue.