### PR TITLE
Fix duplicate words in handbook, status reports, and release notes

### DIFF
--- a/documentation/content/en/books/developers-handbook/l10n/_index.adoc
+++ b/documentation/content/en/books/developers-handbook/l10n/_index.adoc
@@ -250,7 +250,7 @@ In order to simplify this process even more, [.filename]#bsd.nls.mk# introduces 
 It is not necessary to include [.filename]#bsd.nls.mk# explicitly, it is pulled in from the common Makefiles, such as [.filename]#bsd.prog.mk# or [.filename]#bsd.lib.mk#.
 
 Usually it is enough to define `NLSNAME`, which should have the catalog name mentioned as the first argument of man:catopen[3] and list the catalog files in `NLS` without their `.msg` extension.
-Here is an example, which makes it possible to to disable NLS when used with the code examples before.
+Here is an example, which makes it possible to disable NLS when used with the code examples before.
 The `WITHOUT_NLS` man:make[1] variable has to be defined in order to build the program without NLS support.
 
 [.programlisting]

--- a/documentation/content/en/books/porters-handbook/makefiles/_index.adoc
+++ b/documentation/content/en/books/porters-handbook/makefiles/_index.adoc
@@ -3212,7 +3212,7 @@ When `_permission_` is not present, it is considered to be a `no-_permission_`.
 ====
 Some missing permissions will prevent a port (and all ports depending on it) from being usable by package users:
 
-A port without the `auto-accept` permission will never be be built and all the ports depending on it will be ignored.
+A port without the `auto-accept` permission will never be built and all the ports depending on it will be ignored.
 
 A port without the `pkg-mirror` permission, and any ports that depend on it, will be removed after the build, thus ensuring they are not distributed.
 ====

--- a/website/content/en/internal/software-license.adoc
+++ b/website/content/en/internal/software-license.adoc
@@ -157,5 +157,5 @@ The following licenses are considered to be acceptable BSD-Like Licenses for the
  */
 ....
 
-* It is acceptable to use use only the SPDX-License-Identifier
+* It is acceptable to use only the SPDX-License-Identifier
 ** See https://spdx.github.io/spdx-spec/[Annex D of SPDX Standard] for definition of standard SPDX-License-Identifier expressions used, how to interpret them and where to find the license text(s) that are applicable.

--- a/website/content/en/releases/14.2R/relnotes.adoc
+++ b/website/content/en/releases/14.2R/relnotes.adoc
@@ -308,7 +308,7 @@ gitref:56f0fc0011c2[repository=src]
 A new wireless driver supporting some Realtek chipsets is available: man:rtw89[4].
 gitref:a2d1e07f6451[repository=src] (Sponsored by The FreeBSD Foundation)
 
-Support for Realtek 8156/8156B has been moved from from man:cdce[4] to man:ure[4] for improved performance and reliability.
+Support for Realtek 8156/8156B has been moved from man:cdce[4] to man:ure[4] for improved performance and reliability.
 gitref:630077a84186[repository=src] (Sponsored by The FreeBSD Foundation)
 
 Support for ACPI GPIO _AEI objects has been added.

--- a/website/content/en/status/report-2021-04-2021-06/gcc.adoc
+++ b/website/content/en/status/report-2021-04-2021-06/gcc.adoc
@@ -10,7 +10,7 @@ With the great help of linimon@ GCC 10 became the default version of GCC in the 
 
 Looking one step ahead, GCC 11 is now available as a port and even for use as GCC_DEFAULT via Mk/bsd.default-versions.mk .
 
-Modern GCC ports like this now feature support for powerpcle, and most related changes also made it it upstream.
+Modern GCC ports like this now feature support for powerpcle, and most related changes also made it upstream.
 
 On the infrastructure side, USE_GCC now allows for a build time-only dependency, e.g. USE_GCC=yes:build .
 

--- a/website/content/en/status/report-2026-01-2026-03/gcc.adoc
+++ b/website/content/en/status/report-2026-01-2026-03/gcc.adoc
@@ -22,4 +22,4 @@ link:https://bugs.freebsd.org/bugzilla/show_bug.cgi?id=294062[PR 294062] is the 
 
 The link:https://bugs.freebsd.org/bugzilla/show_bug.cgi?id=292692[process] to get GCC_DEFAULT=15 has started.
 The GCC_DEFAULT=14 update is still recent and GCC 14 is actively supported, so there is no hurry to get this completed; but since those updates tend to be long I have already started it.
-Thus this is not my top priority at the moment: it is is where I put my energy when I have spare cycles, for now.
+Thus this is not my top priority at the moment: it is where I put my energy when I have spare cycles, for now.


### PR DESCRIPTION
Fix duplicate words scattered across several documentation files:

- Porters and Developers Handbook
- software-license article
- GCC status reports
- 14.2R release notes