### PR TITLE
Update _index.adoc

### DIFF
--- a/documentation/content/en/books/faq/_index.adoc
+++ b/documentation/content/en/books/faq/_index.adoc
@@ -108,7 +108,7 @@ This collaborative and community-driven approach has been fundamental to FreeBSD
 === How can I contribute to FreeBSD? What can I do to help?
 
 We accept all types of contributions: documentation, code, and even art.
-See the article on extref:{contributing}[Contributing to FreeBSD] for specific advice on how to do this.
+See the article on https://docs.freebsd.org/en/articles/contributing/[Contributing to FreeBSD] for specific advice on how to do this.
 
 And thanks for the thought!
 


### PR DESCRIPTION
Link under 1.3 "Contribute to FreeBSD" led to empty site, changed to existing https://docs.freebsd.org/en/books/%7Bmain-site%7D/articles/contributing//index.html > https://docs.freebsd.org/en/articles/contributing/