### PR TITLE
hardware: update pSeries entries

### DIFF
--- a/website/content/en/releases/14.4R/hardware.adoc
+++ b/website/content/en/releases/14.4R/hardware.adoc
@@ -171,6 +171,7 @@ IBM:
 QEMU
 
 * PowerNV
+* pSeries
 
 Raptor CS:
 
@@ -187,10 +188,6 @@ Apple:
 
 * Power Mac G5 (PowerPC 970)
 * Xserve G5 (PowerPC 970)
-
-IBM:
-
-* pSeries VM
 
 [[proc-risc-v]]
 === RISC-V
@@ -5116,4 +5113,3 @@ Unitek Y-2240 USB to DVI
 VideoHome NBdock1920
 
 i-tec USB 2.0 Docking Station (USBDVIDOCK)
-

--- a/website/content/en/releases/15.0R/hardware.adoc
+++ b/website/content/en/releases/15.0R/hardware.adoc
@@ -190,9 +190,9 @@ Apple:
 * Power Mac G5 (PowerPC 970)
 * Xserve G5 (PowerPC 970)
 
-IBM:
+QEMU:
 
-* pSeries VM
+* pSeries
 
 [[proc-risc-v]]
 === RISC-V
@@ -5067,4 +5067,3 @@ based on the DisplayLink DL-120 and DL-160 graphic chip, including:
 *	Unitek Y-2240 USB to DVI
 *	VideoHome NBdock1920
 *	i-tec USB 2.0 Docking Station (USBDVIDOCK)
-

--- a/website/content/en/releases/15.1R/hardware.adoc
+++ b/website/content/en/releases/15.1R/hardware.adoc
@@ -173,6 +173,7 @@ IBM:
 QEMU
 
 * PowerNV
+* pSeries
 
 Raptor CS:
 
@@ -189,10 +190,6 @@ Apple:
 
 * Power Mac G5 (PowerPC 970)
 * Xserve G5 (PowerPC 970)
-
-IBM:
-
-* pSeries VM
 
 [[proc-risc-v]]
 === RISC-V
@@ -5132,4 +5129,3 @@ based on the DisplayLink DL-120 and DL-160 graphic chips, including:
 *	Unitek Y-2240 USB to DVI
 *	VideoHome NBdock1920
 *	i-tec USB 2.0 Docking Station (USBDVIDOCK)
-


### PR DESCRIPTION
14.4 and 15.1 support little-endian pSeries.
15.0 has boot panic due to bug in SLOF, but it should be reclassified as QEMU pSeries instead of IBM.