### PR TITLE
website: Add zh-cn language support and About page

### DIFF
--- a/website/content/zh-cn/about.adoc
+++ b/website/content/zh-cn/about.adoc
@@ -1,0 +1,46 @@
+---
+title: "关于 FreeBSD"
+sidenav: about
+---
+
+include::shared/zh-cn/urls.adoc[]
+include::shared/releases.adoc[]
+
+= 关于 FreeBSD
+
+== 什么是 FreeBSD？
+
+FreeBSD 是一个面向多种 link:../platforms[硬件平台] 的操作系统，注重特性、速度与稳定性。它源自 BSD，即加州大学伯克利分校开发的 UNIX(R) 版本。由 link:{contributors}#staff-committers[庞大的社区] 开发并维护。
+
+== 尖端特性
+
+FreeBSD 今日提供的先进网络、性能、安全与兼容性 link:../features[特性]，即使在一些最好的商业操作系统中也仍然缺失。
+
+== 强大的互联网解决方案
+
+FreeBSD 是理想的互联网或内网服务器。它能在最高负载下提供稳定的网络服务，并高效利用内存，为数千个同时运行的用户进程保持良好的响应时间。
+
+== 先进的嵌入式平台
+
+FreeBSD 将先进的网络操作系统特性带到设备和嵌入式平台，从高端基于 Intel 的设备到 ARM、PowerPC 和 MIPS 硬件平台。全球的厂商都依赖 FreeBSD 集成的构建与交叉构建环境以及先进特性，作为其嵌入式产品的基础。Berkeley 开源许可允许他们决定将多少本地修改回馈社区。
+
+== 支持海量应用程序
+
+借助超过 {numports} 个已移植的库和 link:../applications[应用程序]，FreeBSD 支持桌面、服务器、设备和嵌入式环境中的应用程序。
+
+== 安装简便
+
+FreeBSD 可以通过多种介质安装，包括 CD-ROM、DVD，或直接通过网络使用 FTP 或 NFS 安装。您只需按照 link:{handbook}bsdinstall[这些说明] 操作即可。
+
+== FreeBSD 是自由的
+
+[.right]
+image:../gifs/dae_up3.gif[The BSD Daemon,width=72,height=81]
+
+虽然您可能以为具备这些特性的操作系统会售价高昂，但 FreeBSD 可以 link:../copyright[免费] 获取，并附带源代码。如果您想购买或下载一份来尝试，请参阅 link:{handbook}mirrors[更多信息]。
+
+== 为 FreeBSD 做贡献
+
+为 FreeBSD 做贡献很简单。您只需找到您认为可以改进的 FreeBSD 部分，做出修改（仔细且干净），然后通过问题报告或认识的提交者提交回项目。这可以是文档、美工或源代码等任何内容。更多信息请参阅 link:{contributing}[为 FreeBSD 做贡献] 一文。
+
+即使您不是程序员，也有其他方式为 FreeBSD 做出贡献。https://www.freebsdfoundation.org[FreeBSD 基金会] 是一个非营利组织，直接捐款可完全免税。更多信息请访问 https://freebsdfoundation.org/about-us/contact-us/[联系我们] 页面。

--- a/website/hugo.toml
+++ b/website/hugo.toml
@@ -63,3 +63,7 @@ Rel = "alternate"
     contentDir = "content/zh-tw"
     label = "繁體中文"
     weight = 3
+  [languages.zh-cn]
+    contentDir = "content/zh-cn"
+    label = "简体中文"
+    weight = 4


### PR DESCRIPTION
## Summary

This PR adds initial Simplified Chinese (zh-cn) language support to the FreeBSD website.

It includes:
- Language configuration in `website/hugo.toml`
- Translation of the About page (`website/content/zh-cn/about.adoc`)

## Background

The `shared/zh-cn/urls.adoc` already exists in the repository with all necessary URL attributes defined, so no shared configuration changes are needed. This PR builds on that existing infrastructure.

## Changes

- `website/hugo.toml`: Added `[languages.zh-cn]` configuration with `label = "简体中文"` and `weight = 4`
- `website/content/zh-cn/about.adoc`: Full translation of the About FreeBSD page

## Scope

This is the first zh-cn content page, intended to establish the foundation for incremental zh-cn website translations. Additional pages will follow in subsequent PRs.

## Testing

- The page follows the structure and conventions of the existing zh-tw and en About pages
- All AsciiDoc includes (`shared/zh-cn/urls.adoc`, `shared/releases.adoc`) are in place
- Attribute references (`{handbook}`, `{contributors}`, `{contributing}`, `{numports}`) are all defined