### PR TITLE
better us of ls in example

### DIFF
--- a/documentation/content/en/books/handbook/basics/_index.adoc
+++ b/documentation/content/en/books/handbook/basics/_index.adoc
@@ -1058,7 +1058,7 @@ The `sticky bit` permission will display as a `t` at the very end of the permiss
 
 [source,shell]
 ....
-# ls -al / | grep tmp
+# ls -ld /tmp
 ....
 
 [source,shell]


### PR DESCRIPTION
To show the sticky bit on the /tmp directory,
just ls the /tmp directory, as opposed to
listing everything and greping for /tmp