### PR TITLE
sidenav: fix link to handbook security advisories section

### DIFF
--- a/website/themes/beastie/layouts/_partials/sidenav.html
+++ b/website/themes/beastie/layouts/_partials/sidenav.html
@@ -103,7 +103,7 @@
       <li><a href={{ "security/notices/" | relLangURL }}>{{ i18n "errataNoticesSidenav" }}</a></li>
       <li><a href={{ "security/#sup" | relLangURL }}>{{ i18n "supportedReleases" }}</a></li>
       <li><a href={{ "security/unsupported/" | relLangURL }}>{{ i18n "unsupportedReleases" }}</a></li>
-      <li><a href={{ printf "%s%s%s" "https://docs.FreeBSD.org/" $currentLang "/books/handbook/#security-advisories" }}>{{ i18n "readSecurityAdvisories" }}</a></li>
+      <li><a href={{ printf "%s%s%s" "https://docs.FreeBSD.org/" $currentLang "/books/handbook/security/#security-advisories" }}>{{ i18n "readSecurityAdvisories" }}</a></li>
       <li><a href={{ "security/charter/" | relLangURL }}>{{ i18n "charterSecurityOfficerTeam" }}</a></li>
     </ul>
   </li>


### PR DESCRIPTION
Broken link in the sidenav bar.