### PR TITLE
press: Add Foundation blog posts for May-July 2026

### DIFF
--- a/website/data/en/press/press.toml
+++ b/website/data/en/press/press.toml
@@ -1,5 +1,104 @@
 # Sort the entries by date
 [[press]]
+name = "BSDCan 2026 Travel Report – Patrick McEvoy"
+url = "https://freebsdfoundation.org/blog/bsdcan-2026-travel-report-patrick-mcevoy/"
+siteName = "FreeBSD Foundation Blog"
+siteUrl = "https://freebsdfoundation.org/blog/"
+date = "2026-07-21"
+author = "FreeBSD Foundation"
+description = "Patrick McEvoy reports back from his visit to BSDCan 2026"
+
+[[press]]
+name = "BSDCan 2026 Trip Report – ShengYi Hung"
+url = "https://freebsdfoundation.org/blog/bsdcan-2026-trip-report-shengyi-hung/"
+siteName = "FreeBSD Foundation Blog"
+siteUrl = "https://freebsdfoundation.org/blog/"
+date = "2026-07-21"
+author = "FreeBSD Foundation"
+description = "ShengYi Hung reports back from his visit to BSDCan 2026"
+
+[[press]]
+name = "Understanding the Foundation Board’s Role in the FreeBSD Ecosystem"
+url = "https://freebsdfoundation.org/blog/understanding-the-foundation-boards-role-in-the-freebsd-ecosystem/"
+siteName = "FreeBSD Foundation Blog"
+siteUrl = "https://freebsdfoundation.org/blog/"
+date = "2026-07-16"
+author = "FreeBSD Foundation"
+description = "During BSDCan, the FreeBSD Foundation holds its annual meeting and Board elections."
+
+[[press]]
+name = "FreeBSD Foundation Welcomes New Board Member: Dave Cottlehuber"
+url = "https://freebsdfoundation.org/blog/freebsd-foundation-welcomes-new-board-member-dave-cottlehuber/"
+siteName = "FreeBSD Foundation Blog"
+siteUrl = "https://freebsdfoundation.org/blog/"
+date = "2026-07-16"
+author = "FreeBSD Foundation"
+description = "Dave Cottlehuber, was elected to the FreeBSD Foundation Board during the Annual Meeting on June 15, 2026."
+
+[[press]]
+name = "Represent FreeBSD in Your Community"
+url = "https://freebsdfoundation.org/blog/represent-freebsd-in-your-community/"
+siteName = "FreeBSD Foundation Blog"
+siteUrl = "https://freebsdfoundation.org/blog/"
+date = "2026-07-15"
+author = "FreeBSD Foundation"
+description = "Is There a Local Event Where You Could Represent FreeBSD?"
+
+[[press]]
+name = "EuroBSDCon 2026 Travel Grant Open"
+url = "https://freebsdfoundation.org/blog/eurobsdcon-2026-travel-grant-application-now-open/"
+siteName = "FreeBSD Foundation Blog"
+siteUrl = "https://freebsdfoundation.org/blog/"
+date = "2026-06-30"
+author = "FreeBSD Foundation"
+description = "The Foundation can help you attend EuroBSDCon through our travel grant program."
+
+[[press]]
+name = "FreeBSD Graphics Port Upgraded to Linux 6.12"
+url = "https://freebsdfoundation.org/blog/freebsd-graphics-port-upgraded-to-linux-6-12/"
+siteName = "FreeBSD Foundation Blog"
+siteUrl = "https://freebsdfoundation.org/blog/"
+date = "2026-06-16"
+author = "FreeBSD Foundation"
+description = "Graphics support in FreeBSD has reached a milestone with the drm-kmod port"
+
+[[press]]
+name = "FreeBSD AI-assisted Vulnerability Discovery Project launch"
+url = "https://freebsdfoundation.org/blog/freebsd-ai-assisted-vulnerability-discovery-project-launch/"
+siteName = "FreeBSD Foundation Blog"
+siteUrl = "https://freebsdfoundation.org/blog/"
+date = "2026-06-15"
+author = "FreeBSD Foundation"
+description = "The FreeBSD Foundation has launched its AI-assisted Vulnerability Discovery Project."
+
+[[press]]
+name = "May 2026 FreeBSD Newsletter"
+url = "https://freebsdfoundation.org/news-and-events/newsletter/may-newsletter/"
+siteName = "FreeBSD Foundation Newsletter"
+siteUrl = "https://freebsdfoundation.org/news-and-events/newsletter/"
+date = "2026-06-02"
+author = "FreeBSD Foundation"
+description = "The May FreeBSD Newsletter"
+
+[[press]]
+name = "April 2026 FreeBSD Newsletter"
+url = "https://freebsdfoundation.org/news-and-events/newsletter/april-newsletter/"
+siteName = "FreeBSD Foundation Newsletter"
+siteUrl = "https://freebsdfoundation.org/news-and-events/newsletter/"
+date = "2026-06-02"
+author = "FreeBSD Foundation"
+description = "The April FreeBSD Newsletter"
+
+[[press]]
+name = "Recap of the April 2026 Frankfurt Area FreeBSD Hackathon – Sven Ruediger"
+url = "https://freebsdfoundation.org/blog/recap-of-the-april-2026-frankfurt-area-freebsd-hackathon-sven-ruediger/"
+siteName = "FreeBSD Foundation Blog"
+siteUrl = "https://freebsdfoundation.org/blog/"
+date = "2026-06-02"
+author = "FreeBSD Foundation"
+description = "Sven Ruediger recaps the first regional FreeBSD Hackathon in the Frankfurt area, Germany."
+
+[[press]]
 name = "Em Do What?"
 url = "https://youtu.be/dA-TNsVG9IY"
 siteName = "FreeBSD YouTube"


### PR DESCRIPTION
Added multiple press entries for BSDCan 2026 and other events.