### PR TITLE
Add 2026Q3 status report for Capsicumize fts(3)

### DIFF
--- a/website/content/en/status/report-2026-07-2026-09/fts_openat.adoc
+++ b/website/content/en/status/report-2026-07-2026-09/fts_openat.adoc
@@ -1,0 +1,18 @@
+=== Capsicumize fts(3)
+
+Links: +
+link:https://man.freebsd.org/cgi/man.cgi?fts(3)[fts(3) manual page] URL: link:https://man.freebsd.org/cgi/man.cgi?fts(3)[]
+
+Contact: Jitendra Bhati <jitendrabhati2026@gmail.com> +
+Contact: Alan Somers <asomers@FreeBSD.org>
+
+The link:https://man.freebsd.org/cgi/man.cgi?fts(3)[fts(3)] directory traversal library, used by find(1), rm(1), ls(1), chflags(1) and other utilities, historically relied on path-based syscalls that fail in capsicum(4) capability mode.
+
+This quarter fts(3) gained a new `fts_openat()` entry point that accepts a pre-opened directory descriptor, a per-entry `fts_dirfd` field, and a conversion of its internals to fd-relative operations, with ABI compatibility preserved through ELF symbol versioning.
+A traversal can now run entirely inside a Capsicum sandbox.
+
+As a first consumer, chflags(1) was capsicumized to perform its work through `chflagsat()` on descriptors opened before entering capability mode, confining it to the hierarchies named on its command line.
+
+This work was completed as a Google Summer of Code 2026 project.
+
+Sponsor: Google Summer of Code 2026


### PR DESCRIPTION
Status report for the GSoC 2026 project adding `fts_openat()` and Capsicum capability mode support to `fts(3)`, and capsicumizing chflags(1) as the first consumer. This work was completed as a Google Summer of Code 2026 project.

New file: `website/content/en/status/report-2026-07-2026-09/fts_openat.adoc`

Sponsor: Google Summer of Code 2026

