### PR TITLE
contribution article: Align Ensure your ports continue to build correctly with current Tiers

### DIFF
--- a/documentation/content/en/articles/contributing/_index.adoc
+++ b/documentation/content/en/articles/contributing/_index.adoc
@@ -457,8 +457,7 @@ This section is about discovering and fixing problems that stop your ports from 
 FreeBSD only guarantees that the Ports Collection works on the `-STABLE` branches.
 In theory, you should be able to get by with running the latest release of each stable branch (since the ABIs are not supposed to change) but if you can run the branch, that is even better.
 
-Since the majority of FreeBSD installations run on PC-compatible machines (what is termed the `i386` architecture), we expect you to keep the port working on that architecture.
-We prefer that ports also work on the `amd64` architecture running native.
+Since the majority of FreeBSD installations run on PC-compatible machines (what is termed the `amd64` architecture), we expect you to keep the port working on that architecture.
 It is completely fair to ask for help if you do not have one of these machines.
 
 [NOTE]


### PR DESCRIPTION
i386 mentioned as a must for all ports is not aligned with current Tiers, it's unsupported starting from 15.x releases:

> Since the majority of FreeBSD installations run on PC-compatible machines (what is termed the **i386** architecture), we expect you to keep the port working on that architecture.

https://docs.freebsd.org/en/articles/contributing/#adopt-port

Thus

Platform Name | TARGET_ARCH | 14.x Support Tier | 15.x Support Tier | Projected 16.x Support Tier
-- | -- | -- | -- | --
64-bit x86 | amd64 | Tier 1 | Tier 1 | Tier 1
32-bit x86 | i386 | Tier 2 | Unsupported | Unsupported
64-bit ARMv8 | aarch64 | Tier 1 | Tier 1 | Tier 1

https://www.freebsd.org/platforms/
